### PR TITLE
feat: implement syntax highlighting with chroma (Phase 10-1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require gopkg.in/yaml.v3 v3.0.1
 require github.com/yuin/goldmark v1.7.16
 
 require (
+	github.com/alecthomas/chroma/v2 v2.23.1 // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=
+github.com/alecthomas/chroma/v2 v2.23.1/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9cxBOfyMbMQPs3o=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,13 +13,14 @@ import (
 )
 
 const (
-	configFileName     = "config.yaml"
-	defaultContentDir  = "content"
-	defaultOutputDir   = "public"
-	defaultAssetsDir   = "assets"
-	defaultParallelism = 4
-	defaultThemeName   = "default"
-	defaultLanguage    = "en"
+	configFileName        = "config.yaml"
+	defaultContentDir     = "content"
+	defaultOutputDir      = "public"
+	defaultAssetsDir      = "assets"
+	defaultParallelism    = 4
+	defaultThemeName      = "default"
+	defaultLanguage       = "en"
+	defaultHighlightTheme = "github"
 )
 
 // Loader reads and validates the gohan project configuration.
@@ -81,6 +82,9 @@ func applyDefaults(cfg *model.Config) {
 	}
 	if cfg.Site.Language == "" {
 		cfg.Site.Language = defaultLanguage
+	}
+	if cfg.SyntaxHighlight.Theme == "" {
+		cfg.SyntaxHighlight.Theme = defaultHighlightTheme
 	}
 }
 

--- a/internal/highlight/highlight.go
+++ b/internal/highlight/highlight.go
@@ -1,0 +1,133 @@
+// Package highlight provides chroma-based syntax highlighting
+// for fenced code blocks in goldmark-rendered Markdown.
+package highlight
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"strings"
+
+	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+// Config holds syntax highlighting settings derived from config.yaml.
+type Config struct {
+	// Theme is a chroma style name (e.g. "github", "monokai", "dracula").
+	// Defaults to "github".
+	Theme string
+	// LineNumbers enables line number display.
+	LineNumbers bool
+}
+
+// DefaultConfig returns the default highlighting configuration.
+func DefaultConfig() Config {
+	return Config{Theme: "github", LineNumbers: false}
+}
+
+// Highlighter renders fenced code blocks with chroma.
+type Highlighter struct {
+	cfg Config
+}
+
+// New creates a Highlighter with the provided config.
+func New(cfg Config) *Highlighter {
+	return &Highlighter{cfg: cfg}
+}
+
+// Highlight returns a syntax-highlighted HTML fragment for the given code and language.
+// If the language is unknown or empty, it falls back to a plain <pre><code> block.
+func (h *Highlighter) Highlight(code, lang string) (string, error) {
+	var lexer = lexers.Get(lang)
+	if lexer == nil {
+		lexer = lexers.Fallback
+	}
+
+	style := styles.Get(h.cfg.Theme)
+	if style == nil {
+		style = styles.Fallback
+	}
+
+	opts := []chromahtml.Option{
+		chromahtml.WithClasses(false), // inline styles for portability
+	}
+	if h.cfg.LineNumbers {
+		opts = append(opts, chromahtml.WithLineNumbers(true))
+	}
+	formatter := chromahtml.New(opts...)
+
+	iterator, err := lexer.Tokenise(nil, code)
+	if err != nil {
+		return plainBlock(code), fmt.Errorf("tokenise: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, style, iterator); err != nil {
+		return plainBlock(code), fmt.Errorf("format: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func plainBlock(code string) string {
+	return "<pre><code>" + html.EscapeString(code) + "</code></pre>"
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Goldmark extension
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+// Extension returns a goldmark.Extender that replaces the default fenced-code-
+// block renderer with chroma-based highlighting.
+func (h *Highlighter) Extension() goldmark.Extender {
+	return &chromaExtender{h: h}
+}
+
+type chromaExtender struct{ h *Highlighter }
+
+func (e *chromaExtender) Extend(m goldmark.Markdown) {
+	m.Renderer().AddOptions(
+		renderer.WithNodeRenderers(
+			util.Prioritized(&codeBlockRenderer{h: e.h}, 200),
+		),
+	)
+}
+
+// codeBlockRenderer replaces goldmark's default FencedCodeBlock renderer.
+type codeBlockRenderer struct{ h *Highlighter }
+
+func (r *codeBlockRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindFencedCodeBlock, r.renderFencedCodeBlock)
+}
+
+func (r *codeBlockRenderer) renderFencedCodeBlock(
+	w util.BufWriter, source []byte, node ast.Node, entering bool,
+) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.FencedCodeBlock)
+
+	// Collect raw code
+	var sb strings.Builder
+	lines := n.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		line := lines.At(i)
+		sb.Write(line.Value(source))
+	}
+
+	lang := string(n.Language(source))
+	highlighted, err := r.h.Highlight(sb.String(), lang)
+	if err != nil {
+		// fallback – already returns plain HTML from plainBlock
+		_, _ = fmt.Fprint(w, highlighted)
+		return ast.WalkSkipChildren, nil
+	}
+	_, _ = fmt.Fprint(w, highlighted)
+	return ast.WalkSkipChildren, nil
+}

--- a/internal/highlight/highlight_test.go
+++ b/internal/highlight/highlight_test.go
@@ -1,0 +1,93 @@
+package highlight
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHighlight_Go(t *testing.T) {
+	h := New(DefaultConfig())
+	code := "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hi\")\n}\n"
+	out, err := h.Highlight(code, "go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "<pre") {
+		t.Error("expected <pre> in output")
+	}
+	if !strings.Contains(out, "fmt") {
+		t.Error("expected source content in output")
+	}
+}
+
+func TestHighlight_Python(t *testing.T) {
+	h := New(DefaultConfig())
+	code := "def hello():\n    print('hello')\n"
+	out, err := h.Highlight(code, "python")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Error("expected source content in output")
+	}
+}
+
+func TestHighlight_Shell(t *testing.T) {
+	h := New(DefaultConfig())
+	code := "#!/bin/bash\necho hello\n"
+	out, err := h.Highlight(code, "bash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "echo") {
+		t.Error("expected source content in output")
+	}
+}
+
+func TestHighlight_UnknownLanguage(t *testing.T) {
+	h := New(DefaultConfig())
+	code := "some unknown lang code\n"
+	out, err := h.Highlight(code, "totally-unknown-xyz")
+	// Should not error; falls back to plain rendering
+	if err != nil {
+		t.Fatalf("unexpected error for unknown language: %v", err)
+	}
+	if !strings.Contains(out, "some unknown lang code") {
+		t.Errorf("expected original code in fallback output, got: %s", out)
+	}
+}
+
+func TestHighlight_EmptyLanguage(t *testing.T) {
+	h := New(DefaultConfig())
+	code := "hello world\n"
+	out, err := h.Highlight(code, "")
+	if err != nil {
+		t.Fatalf("unexpected error for empty language: %v", err)
+	}
+	if !strings.Contains(out, "hello world") {
+		t.Errorf("expected original code in output, got: %s", out)
+	}
+}
+
+func TestHighlight_LineNumbers(t *testing.T) {
+	h := New(Config{Theme: "github", LineNumbers: true})
+	code := "line one\nline two\n"
+	out, err := h.Highlight(code, "text")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// chroma with line numbers wraps in a table; just verify content exists
+	if !strings.Contains(out, "line one") {
+		t.Errorf("expected source content in line-number output, got: %s", out)
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Theme != "github" {
+		t.Errorf("expected default theme github, got %s", cfg.Theme)
+	}
+	if cfg.LineNumbers {
+		t.Error("expected default line numbers false")
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -37,10 +37,19 @@ type FrontMatter struct {
 
 // Config is the top-level structure of config.yaml.
 type Config struct {
-	Site    SiteConfig             `yaml:"site"`
-	Build   BuildConfig            `yaml:"build"`
-	Theme   ThemeConfig            `yaml:"theme"`
-	Plugins map[string]interface{} `yaml:"plugins"`
+	Site            SiteConfig             `yaml:"site"`
+	Build           BuildConfig            `yaml:"build"`
+	Theme           ThemeConfig            `yaml:"theme"`
+	SyntaxHighlight SyntaxHighlightConfig  `yaml:"syntax_highlight"`
+	Plugins         map[string]interface{} `yaml:"plugins"`
+}
+
+// SyntaxHighlightConfig holds settings for code-block syntax highlighting.
+type SyntaxHighlightConfig struct {
+	// Theme is a chroma style name (e.g. "github", "monokai", "dracula").
+	Theme string `yaml:"theme"`
+	// LineNumbers enables line number display when true.
+	LineNumbers bool `yaml:"line_numbers"`
 }
 
 // SiteConfig holds site-wide metadata.

--- a/internal/processor/processor_impl.go
+++ b/internal/processor/processor_impl.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmf-san/gohan/internal/highlight"
 	"github.com/bmf-san/gohan/internal/model"
 	"github.com/bmf-san/gohan/internal/parser"
 )
@@ -21,7 +22,15 @@ func NewSiteProcessor() *SiteProcessor {
 // Process converts raw Articles into ProcessedArticles by rendering Markdown
 // to HTML, extracting summaries, and computing output paths.
 func (p *SiteProcessor) Process(articles []*model.Article, cfg model.Config) ([]*model.ProcessedArticle, error) {
-	conv := parser.NewConverter(parser.WithGFM())
+	hlCfg := highlight.Config{
+		Theme:       cfg.SyntaxHighlight.Theme,
+		LineNumbers: cfg.SyntaxHighlight.LineNumbers,
+	}
+	convOpts := []parser.ConverterOption{parser.WithGFM()}
+	if hlCfg.Theme != "" {
+		convOpts = append(convOpts, parser.WithHighlighting(hlCfg))
+	}
+	conv := parser.NewConverter(convOpts...)
 	result := make([]*model.ProcessedArticle, 0, len(articles))
 	for _, a := range articles {
 		html, err := conv.Convert([]byte(a.RawContent))


### PR DESCRIPTION
## Summary

Implements chroma-based syntax highlighting for fenced code blocks (Phase 10-1, Closes #22).

## Changes

- `go.mod` / `go.sum` — adds `github.com/alecthomas/chroma/v2 v2.23.1`
- `internal/highlight/highlight.go` — `Highlighter` type + goldmark `Extender`
- `internal/highlight/highlight_test.go` — 7 unit tests
- `internal/model/model.go` — adds `SyntaxHighlightConfig{Theme, LineNumbers}`
- `internal/config/config.go` — default theme `"github"`
- `internal/parser/markdown.go` — adds `WithHighlighting()` `ConverterOption`
- `internal/processor/processor_impl.go` — wires `SyntaxHighlight` config into converter

## config.yaml

```yaml
syntax_highlight:
  theme: "github"        # any chroma style name
  line_numbers: false    # set to true to show line numbers
```

## How it works

1. `Highlighter.Highlight(code, lang)` tokenises via chroma lexer, formats with inline styles → no external CSS needed
2. `Highlighter.Extension()` returns a goldmark `Extender` that replaces the default `FencedCodeBlock` renderer
3. `WithHighlighting(cfg)` is a `ConverterOption` — enabled when `SyntaxHighlight.Theme != ""`
4. Processor passes `cfg.SyntaxHighlight` to the converter at build time

## Tests

| Test | Coverage |
|---|---|
| `TestHighlight_Go` | Go source highlighting |
| `TestHighlight_Python` | Python source highlighting |
| `TestHighlight_Shell` | Bash highlighting |
| `TestHighlight_UnknownLanguage` | Falls back gracefully (no error) |
| `TestHighlight_EmptyLanguage` | Falls back gracefully |
| `TestHighlight_LineNumbers` | Line number output |
| `TestDefaultConfig` | Default theme = "github", line_numbers = false |

## Design Doc差分

Design Doc Section 6.1 specifies syntax highlighting but does not name a library. Chroma was chosen per Issue #22 recommendations (widely used, goldmark-compatible).