### PR TITLE
feat: initialize Go module and project directory structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,17 @@ go.work.sum
 .env
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode/
+
+# gohan binary
+gohan
+
+# GoReleaser build output
+dist/
+
+# gohan build cache
+.gohan/
+
+# macOS
+.DS_Store

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bmf-san/gohan
+
+go 1.25.3

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,2 @@
+// Package config loads and validates gohan configuration from YAML files.
+package config

--- a/internal/diff/doc.go
+++ b/internal/diff/doc.go
@@ -1,0 +1,2 @@
+// Package diff detects changed files between builds using Git or file hash comparison.
+package diff

--- a/internal/generator/doc.go
+++ b/internal/generator/doc.go
@@ -1,0 +1,2 @@
+// Package generator writes rendered HTML, assets, sitemaps, and feeds to the output directory.
+package generator

--- a/internal/parser/doc.go
+++ b/internal/parser/doc.go
@@ -1,0 +1,2 @@
+// Package parser parses Markdown content and YAML Front Matter into Article structs.
+package parser

--- a/internal/processor/doc.go
+++ b/internal/processor/doc.go
@@ -1,0 +1,2 @@
+// Package processor builds dependency graphs and processes articles for output.
+package processor

--- a/internal/server/doc.go
+++ b/internal/server/doc.go
@@ -1,0 +1,2 @@
+// Package server implements the local development HTTP server with live reload.
+package server

--- a/internal/template/doc.go
+++ b/internal/template/doc.go
@@ -1,0 +1,2 @@
+// Package template loads Go html/template files and renders pages with site data.
+package template


### PR DESCRIPTION
## Summary

Initialize the Go module and establish the project directory skeleton.

## Changes

- `go.mod` — `go mod init github.com/bmf-san/gohan`
- `cmd/gohan/main.go` — CLI entry point placeholder
- `internal/config/`, `internal/parser/`, `internal/processor/`, `internal/template/`, `internal/generator/`, `internal/diff/`, `internal/server/` — package stubs with doc comments
- `.gitignore` — added `.gohan/`, `dist/`, IDE dirs, gohan binary

## Checklist

- [x] `go build ./...` passes
- [ ] Tests added / updated
- [ ] Documentation updated if needed
- [ ] `golangci-lint run` passes

Closes #4