### PR TITLE
feat: implement dev server with fsnotify + SSE live reload (Phase 9)

### DIFF
--- a/cmd/gohan/serve.go
+++ b/cmd/gohan/serve.go
@@ -29,7 +29,12 @@ func runServe(args []string) error {
 	rootDir := filepath.Dir(*configPath)
 	outDir := filepath.Join(rootDir, "public")
 
-	srv := server.NewDevServer(*host, *port, outDir)
+	// rebuildFn triggers a differential build on file change
+	rebuildFn := func() error {
+		return runBuild([]string{"--config", *configPath})
+	}
+
+	srv := server.NewDevServer(*host, *port, outDir, rebuildFn)
 	fmt.Printf("serve: listening on http://%s:%d\n", *host, *port)
 	return srv.Start()
 }

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,8 @@ go 1.25.3
 require gopkg.in/yaml.v3 v3.0.1
 
 require github.com/yuin/goldmark v1.7.16
+
+require (
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
 github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,9 +1,18 @@
 package server
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
 )
+
+// ─────────────────────────────────────────
+// FileWatcher interface
+// ─────────────────────────────────────────
 
 // FileWatcher is the file change detection interface. The implementation uses fsnotify.
 type FileWatcher interface {
@@ -12,28 +21,265 @@ type FileWatcher interface {
 	Close() error
 }
 
-// DevServer is a local HTTP development server.
-type DevServer struct {
-	Host    string
-	Port    int
-	OutDir  string
-	Watcher FileWatcher
+// ─────────────────────────────────────────
+// FsnotifyWatcher: FileWatcher backed by fsnotify
+// ─────────────────────────────────────────
+
+// FsnotifyWatcher implements FileWatcher using github.com/fsnotify/fsnotify.
+type FsnotifyWatcher struct {
+	watcher *fsnotify.Watcher
+	events  chan string
+	done    chan struct{}
 }
 
-// NewDevServer creates a new DevServer.
-func NewDevServer(host string, port int, outDir string) *DevServer {
-	return &DevServer{
-		Host:   host,
-		Port:   port,
-		OutDir: outDir,
+// NewFsnotifyWatcher creates and starts a new FsnotifyWatcher.
+func NewFsnotifyWatcher() (*FsnotifyWatcher, error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	fw := &FsnotifyWatcher{
+		watcher: w,
+		events:  make(chan string, 100),
+		done:    make(chan struct{}),
+	}
+	go fw.loop()
+	return fw, nil
+}
+
+func (fw *FsnotifyWatcher) loop() {
+	defer close(fw.events)
+	for {
+		select {
+		case event, ok := <-fw.watcher.Events:
+			if !ok {
+				return
+			}
+			// Filter: only care about write/create/remove events
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Remove) {
+				select {
+				case fw.events <- event.Name:
+				default: // drop if buffer full
+				}
+			}
+		case _, ok := <-fw.watcher.Errors:
+			if !ok {
+				return
+			}
+		case <-fw.done:
+			return
+		}
 	}
 }
 
-// Start starts the development server.
-// Phase 9 expands this with fsnotify file watching and SSE live reload.
+// Add adds a path to be watched.
+func (fw *FsnotifyWatcher) Add(path string) error { return fw.watcher.Add(path) }
+
+// Events returns the channel that receives changed file paths.
+func (fw *FsnotifyWatcher) Events() <-chan string { return fw.events }
+
+// Close stops the watcher.
+func (fw *FsnotifyWatcher) Close() error {
+	close(fw.done)
+	return fw.watcher.Close()
+}
+
+// ─────────────────────────────────────────
+// SSE broadcaster
+// ─────────────────────────────────────────
+
+type sseBroadcaster struct {
+	mu      sync.Mutex
+	clients map[chan string]struct{}
+}
+
+func newSSEBroadcaster() *sseBroadcaster {
+	return &sseBroadcaster{clients: make(map[chan string]struct{})}
+}
+
+func (b *sseBroadcaster) subscribe() chan string {
+	ch := make(chan string, 1)
+	b.mu.Lock()
+	b.clients[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch
+}
+
+func (b *sseBroadcaster) unsubscribe(ch chan string) {
+	b.mu.Lock()
+	delete(b.clients, ch)
+	b.mu.Unlock()
+}
+
+func (b *sseBroadcaster) broadcast(msg string) {
+	b.mu.Lock()
+	clients := make([]chan string, 0, len(b.clients))
+	for ch := range b.clients {
+		clients = append(clients, ch)
+	}
+	b.mu.Unlock()
+	for _, ch := range clients {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+}
+
+// ─────────────────────────────────────────
+// Script-injecting response writer
+// ─────────────────────────────────────────
+
+const sseScript = `<script>(function(){` +
+	`var e=new EventSource("/__gohan/reload");` +
+	`e.onmessage=function(){location.reload();};` +
+	`})()</script>`
+
+type injectingResponseWriter struct {
+	wrapped    http.ResponseWriter
+	buf        bytes.Buffer
+	header     int
+	isHTML     bool
+	headerSent bool
+}
+
+func (w *injectingResponseWriter) Header() http.Header { return w.wrapped.Header() }
+
+func (w *injectingResponseWriter) WriteHeader(code int) {
+	ct := w.Header().Get("Content-Type")
+	w.isHTML = strings.Contains(ct, "text/html")
+	w.header = code
+}
+
+func (w *injectingResponseWriter) Write(b []byte) (int, error) {
+	if !w.isHTML {
+		return w.wrapped.Write(b)
+	}
+	return w.buf.Write(b)
+}
+
+func (w *injectingResponseWriter) flush() {
+	if !w.isHTML {
+		return
+	}
+	if w.header != 0 {
+		w.wrapped.WriteHeader(w.header)
+	}
+	body := w.buf.Bytes()
+	script := []byte(sseScript)
+	if idx := bytes.Index(body, []byte("</body>")); idx >= 0 {
+		injected := make([]byte, 0, len(body)+len(script))
+		injected = append(injected, body[:idx]...)
+		injected = append(injected, script...)
+		injected = append(injected, body[idx:]...)
+		body = injected
+	} else {
+		body = append(body, script...)
+	}
+	_, _ = w.wrapped.Write(body)
+}
+
+// injectingHandler wraps handler and injects the SSE script into HTML responses.
+func injectingHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		iw := &injectingResponseWriter{wrapped: w}
+		h.ServeHTTP(iw, r)
+		iw.flush()
+	})
+}
+
+// ─────────────────────────────────────────
+// DevServer
+// ─────────────────────────────────────────
+
+// DevServer is a local HTTP development server with live reload.
+type DevServer struct {
+	Host        string
+	Port        int
+	OutDir      string
+	Watcher     FileWatcher
+	RebuildFunc func() error // called on file change; may be nil
+}
+
+// NewDevServer creates a new DevServer.
+// rebuildFn is called when a watched file changes; pass nil to disable rebuild.
+func NewDevServer(host string, port int, outDir string, rebuildFn func() error) *DevServer {
+	return &DevServer{
+		Host:        host,
+		Port:        port,
+		OutDir:      outDir,
+		RebuildFunc: rebuildFn,
+	}
+}
+
+// WatchDirs is the set of directories monitored for changes.
+var WatchDirs = []string{"content", "themes", "assets"}
+
+// Start starts the development server and blocks until it exits.
 func (s *DevServer) Start() error {
-	fs := http.FileServer(http.Dir(s.OutDir))
+	broadcaster := newSSEBroadcaster()
+
+	// Set up HTTP mux
 	mux := http.NewServeMux()
-	mux.Handle("/", fs)
-	return http.ListenAndServe(fmt.Sprintf("%s:%d", s.Host, s.Port), mux)
+
+	// SSE endpoint: /__gohan/reload
+	mux.HandleFunc("/__gohan/reload", func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "SSE not supported", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		ch := broadcaster.subscribe()
+		defer broadcaster.unsubscribe(ch)
+
+		notify := r.Context().Done()
+		for {
+			select {
+			case <-notify:
+				return
+			case msg, ok := <-ch:
+				if !ok {
+					return
+				}
+				fmt.Fprintf(w, "data: %s\n\n", msg)
+				flusher.Flush()
+			}
+		}
+	})
+
+	// Static file server with script injection
+	fileHandler := injectingHandler(http.FileServer(http.Dir(s.OutDir)))
+	mux.Handle("/", fileHandler)
+
+	// Start file watcher if available
+	if s.Watcher == nil {
+		// Try to create a real watcher; silently skip if unavailable
+		if fw, err := NewFsnotifyWatcher(); err == nil {
+			s.Watcher = fw
+			defer fw.Close()
+		}
+	}
+	if s.Watcher != nil {
+		for _, dir := range WatchDirs {
+			_ = s.Watcher.Add(dir) // ignore missing dirs
+		}
+		go s.watchLoop(broadcaster)
+	}
+
+	addr := fmt.Sprintf("%s:%d", s.Host, s.Port)
+	return http.ListenAndServe(addr, mux)
+}
+
+// watchLoop listens for file change events and triggers rebuild + SSE broadcast.
+func (s *DevServer) watchLoop(b *sseBroadcaster) {
+	for path := range s.Watcher.Events() {
+		if s.RebuildFunc != nil {
+			_ = s.RebuildFunc() // best-effort; errors go to stderr via rebuild
+		}
+		b.broadcast(path)
+	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,11 +1,16 @@
 package server
 
 import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewDevServer(t *testing.T) {
-	srv := NewDevServer("127.0.0.1", 1313, "public")
+	srv := NewDevServer("127.0.0.1", 1313, "public", nil)
 	if srv.Host != "127.0.0.1" {
 		t.Errorf("expected host 127.0.0.1, got %s", srv.Host)
 	}
@@ -14,5 +19,90 @@ func TestNewDevServer(t *testing.T) {
 	}
 	if srv.OutDir != "public" {
 		t.Errorf("expected outDir public, got %s", srv.OutDir)
+	}
+}
+
+func TestSSEBroadcaster(t *testing.T) {
+	b := newSSEBroadcaster()
+	ch := b.subscribe()
+
+	b.broadcast("reload")
+
+	select {
+	case msg := <-ch:
+		if msg != "reload" {
+			t.Errorf("expected reload, got %s", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for SSE broadcast")
+	}
+
+	b.unsubscribe(ch)
+}
+
+func TestInjectScript_WithBody(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body>Hello</body></html>"))
+	})
+
+	handler := injectingHandler(inner)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	body := rec.Body.String()
+	if !strings.Contains(body, sseScript) {
+		t.Errorf("expected SSE script injected, body:\n%s", body)
+	}
+	if !strings.Contains(body, "Hello") {
+		t.Error("original content must be preserved")
+	}
+}
+
+func TestInjectScript_NoBody(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>no body tag</html>"))
+	})
+
+	handler := injectingHandler(inner)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	body := rec.Body.String()
+	if !strings.Contains(body, sseScript) {
+		t.Errorf("expected SSE script appended when no </body>, body:\n%s", body)
+	}
+}
+
+func TestInjectScript_NotHTML(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("body { color: red; }"))
+	})
+
+	handler := injectingHandler(inner)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest("GET", "/style.css", nil))
+
+	body := rec.Body.String()
+	if strings.Contains(body, "<script>") {
+		t.Error("must not inject script into non-HTML response")
+	}
+}
+
+func TestInjectingResponseWriter_Buffer(t *testing.T) {
+	rec := httptest.NewRecorder()
+	iw := &injectingResponseWriter{wrapped: rec}
+	iw.Header().Set("Content-Type", "text/html")
+	iw.WriteHeader(http.StatusOK)
+	_, _ = iw.Write([]byte("<html><body>test</body></html>"))
+	iw.flush()
+
+	if !bytes.Contains(rec.Body.Bytes(), []byte(sseScript)) {
+		t.Error("expected SSE script in flushed response")
 	}
 }


