### PR TITLE
feat: build dependency graph and content processor

### DIFF
--- a/internal/processor/graph.go
+++ b/internal/processor/graph.go
@@ -1,0 +1,85 @@
+package processor
+
+import (
+	"fmt"
+
+	"github.com/bmf-san/gohan/internal/model"
+)
+
+// addNode inserts a node into the graph if it does not already exist.
+func addNode(g *model.DependencyGraph, node *model.Node) {
+	if _, exists := g.Nodes[node.Path]; !exists {
+		g.Nodes[node.Path] = node
+	}
+}
+
+// addEdge records a directed edge from → to in the graph.
+func addEdge(g *model.DependencyGraph, from, to string) {
+	g.Edges[from] = appendUnique(g.Edges[from], to)
+	// Update dependents on the target node.
+	if n, ok := g.Nodes[to]; ok {
+		n.Dependents = appendUnique(n.Dependents, from)
+	}
+	// Update dependencies on the source node.
+	if n, ok := g.Nodes[from]; ok {
+		n.Dependencies = appendUnique(n.Dependencies, to)
+	}
+}
+
+// CalculateImpact returns all node paths that are transitively impacted when
+// changedPath changes (i.e., changedPath plus all its transitive dependents).
+func CalculateImpact(g *model.DependencyGraph, changedPath string) []string {
+	visited := make(map[string]bool)
+	result := traverseDependents(g, changedPath, visited)
+	return result
+}
+
+// traverseDependents recursively collects all dependents of path.
+func traverseDependents(g *model.DependencyGraph, path string, visited map[string]bool) []string {
+	if visited[path] {
+		return nil
+	}
+	visited[path] = true
+	result := []string{path}
+
+	node, ok := g.Nodes[path]
+	if !ok {
+		return result
+	}
+	for _, dep := range node.Dependents {
+		result = append(result, traverseDependents(g, dep, visited)...)
+	}
+	return result
+}
+
+// CalculateDiff compares two dependency graphs and returns a ChangeSet
+// describing added, deleted, and modified nodes.
+func CalculateDiff(oldGraph, newGraph *model.DependencyGraph) (*model.ChangeSet, error) {
+	if oldGraph == nil || newGraph == nil {
+		return nil, fmt.Errorf("processor: graph must not be nil")
+	}
+	cs := &model.ChangeSet{}
+	for path := range newGraph.Nodes {
+		if _, exists := oldGraph.Nodes[path]; !exists {
+			cs.AddedFiles = append(cs.AddedFiles, path)
+		} else {
+			cs.ModifiedFiles = append(cs.ModifiedFiles, path)
+		}
+	}
+	for path := range oldGraph.Nodes {
+		if _, exists := newGraph.Nodes[path]; !exists {
+			cs.DeletedFiles = append(cs.DeletedFiles, path)
+		}
+	}
+	return cs, nil
+}
+
+// appendUnique appends s to slice only if it is not already present.
+func appendUnique(slice []string, s string) []string {
+	for _, v := range slice {
+		if v == s {
+			return slice
+		}
+	}
+	return append(slice, s)
+}

