### PR TITLE
feat: implement build cache for .gohan/cache/ (Phase 7-2, #17)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,9 +28,9 @@ feat: {概要} (#{issue番号})
 
 ## PR チェーン（全フェーズ）
 
-> **現在のブランチ**: `feat/phase-6-1-html-generator`（PR #35 作成済み）
-> **次のタスク**: Phase 6-2 (Issue #15) から再開
-> **注意**: PR #26〜#35 はすべて OPEN。チェーン構成のため #26 から順番にマージすること。
+> **現在のブランチ**: `feat/phase-7-2-cache`（PR #38 作成済み）
+> **次のタスク**: Phase 8-1 (Issue #18) から再開
+> **注意**: PR #26〜#38 はすべて OPEN。チェーン構成のため #26 から順番にマージすること。
 
 | フェーズ | Issue | ブランチ | Base ブランチ | PR | 状態 |
 |---|---|---|---|---|---|
@@ -44,9 +44,9 @@ feat: {概要} (#{issue番号})
 | 5-1  | #12 | `feat/phase-5-1-build-processor`     | `feat/phase-4-template-engine`       | #33 | ✅ PR作成済み |
 | 5-2  | #13 | `feat/phase-5-2-taxonomy-system`     | `feat/phase-5-1-build-processor`     | #34 | ✅ PR作成済み |
 | 6-1  | #14 | `feat/phase-6-1-html-generator`      | `feat/phase-5-2-taxonomy-system`     | #35 | ✅ PR作成済み |
-| 6-2  | #15 | `feat/phase-6-2-sitemap-feed`        | `feat/phase-6-1-html-generator`      | -   | ⏳ 未着手 |
-| 7-1  | #16 | `feat/phase-7-1-git-diff`            | `feat/phase-6-2-sitemap-feed`        | -   | ⏳ 未着手 |
-| 7-2  | #17 | `feat/phase-7-2-cache`               | `feat/phase-7-1-git-diff`            | -   | ⏳ 未着手 |
+| 6-2  | #15 | `feat/phase-6-2-sitemap-feed`        | `feat/phase-6-1-html-generator`      | #36 | ✅ PR作成済み |
+| 7-1  | #16 | `feat/phase-7-1-git-diff`            | `feat/phase-6-2-sitemap-feed`        | #37 | ✅ PR作成済み |
+| 7-2  | #17 | `feat/phase-7-2-cache`               | `feat/phase-7-1-git-diff`            | #38 | ✅ PR作成済み |
 | 8-1  | #18 | `feat/phase-8-1-build-command`       | `feat/phase-7-2-cache`               | -   | ⏳ 未着手 |
 | 8-2  | #19 | `feat/phase-8-2-new-command`         | `feat/phase-8-1-build-command`       | -   | ⏳ 未着手 |
 | 8-3  | #20 | `feat/phase-8-3-serve-command`       | `feat/phase-8-2-new-command`         | -   | ⏳ 未着手 |
@@ -90,15 +90,15 @@ feat: {概要} (#{issue番号})
 
 ```bash
 cd /Users/bmf/localdev/gohan
-git checkout feat/phase-6-1-html-generator  # 現在の最新ブランチ
+git checkout feat/phase-7-2-cache  # 現在の最新ブランチ
 
-# Phase 6-2 から再開
-git checkout -b feat/phase-6-2-sitemap-feed
+# Phase 8-1 から再開
+git checkout -b feat/phase-8-1-build-command
 # 実装 → テスト → コミット
-git add -A && git commit -m "feat: implement sitemap and feed generator (#15)"
-git push -u origin feat/phase-6-2-sitemap-feed
-gh pr create --base feat/phase-6-1-html-generator --head feat/phase-6-2-sitemap-feed \
-  --title "feat: implement sitemap and feed generator" --body "Closes #15"
+git add -A && git commit -m "feat: implement gohan build command (#18)"
+git push -u origin feat/phase-8-1-build-command
+gh pr create --base feat/phase-7-2-cache --head feat/phase-8-1-build-command \
+  --title "feat: implement gohan build command (Phase 8-1, #18)" --body "Closes #18"
 gh api -X POST /repos/bmf-san/gohan/issues/<PR番号>/labels -f "labels[]=enhancement"
 gh api -X POST /repos/bmf-san/gohan/issues/<PR番号>/assignees -f "assignees[]=bmf-san"
 ```
@@ -118,6 +118,13 @@ internal/
   processor/taxonomy.go + _test.go        # タクソノミーシステム (94.7% coverage)
   generator/generator.go                  # OutputGenerator インターフェース
   generator/html.go + html_test.go        # HTMLGenerator (86.2% coverage)
+  generator/sitemap.go                    # GenerateSitemap() → sitemap.xml
+  generator/feed.go                       # GenerateFeeds() → feed.xml (RSS) + atom.xml (Atom)
+  generator/sitemap_feed_test.go          # 7テスト (86.4% coverage)
+  diff/git.go                             # GitDiffEngine: Detect/Hash/IsGitRepo/DetectChanges (78.8% coverage)
+  diff/git_test.go                        # 9テスト
+  diff/cache.go                           # ReadManifest/WriteManifest/ReadCachedHTML/WriteCachedHTML/ClearCache/CheckConfigChange (78.5% coverage)
+  diff/cache_test.go                      # 9テスト
 ```
 
 ## ファイル作成時の注意点

--- a/internal/diff/cache.go
+++ b/internal/diff/cache.go
@@ -1,0 +1,109 @@
+package diff
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/bmf-san/gohan/internal/model"
+)
+
+const (
+	cacheManifestFile = "manifest.json"
+	cacheHTMLDir      = "html"
+	configHashKey     = "__config__"
+	manifestVersion   = "1"
+)
+
+// ReadManifest loads the BuildManifest from cacheDir/manifest.json.
+// Returns nil (no error) when the file does not exist yet.
+func ReadManifest(cacheDir string) (*model.BuildManifest, error) {
+	path := filepath.Join(cacheDir, cacheManifestFile)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+	var m model.BuildManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("unmarshal manifest: %w", err)
+	}
+	return &m, nil
+}
+
+// WriteManifest persists m to cacheDir/manifest.json, creating directories as
+// needed.
+func WriteManifest(cacheDir string, m *model.BuildManifest) error {
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return fmt.Errorf("mkdir cache: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	path := filepath.Join(cacheDir, cacheManifestFile)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("write manifest: %w", err)
+	}
+	return nil
+}
+
+// ReadCachedHTML returns the cached HTML for slug from cacheDir/html/<slug>.html.
+// Returns ("", nil) when not present.
+func ReadCachedHTML(cacheDir, slug string) (string, error) {
+	path := filepath.Join(cacheDir, cacheHTMLDir, slug+".html")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read cached html: %w", err)
+	}
+	return string(data), nil
+}
+
+// WriteCachedHTML stores html under cacheDir/html/<slug>.html.
+func WriteCachedHTML(cacheDir, slug, html string) error {
+	dir := filepath.Join(cacheDir, cacheHTMLDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("mkdir html cache: %w", err)
+	}
+	path := filepath.Join(dir, slug+".html")
+	if err := os.WriteFile(path, []byte(html), 0644); err != nil {
+		return fmt.Errorf("write cached html: %w", err)
+	}
+	return nil
+}
+
+// ClearCache removes all files under cacheDir.
+func ClearCache(cacheDir string) error {
+	if err := os.RemoveAll(cacheDir); err != nil {
+		return fmt.Errorf("clear cache: %w", err)
+	}
+	return nil
+}
+
+// CheckConfigChange returns true when the hash stored for configHashKey in
+// manifest differs from currentConfigHash.  A nil manifest is treated as
+// changed (first build).
+func CheckConfigChange(manifest *model.BuildManifest, currentConfigHash string) bool {
+	if manifest == nil || manifest.FileHashes == nil {
+		return true
+	}
+	stored, ok := manifest.FileHashes[configHashKey]
+	return !ok || stored != currentConfigHash
+}
+
+// NewManifest returns a fresh BuildManifest stamped with currentConfigHash.
+func NewManifest(configHash string) *model.BuildManifest {
+	return &model.BuildManifest{
+		Version:    manifestVersion,
+		BuildTime:  time.Now().UTC(),
+		FileHashes: map[string]string{configHashKey: configHash},
+	}
+}

--- a/internal/diff/cache_test.go
+++ b/internal/diff/cache_test.go
@@ -1,0 +1,76 @@
+package diff
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bmf-san/gohan/internal/model"
+)
+
+func TestWriteReadManifest(t *testing.T) {
+	dir := t.TempDir()
+	m := &model.BuildManifest{
+		Version:   "1",
+		BuildTime: time.Now().UTC().Truncate(time.Second),
+		FileHashes: map[string]string{"a.md": "abc"},
+	}
+	if err := WriteManifest(dir, m); err != nil { t.Fatalf("WriteManifest: %v", err) }
+	got, err := ReadManifest(dir)
+	if err != nil { t.Fatalf("ReadManifest: %v", err) }
+	if got.Version != m.Version { t.Errorf("version mismatch") }
+	if got.FileHashes["a.md"] != "abc" { t.Error("hash mismatch") }
+}
+
+func TestReadManifest_NotExist(t *testing.T) {
+	dir := t.TempDir()
+	m, err := ReadManifest(dir)
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if m != nil { t.Error("expected nil") }
+}
+
+func TestWriteReadCachedHTML(t *testing.T) {
+	dir := t.TempDir()
+	html := "<h1>hello</h1>"
+	if err := WriteCachedHTML(dir, "my-post", html); err != nil { t.Fatalf("write: %v", err) }
+	got, err := ReadCachedHTML(dir, "my-post")
+	if err != nil { t.Fatalf("read: %v", err) }
+	if got != html { t.Errorf("got %q, want %q", got, html) }
+}
+
+func TestReadCachedHTML_NotExist(t *testing.T) {
+	dir := t.TempDir()
+	got, err := ReadCachedHTML(dir, "nope")
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if got != "" { t.Error("expected empty string") }
+}
+
+func TestClearCache(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "cache")
+	if err := os.MkdirAll(sub, 0755); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(filepath.Join(sub, "x.json"), []byte("{}"), 0644); err != nil { t.Fatal(err) }
+	if err := ClearCache(sub); err != nil { t.Fatalf("ClearCache: %v", err) }
+	if _, err := os.Stat(sub); !os.IsNotExist(err) { t.Error("expected removed") }
+}
+
+func TestCheckConfigChange_NilManifest(t *testing.T) {
+	if !CheckConfigChange(nil, "hash") { t.Error("expected true for nil") }
+}
+
+func TestCheckConfigChange_Same(t *testing.T) {
+	m := &model.BuildManifest{FileHashes: map[string]string{"__config__": "h1"}}
+	if CheckConfigChange(m, "h1") { t.Error("expected false") }
+}
+
+func TestCheckConfigChange_Different(t *testing.T) {
+	m := &model.BuildManifest{FileHashes: map[string]string{"__config__": "old"}}
+	if !CheckConfigChange(m, "new") { t.Error("expected true") }
+}
+
+func TestNewManifest(t *testing.T) {
+	m := NewManifest("myhash")
+	if m.Version != "1" { t.Errorf("version: %s", m.Version) }
+	if m.FileHashes["__config__"] != "myhash" { t.Errorf("config hash: %v", m.FileHashes) }
+}


### PR DESCRIPTION
## Summary
Phase 7-2: persist build state to `.gohan/cache/`.

## Changes
- `ReadManifest` / `WriteManifest`: JSON round-trip for `BuildManifest` at `manifest.json`
- `ReadCachedHTML` / `WriteCachedHTML`: per-slug HTML cache at `html/<slug>.html`
- `ClearCache`: remove entire cache directory
- `CheckConfigChange`: detect full-rebuild trigger via `__config__` hash key
- `NewManifest`: create fresh manifest stamped with config hash
- 9 unit tests (18 total in package, 78.5% coverage)

Closes #17