### PR DESCRIPTION
## Summary

Full dev server implementation with `fsnotify` file watching and SSE live reload (Phase 9, Closes #21).

## Changes

- `go.mod` / `go.sum` — adds `github.com/fsnotify/fsnotify v1.9.0` (+ `golang.org/x/sys`)
- `internal/server/server.go` — complete rewrite of Phase 8-3 stub
- `internal/server/server_test.go` — 6 unit tests
- `cmd/gohan/serve.go` — updated to pass `rebuildFn` to `NewDevServer`

## Architecture

```
File change (content/, themes/, assets/)
  → FsnotifyWatcher detects event
  → watchLoop calls RebuildFunc (differential build)
  → sseBroadcaster fans out to connected SSE clients
  → browser receives SSE "data:" message → location.reload()
```

### Key types

| Type | Purpose |
|---|---|
| `FsnotifyWatcher` | `FileWatcher` implementation using fsnotify |
| `sseBroadcaster` | Fan-out of SSE events to all connected browsers |
| `injectingHandler` | Wraps `http.FileServer`; injects SSE `<script>` into HTML responses |
| `DevServer` | Wires HTTP mux + SSE endpoint + watcher loop |

### SSE script injected into every HTML response

```html
<script>(function(){var e=new EventSource("/__gohan/reload");e.onmessage=function(){location.reload();};})()</script>
```

## Tests

- `TestNewDevServer` — constructor
- `TestSSEBroadcaster` — subscribe / broadcast / receive
- `TestInjectScript_WithBody` — injects before `</body>`
- `TestInjectScript_NoBody` — appends when no `</body>`
- `TestInjectScript_NotHTML` — does not inject into CSS/JS
- `TestInjectingResponseWriter_Buffer` — buffer + flush cycle

## Design Doc alignment

Implements Design Doc Section 12 exactly (12.1–12.4).