--- a/internal/processor/processor_impl.go
+++ b/internal/processor/processor_impl.go
@@ -1,0 +1,126 @@
+package processor
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/bmf-san/gohan/internal/model"
+	"github.com/bmf-san/gohan/internal/parser"
+)
+
+// SiteProcessor implements the Processor interface.
+type SiteProcessor struct{}
+
+// NewSiteProcessor returns a new SiteProcessor.
+func NewSiteProcessor() *SiteProcessor {
+	return &SiteProcessor{}
+}
+
+// Process converts raw Articles into ProcessedArticles by rendering Markdown
+// to HTML, extracting summaries, and computing output paths.
+func (p *SiteProcessor) Process(articles []*model.Article, cfg model.Config) ([]*model.ProcessedArticle, error) {
+	conv := parser.NewConverter(parser.WithGFM())
+	result := make([]*model.ProcessedArticle, 0, len(articles))
+	for _, a := range articles {
+		html, err := conv.Convert([]byte(a.RawContent))
+		if err != nil {
+			return nil, fmt.Errorf("processor: render %s: %w", a.FilePath, err)
+		}
+		processed := &model.ProcessedArticle{
+			Article:     *a,
+			HTMLContent: html,
+			Summary:     extractSummary(a.RawContent, 200),
+			OutputPath:  computeOutputPath(a, cfg),
+		}
+		result = append(result, processed)
+	}
+	return result, nil
+}
+
+// BuildDependencyGraph constructs a DependencyGraph from all processed articles,
+// linking each article to its tag, category, and archive (year) nodes.
+func (p *SiteProcessor) BuildDependencyGraph(articles []*model.ProcessedArticle) (*model.DependencyGraph, error) {
+	g := &model.DependencyGraph{
+		Nodes: make(map[string]*model.Node),
+		Edges: make(map[string][]string),
+	}
+	for _, a := range articles {
+		articlePath := a.FilePath
+		addNode(g, &model.Node{
+			Path:         articlePath,
+			Type:         model.NodeTypeArticle,
+			LastModified: a.LastModified,
+		})
+		for _, tag := range a.FrontMatter.Tags {
+			tagPath := "tag:" + tag
+			addNode(g, &model.Node{Path: tagPath, Type: model.NodeTypeTag, LastModified: time.Time{}})
+			addEdge(g, articlePath, tagPath)
+		}
+		for _, cat := range a.FrontMatter.Categories {
+			catPath := "category:" + cat
+			addNode(g, &model.Node{Path: catPath, Type: model.NodeTypeCategory, LastModified: time.Time{}})
+			addEdge(g, articlePath, catPath)
+		}
+		if !a.FrontMatter.Date.IsZero() {
+			year := fmt.Sprintf("archive:%d", a.FrontMatter.Date.Year())
+			addNode(g, &model.Node{Path: year, Type: model.NodeTypeArchive, LastModified: time.Time{}})
+			addEdge(g, articlePath, year)
+		}
+	}
+	return g, nil
+}
+
+// BuildTaxonomyRegistry collects all unique tags and categories referenced
+// across the article set and returns a TaxonomyRegistry.
+func (p *SiteProcessor) BuildTaxonomyRegistry(articles []*model.ProcessedArticle, cfg model.Config) (*model.TaxonomyRegistry, error) {
+	tagSeen := make(map[string]bool)
+	catSeen := make(map[string]bool)
+	reg := &model.TaxonomyRegistry{}
+	for _, a := range articles {
+		for _, t := range a.FrontMatter.Tags {
+			if !tagSeen[t] {
+				tagSeen[t] = true
+				reg.Tags = append(reg.Tags, model.Taxonomy{Name: t})
+			}
+		}
+		for _, c := range a.FrontMatter.Categories {
+			if !catSeen[c] {
+				catSeen[c] = true
+				reg.Categories = append(reg.Categories, model.Taxonomy{Name: c})
+			}
+		}
+	}
+	return reg, nil
+}
+
+// computeOutputPath determines the output HTML path for an article.
+// Respects FrontMatter.Slug when set; otherwise uses the file base name.
+func computeOutputPath(a *model.Article, cfg model.Config) string {
+	rel, err := filepath.Rel(cfg.Build.ContentDir, a.FilePath)
+	if err != nil {
+		rel = filepath.Base(a.FilePath)
+	}
+	dir := filepath.Dir(rel)
+	base := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
+	if a.FrontMatter.Slug != "" {
+		base = a.FrontMatter.Slug
+	}
+	return filepath.Join(cfg.Build.OutputDir, dir, base, "index.html")
+}
+
+// extractSummary returns the first paragraph of content, truncated to maxChars.
+func extractSummary(content string, maxChars int) string {
+	content = strings.TrimSpace(content)
+	if idx := strings.Index(content, "\n\n"); idx > 0 && idx <= maxChars {
+		return strings.TrimSpace(content[:idx])
+	}
+	if len(content) <= maxChars {
+		return content
+	}
+	return content[:maxChars] + "..."
+}
+
+// Ensure SiteProcessor implements the Processor interface at compile time.
+var _ Processor = (*SiteProcessor)(nil)

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -1,0 +1,207 @@
+package processor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bmf-san/gohan/internal/model"
+)
+
+func testArticle(path, title, raw string, tags, cats []string, date time.Time) *model.Article {
+	return &model.Article{
+		FrontMatter: model.FrontMatter{
+			Title:      title,
+			Tags:       tags,
+			Categories: cats,
+			Date:       date,
+		},
+		RawContent:   raw,
+		FilePath:     path,
+		LastModified: time.Now(),
+	}
+}
+
+func TestSiteProcessor_Process_Basic(t *testing.T) {
+	p := NewSiteProcessor()
+	articles := []*model.Article{
+		testArticle("content/posts/hello.md", "Hello", "# Hello\n\nWorld.", []string{"go"}, nil, time.Time{}),
+	}
+	cfg := model.Config{Build: model.BuildConfig{ContentDir: "content", OutputDir: "public"}}
+	processed, err := p.Process(articles, cfg)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if len(processed) != 1 {
+		t.Fatalf("expected 1 article, got %d", len(processed))
+	}
+	a := processed[0]
+	if !strings.Contains(string(a.HTMLContent), "<h1") {
+		t.Errorf("HTMLContent missing h1: %q", a.HTMLContent)
+	}
+	if a.Summary == "" {
+		t.Error("Summary should not be empty")
+	}
+	if a.OutputPath == "" {
+		t.Error("OutputPath should not be empty")
+	}
+}
+
+func TestSiteProcessor_Process_OutputPath_WithSlug(t *testing.T) {
+	p := NewSiteProcessor()
+	a := &model.Article{
+		FrontMatter:  model.FrontMatter{Slug: "my-slug"},
+		RawContent:   "content",
+		FilePath:     "content/posts/post.md",
+		LastModified: time.Now(),
+	}
+	cfg := model.Config{Build: model.BuildConfig{ContentDir: "content", OutputDir: "public"}}
+	processed, err := p.Process([]*model.Article{a}, cfg)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	expected := filepath.Join("public", "posts", "my-slug", "index.html")
+	if processed[0].OutputPath != expected {
+		t.Errorf("OutputPath: got %q, want %q", processed[0].OutputPath, expected)
+	}
+}
+
+func TestSiteProcessor_Process_OutputPath_NoSlug(t *testing.T) {
+	p := NewSiteProcessor()
+	a := &model.Article{
+		FilePath:     "content/posts/my-post.md",
+		RawContent:   "content",
+		LastModified: time.Now(),
+	}
+	cfg := model.Config{Build: model.BuildConfig{ContentDir: "content", OutputDir: "public"}}
+	processed, err := p.Process([]*model.Article{a}, cfg)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	expected := filepath.Join("public", "posts", "my-post", "index.html")
+	if processed[0].OutputPath != expected {
+		t.Errorf("OutputPath: got %q, want %q", processed[0].OutputPath, expected)
+	}
+}
+
+func TestSiteProcessor_BuildDependencyGraph(t *testing.T) {
+	p := NewSiteProcessor()
+	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	articles := []*model.ProcessedArticle{
+		{Article: *testArticle("a.md", "A", "", []string{"go", "ssg"}, []string{"news"}, date)},
+		{Article: *testArticle("b.md", "B", "", []string{"go"}, nil, time.Time{})},
+	}
+	g, err := p.BuildDependencyGraph(articles)
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph: %v", err)
+	}
+	if _, ok := g.Nodes["a.md"]; !ok {
+		t.Error("expected node for a.md")
+	}
+	if _, ok := g.Nodes["tag:go"]; !ok {
+		t.Error("expected tag:go node")
+	}
+	if _, ok := g.Nodes["tag:ssg"]; !ok {
+		t.Error("expected tag:ssg node")
+	}
+	if _, ok := g.Nodes["category:news"]; !ok {
+		t.Error("expected category:news node")
+	}
+	if _, ok := g.Nodes["archive:2024"]; !ok {
+		t.Error("expected archive:2024 node")
+	}
+	if len(g.Edges["a.md"]) != 4 {
+		t.Errorf("a.md: expected 4 edges, got %d: %v", len(g.Edges["a.md"]), g.Edges["a.md"])
+	}
+}
+
+func TestSiteProcessor_BuildTaxonomyRegistry(t *testing.T) {
+	p := NewSiteProcessor()
+	articles := []*model.ProcessedArticle{
+		{Article: *testArticle("a.md", "A", "", []string{"go", "ssg"}, []string{"web"}, time.Time{})},
+		{Article: *testArticle("b.md", "B", "", []string{"go"}, []string{"news"}, time.Time{})},
+	}
+	reg, err := p.BuildTaxonomyRegistry(articles, model.Config{})
+	if err != nil {
+		t.Fatalf("BuildTaxonomyRegistry: %v", err)
+	}
+	if len(reg.Tags) != 2 {
+		t.Errorf("Tags: got %d, want 2", len(reg.Tags))
+	}
+	if len(reg.Categories) != 2 {
+		t.Errorf("Categories: got %d, want 2", len(reg.Categories))
+	}
+}
+
+func TestCalculateImpact(t *testing.T) {
+	g := &model.DependencyGraph{
+		Nodes: map[string]*model.Node{
+			"article.md": {Path: "article.md", Type: model.NodeTypeArticle, Dependents: []string{}},
+			"tag:go":     {Path: "tag:go", Type: model.NodeTypeTag, Dependents: []string{"article.md"}},
+		},
+		Edges: map[string][]string{
+			"article.md": {"tag:go"},
+		},
+	}
+	impact := CalculateImpact(g, "tag:go")
+	if len(impact) != 2 {
+		t.Errorf("expected 2 impacted nodes, got %d: %v", len(impact), impact)
+	}
+}
+
+func TestCalculateDiff(t *testing.T) {
+	old := &model.DependencyGraph{
+		Nodes: map[string]*model.Node{
+			"a.md": {Path: "a.md"},
+			"b.md": {Path: "b.md"},
+		},
+		Edges: map[string][]string{},
+	}
+	newG := &model.DependencyGraph{
+		Nodes: map[string]*model.Node{
+			"a.md": {Path: "a.md"},
+			"c.md": {Path: "c.md"},
+		},
+		Edges: map[string][]string{},
+	}
+	cs, err := CalculateDiff(old, newG)
+	if err != nil {
+		t.Fatalf("CalculateDiff: %v", err)
+	}
+	if len(cs.AddedFiles) != 1 || cs.AddedFiles[0] != "c.md" {
+		t.Errorf("AddedFiles: %v", cs.AddedFiles)
+	}
+	if len(cs.DeletedFiles) != 1 || cs.DeletedFiles[0] != "b.md" {
+		t.Errorf("DeletedFiles: %v", cs.DeletedFiles)
+	}
+	if len(cs.ModifiedFiles) != 1 || cs.ModifiedFiles[0] != "a.md" {
+		t.Errorf("ModifiedFiles: %v", cs.ModifiedFiles)
+	}
+}
+
+func TestCalculateDiff_NilGraph(t *testing.T) {
+	_, err := CalculateDiff(nil, &model.DependencyGraph{Nodes: map[string]*model.Node{}, Edges: map[string][]string{}})
+	if err == nil {
+		t.Error("expected error for nil oldGraph")
+	}
+}
+
+func TestExtractSummary_FirstParagraph(t *testing.T) {
+	content := "First paragraph here.\n\nSecond paragraph."
+	got := extractSummary(content, 200)
+	if got != "First paragraph here." {
+		t.Errorf("extractSummary: got %q", got)
+	}
+}
+
+func TestExtractSummary_Truncate(t *testing.T) {
+	content := strings.Repeat("x", 300)
+	got := extractSummary(content, 200)
+	if len(got) > 204 {
+		t.Errorf("extractSummary too long: %d chars", len(got))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Error("expected truncation marker ...")
+	}
+}


### PR DESCRIPTION
## Summary

Implements Phase 5-1: dependency graph construction and content processor pipeline.

Closes #12

## Changes

### `internal/processor/graph.go`
- `addNode` / `addEdge`: build a `*model.DependencyGraph`, maintaining bidirectional `Dependents` / `Dependencies` lists
- `CalculateImpact(g, path)`: returns all transitively impacted node paths via DFS
- `traverseDependents`: recursive helper with cycle-safe visited map
- `CalculateDiff(old, new)`: produces `*model.ChangeSet` (added/deleted/modified nodes)
- `appendUnique`: deduplication helper

### `internal/processor/processor_impl.go`
- `SiteProcessor` struct implementing the `Processor` interface
- `Process(articles, cfg)`: Markdown → HTML (goldmark + GFM), first-paragraph summary, per-article output path respecting `FrontMatter.Slug`
- `BuildDependencyGraph(articles)`: links article nodes to tag/category/archive nodes with proper edges
- `BuildTaxonomyRegistry(articles, cfg)`: deduplicates all tags and categories across articles
- Compile-time check: `var _ Processor = (*SiteProcessor)(nil)`

### `internal/processor/processor_test.go`
- 10 tests, 94.4% coverage