### PR TITLE
feat: implement Markdown converter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/bmf-san/gohan
 go 1.25.3
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/yuin/goldmark v1.7.16

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
+github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -1,0 +1,77 @@
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer/html"
+)
+
+// Converter converts Markdown source bytes into safe HTML.
+// It is CommonMark-compliant and supports GitHub Flavored Markdown (GFM)
+// extensions by default.
+type Converter struct {
+	md goldmark.Markdown
+}
+
+// converterConfig holds the options accumulated before building the Markdown engine.
+type converterConfig struct {
+	gfm        bool
+	unsafeHTML bool
+}
+
+// ConverterOption is a functional option for NewConverter.
+type ConverterOption func(*converterConfig)
+
+// WithGFM enables the GitHub Flavored Markdown extension set (tables,
+// strikethrough, task lists, and auto-links).  Enabled by default via
+// NewConverter.
+func WithGFM() ConverterOption {
+	return func(c *converterConfig) { c.gfm = true }
+}
+
+// WithUnsafeHTML allows raw HTML pass-through in Markdown source.  By
+// default raw HTML is escaped.  Use only when the content source is trusted.
+func WithUnsafeHTML() ConverterOption {
+	return func(c *converterConfig) { c.unsafeHTML = true }
+}
+
+// NewConverter builds a Converter with the supplied options.  When no options
+// are given, GFM extensions are enabled and raw HTML is escaped.
+func NewConverter(opts ...ConverterOption) *Converter {
+	cfg := &converterConfig{gfm: true}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	var mdOpts []goldmark.Option
+
+	if cfg.gfm {
+		mdOpts = append(mdOpts,
+			goldmark.WithExtensions(extension.GFM),
+			goldmark.WithParserOptions(
+				parser.WithAutoHeadingID(),
+			),
+		)
+	}
+
+	if cfg.unsafeHTML {
+		mdOpts = append(mdOpts, goldmark.WithRendererOptions(html.WithUnsafe()))
+	}
+
+	return &Converter{md: goldmark.New(mdOpts...)}
+}
+
+// Convert transforms src Markdown bytes into an HTML string.  The returned
+// value is marked safe for use with html/template without additional escaping.
+func (c *Converter) Convert(src []byte) (template.HTML, error) {
+	var buf bytes.Buffer
+	if err := c.md.Convert(src, &buf); err != nil {
+		return "", fmt.Errorf("markdown: convert: %w", err)
+	}
+	return template.HTML(buf.String()), nil //nolint:gosec // goldmark output is safe HTML
+}

--- a/internal/parser/markdown_test.go
+++ b/internal/parser/markdown_test.go
@@ -1,0 +1,134 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bmf-san/gohan/internal/parser"
+)
+
+func TestConverter_Heading(t *testing.T) {
+	c := parser.NewConverter()
+	got, err := c.Convert([]byte("# Hello\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), "Hello") {
+		t.Errorf("expected Hello in output, got: %s", got)
+	}
+}
+
+func TestConverter_Paragraph(t *testing.T) {
+	c := parser.NewConverter()
+	got, err := c.Convert([]byte("Hello, world.\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), "<p>Hello, world.</p>") {
+		t.Errorf("expected paragraph, got: %s", got)
+	}
+}
+
+func TestConverter_Link(t *testing.T) {
+	c := parser.NewConverter()
+	got, err := c.Convert([]byte("[Go](https://go.dev)\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	html := string(got)
+	if !strings.Contains(html, "https://go.dev") {
+		t.Errorf("expected link href, got: %s", html)
+	}
+}
+
+func TestConverter_CodeBlock(t *testing.T) {
+	c := parser.NewConverter()
+	src := "```go\nfmt.Println()\n```\n"
+	got, err := c.Convert([]byte(src))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), "<pre><code") {
+		t.Errorf("expected code block, got: %s", got)
+	}
+}
+
+func TestConverter_GFM_Strikethrough(t *testing.T) {
+	c := parser.NewConverter()
+	got, err := c.Convert([]byte("~~strike~~\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), "<del>strike</del>") {
+		t.Errorf("expected strikethrough, got: %s", got)
+	}
+}
+
+func TestConverter_GFM_Table(t *testing.T) {
+	c := parser.NewConverter()
+	src := "| A | B |\n|---|---|\n| 1 | 2 |\n"
+	got, err := c.Convert([]byte(src))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	html := string(got)
+	if !strings.Contains(html, "<table>") {
+		t.Errorf("expected table, got: %s", html)
+	}
+}
+func TestConverter_HTMLEscapedByDefault(t *testing.T) {
+	c := parser.NewConverter()
+	src := "<script>alert(1)</script>\n"
+	got, err := c.Convert([]byte(src))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(got), "<script>") {
+		t.Errorf("raw script tag should be escaped, got: %s", got)
+	}
+}
+
+func TestConverter_UnsafeHTMLPassthrough(t *testing.T) {
+	c := parser.NewConverter(parser.WithUnsafeHTML())
+	src := "<b>raw</b>\n"
+	got, err := c.Convert([]byte(src))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), "<b>raw</b>") {
+		t.Errorf("raw HTML not passed through, got: %s", got)
+	}
+}
+
+func TestConverter_WithGFMOption(t *testing.T) {
+	c := parser.NewConverter(parser.WithGFM())
+	got, err := c.Convert([]byte("~~strike~~\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), "<del>") {
+		t.Errorf("WithGFM option: expected strikethrough, got: %s", got)
+	}
+}
+
+func TestConverter_EmptyInput(t *testing.T) {
+	c := parser.NewConverter()
+	got, err := c.Convert([]byte(""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "" {
+		t.Errorf("expected empty output, got: %q", got)
+	}
+}
+
+func TestConverter_HeadingAutoID(t *testing.T) {
+	c := parser.NewConverter()
+	got, err := c.Convert([]byte("## My Section\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), "id=") {
+		t.Errorf("expected id on heading, got: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements Phase 3-1: Markdown-to-HTML converter using [goldmark](https://github.com/yuin/goldmark).

Closes #9

## Changes

### `internal/parser/markdown.go`
- `Converter` struct wrapping a configured `goldmark.Markdown` instance
- Functional options pattern via `ConverterOption`
  - `WithGFM()` — enables GitHub Flavored Markdown (tables, strikethrough, task lists, auto-links); on by default
  - `WithUnsafeHTML()` — allows raw HTML passthrough for trusted content
- `NewConverter(opts ...ConverterOption) *Converter`
- `Convert(src []byte) (template.HTML, error)` — returns `template.HTML` for safe embedding in `html/template`
- Auto heading IDs via `parser.WithAutoHeadingID()`
- Raw HTML escaped by default (safe for untrusted input)

### `internal/parser/markdown_test.go`
- 11 tests co- 11 tests co- 11 tests co- 11 tests co- 11 teks- 11 tests co- 11 tests co- 11 testsL - 11 tests co- 11 tests co- 11 tests co-n - 11 tests co- 11 tests co- 11 tests co- 11 tesag- 11 tests co- 11 tmod` / `go.sum`
- Added `github.com/yuin/goldmark v1.7.16`