### PR TITLE
github: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug Report
+about: Report a bug to help us improve gohan
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- gohan version: <!-- e.g. v0.1.0 -->
+- OS: <!-- e.g. macOS 14.0, Ubuntu 22.04, Windows 11 -->
+- Go version: <!-- e.g. go1.22.0 -->
+
+## Config
+
+```yaml
+# Paste relevant parts of your config.yaml here
+```
+
+## Logs / Error Output
+
+```
+# Paste any relevant log output here
+```
+
+## Additional Context
+
+Add any other context or screenshots about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/bmf-san/gohan/discussions
+    about: For general questions or discussions, please use GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for gohan
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A clear and concise description of the feature you'd like.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+## Proposed Solution
+
+Describe the solution you have in mind.
+
+## Alternatives Considered
+
+Describe any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context, mockups, or examples here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+Describe what this PR does and why.
+
+## Changes
+
+- 
+- 
+
+## Related Issues
+
+Closes #
+
+## Checklist
+
+- [ ] Tests added / updated
+- [ ] Documentation updated if needed
+- [ ] `go test ./...` passes
+- [ ] `golangci-lint run` passes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the contact listed in the repository. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Gohan
+
+Thank you for your interest in contributing to gohan! This document explains how to get involved.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Reporting Bugs](#reporting-bugs)
+- [Requesting Features](#requesting-features)
+- [Development Setup](#development-setup)
+- [Submitting a Pull Request](#submitting-a-pull-request)
+- [Coding Guidelines](#coding-guidelines)
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## Reporting Bugs
+
+Use the [Bug Report](.github/ISSUE_TEMPLATE/bug_report.md) issue template. Please include:
+
+- gohan version, OS, and Go version
+- Steps to reproduce
+- Expected vs. actual behavior
+- Relevant config and log output
+
+## Requesting Features
+
+Use the [Feature Request](.github/ISSUE_TEMPLATE/feature_request.md) issue template. Please describe the motivation and your proposed solution.
+
+## Development Setup
+
+**Prerequisites**: Go 1.22 or later, Git
+
+```bash
+# Clone the repository
+git clone https://github.com/bmf-san/gohan.git
+cd gohan
+
+# Download dependencies
+go mod download
+
+# Run tests
+go test ./...
+
+# Run linter
+golangci-lint run
+```
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a branch from `main`:
+   ```bash
+   git checkout -b your-feature-name
+   ```
+2. Make your changes and add tests where appropriate.
+3. Ensure all tests and linting pass:
+   ```bash
+   go test ./...
+   golangci-lint run
+   ```
+4. Commit using a descriptive message following [Conventional Commits](https://www.conventionalcommits.org/):
+   ```
+   feat: add support for custom output paths
+   fix: correct archive page date grouping
+   docs: update CLI reference
+   ```
+5. Push your branch and open a pull request against `main`.
+6. Fill in the pull request template and link any related issues.
+
+## Coding Guidelines
+
+- Follow standard Go conventions (`gofmt`, `go vet`)
+- Write godoc comments for all exported identifiers
+- Keep functions small and focused; prefer clear naming over comments
+- Add or update tests for every change to core logic
+- Maintain test coverage at 80% or higher overall, 90%+ for parser/renderer


### PR DESCRIPTION
## Summary

Add GitHub community health files: issue/PR templates, contributing guide, and code of conduct.

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.md` — Bug report template
- `.github/ISSUE_TEMPLATE/feature_request.md` — Feature request template
- `.github/ISSUE_TEMPLATE/config.yml` — Disables blank issues; links to Discussions for questions
- `.github/PULL_REQUEST_TEMPLATE.md` — Pull request template
- `CONTRIBUTING.md` — Development setup, PR workflow, and coding guidelines
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1