### PR TITLE
feat: implement gohan new command (Phase 8-2)

### DIFF
--- a/cmd/gohan/new.go
+++ b/cmd/gohan/new.go
@@ -1,8 +1,92 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
 
-// runNew is implemented in Phase 8-2.
 func runNew(args []string) error {
-	return fmt.Errorf("'new' command not yet implemented")
+	fs := flag.NewFlagSet("new", flag.ContinueOnError)
+	title := fs.String("title", "", "article title (defaults to slug)")
+	articleType := fs.String("type", "post", "article type: post or page")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() == 0 {
+		return fmt.Errorf("usage: gohan new [--title=\"...\" ] [--type=post|page] <slug>")
+	}
+	slug := fs.Arg(0)
+
+	// Validate slug: no path separators, no spaces
+	if strings.ContainsAny(slug, "/\\") {
+		return fmt.Errorf("slug must not contain path separators: %q", slug)
+	}
+
+	// Determine directory
+	var dir string
+	switch *articleType {
+	case "post", "":
+		dir = filepath.Join("content", "posts")
+	case "page":
+		dir = filepath.Join("content", "pages")
+	default:
+		return fmt.Errorf("unknown type %q: must be post or page", *articleType)
+	}
+
+	// Resolve title
+	articleTitle := *title
+	if articleTitle == "" {
+		// Convert slug to title: replace hyphens/underscores with spaces, title-case
+		articleTitle = slugToTitle(slug)
+	}
+
+	filePath := filepath.Join(dir, slug+".md")
+
+	// Error if file already exists
+	if _, err := os.Stat(filePath); err == nil {
+		return fmt.Errorf("file already exists: %s", filePath)
+	}
+
+	// Create directory if needed
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	// Build front matter
+	today := time.Now().Format("2006-01-02")
+	content := fmt.Sprintf(`---
+title: %q
+date: %s
+draft: true
+tags: []
+categories: []
+---
+
+`, articleTitle, today)
+
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	fmt.Printf("created: %s\n", filePath)
+	return nil
+}
+
+// slugToTitle converts a hyphen/underscore-separated slug to a title-cased string.
+func slugToTitle(slug string) string {
+	slug = strings.ReplaceAll(slug, "-", " ")
+	slug = strings.ReplaceAll(slug, "_", " ")
+	words := strings.Fields(slug)
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
 }

--- a/cmd/gohan/new_test.go
+++ b/cmd/gohan/new_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunNew_MissingSlug(t *testing.T) {
+	err := runNew([]string{})
+	if err == nil {
+		t.Fatal("expected error for missing slug")
+	}
+}
+
+func TestRunNew_UnknownType(t *testing.T) {
+	err := runNew([]string{"--type=article", "my-slug"})
+	if err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+}
+
+func TestRunNew_CreatePost(t *testing.T) {
+	tmpDir := t.TempDir()
+	old, _ := os.Getwd()
+	defer os.Chdir(old)
+	os.Chdir(tmpDir)
+
+	err := runNew([]string{"my-first-post"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path := filepath.Join("content", "posts", "my-first-post.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "title:") {
+		t.Error("missing title in front matter")
+	}
+	if !strings.Contains(content, "draft: true") {
+		t.Error("missing draft in front matter")
+	}
+	if !strings.Contains(content, "tags: []") {
+		t.Error("missing tags in front matter")
+	}
+	if !strings.Contains(content, "categories: []") {
+		t.Error("missing categories in front matter")
+	}
+}
+
+func TestRunNew_CreatePage(t *testing.T) {
+	tmpDir := t.TempDir()
+	old, _ := os.Getwd()
+	defer os.Chdir(old)
+	os.Chdir(tmpDir)
+
+	err := runNew([]string{"--type=page", "--title=About Me", "about"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path := filepath.Join("content", "pages", "about.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+	if !strings.Contains(string(data), `"About Me"`) {
+		t.Errorf("expected title \"About Me\" in front matter, got:\n%s", string(data))
+	}
+}
+
+func TestRunNew_ExistingFileError(t *testing.T) {
+	tmpDir := t.TempDir()
+	old, _ := os.Getwd()
+	defer os.Chdir(old)
+	os.Chdir(tmpDir)
+
+	// Create first time
+	if err := runNew([]string{"duplicate-slug"}); err != nil {
+		t.Fatalf("first creation failed: %v", err)
+	}
+	// Second creation should fail
+	if err := runNew([]string{"duplicate-slug"}); err == nil {
+		t.Fatal("expected error for existing file")
+	}
+}
+
+func TestRunNew_SlugToTitle(t *testing.T) {
+	cases := []struct {
+		slug, want string
+	}{
+		{"my-first-post", "My First Post"},
+		{"hello_world", "Hello World"},
+		{"simple", "Simple"},
+	}
+	for _, tc := range cases {
+		got := slugToTitle(tc.slug)
+		if got != tc.want {
+			t.Errorf("slugToTitle(%q) = %q, want %q", tc.slug, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements the `gohan new` CLI command (Phase 8-2, Closes #19).

## Changes

- `cmd/gohan/new.go` — full implementation (replaces stub from Phase 8-1)
- `cmd/gohan/new_test.go` — 6 unit tests (all pass)

## `gohan new` usage

```bash
# Create a new post (content/posts/my-first-post.md)
gohan new my-first-post

# With explicit title
gohan new --title="My First Post" my-first-post

# Create a page (content/pages/about.md)
gohan new --type=page about
```

## Flags

| Flag | Default | Description |
|---|---|---|
| `--title` | (from slug) | Article title in front matter |
| `--type` | `post` | `post` → `content/posts/`, `page` → `content/pages/` |

## Generated front matter

```yaml
---
title: "My First Post"
date: 2026-03-01
draft: true
tags: []
categories: []
---
```

## Tests

- `TestRunNew_MissingSlug` — no slug → error
- `TestRunNew_UnknownType` — unknown type → error
- `TestRunNew_CreatePost` — creates post with correct front matter
- `TestRunNew_CreatePage` — creates page with `--title` override
- `TestRunNew_ExistingFileError` — duplicate slug → error
- `TestRunNew_SlugToTitle` — slug-to-title conversion