### PR TITLE
feat: implement Mermaid diagram support (Phase 10-2)

### DIFF
--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bmf-san/gohan/internal/mermaid"
 	"github.com/bmf-san/gohan/internal/model"
 	gohantemplate "github.com/bmf-san/gohan/internal/template"
 )
@@ -168,7 +169,11 @@ func (g *HTMLGenerator) writePage(path, tmplName string, data *model.Site) error
 	if err := g.engine.Render(&buf, tmplName, data); err != nil {
 		return fmt.Errorf("render %s: %w", tmplName, err)
 	}
-	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+	pageBytes := buf.Bytes()
+	if bytes.Contains(pageBytes, []byte(mermaid.MermaidMarker)) {
+		pageBytes = mermaid.InjectScript(pageBytes)
+	}
+	if err := os.WriteFile(path, pageBytes, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil

--- a/internal/mermaid/mermaid.go
+++ b/internal/mermaid/mermaid.go
@@ -1,0 +1,91 @@
+// Package mermaid provides a goldmark extension that transforms fenced code
+// blocks tagged with "mermaid" into browser-renderable <div class="mermaid">
+// elements for client-side rendering via the Mermaid.js CDN.
+package mermaid
+
+import (
+	"bytes"
+	"html"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+// ScriptTag is the Mermaid CDN <script> snippet injected into HTML pages that
+// contain at least one mermaid diagram block.
+const ScriptTag = `<script type="module">` +
+	`import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';` +
+	`mermaid.initialize({startOnLoad:true});` +
+	`</script>`
+
+// MermaidMarker is the CSS class used to identify mermaid diagrams in HTML.
+const MermaidMarker = `class="mermaid"`
+
+// InjectScript inserts ScriptTag into body before </body>.
+// It returns the modified HTML; if </body> is not present the script is appended.
+// Callers should only call this when the HTML contains MermaidMarker.
+func InjectScript(htmlDoc []byte) []byte {
+	script := []byte(ScriptTag)
+	if idx := bytes.Index(htmlDoc, []byte("</body>")); idx >= 0 {
+		out := make([]byte, 0, len(htmlDoc)+len(script))
+		out = append(out, htmlDoc[:idx]...)
+		out = append(out, script...)
+		out = append(out, htmlDoc[idx:]...)
+		return out
+	}
+	return append(htmlDoc, script...)
+}
+
+// Extension returns a goldmark.Extender that replaces the FencedCodeBlock
+// renderer for blocks whose info/language string is "mermaid".
+func Extension() goldmark.Extender {
+	return &mermaidExtender{}
+}
+
+type mermaidExtender struct{}
+
+func (e *mermaidExtender) Extend(m goldmark.Markdown) {
+	m.Renderer().AddOptions(
+		renderer.WithNodeRenderers(
+			util.Prioritized(&mermaidRenderer{}, 199), // higher priority than chroma (200)
+		),
+	)
+}
+
+// mermaidRenderer handles FencedCodeBlock nodes with lang == "mermaid".
+// All other code blocks are passed to the default renderer.
+type mermaidRenderer struct{}
+
+func (r *mermaidRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindFencedCodeBlock, r.renderFencedCodeBlock)
+}
+
+func (r *mermaidRenderer) renderFencedCodeBlock(
+	w util.BufWriter, source []byte, node ast.Node, entering bool,
+) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.FencedCodeBlock)
+	lang := string(n.Language(source))
+	if lang != "mermaid" {
+		// Not a mermaid block — let the next renderer handle it.
+		return ast.WalkContinue, nil
+	}
+
+	// Collect diagram source
+	var buf bytes.Buffer
+	lines := n.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		line := lines.At(i)
+		buf.Write(line.Value(source))
+	}
+
+	// Output as <div class="mermaid"> for client-side rendering
+	_, _ = w.WriteString(`<div class="mermaid">`)
+	_, _ = w.WriteString(html.EscapeString(buf.String()))
+	_, _ = w.WriteString(`</div>`)
+	return ast.WalkSkipChildren, nil
+}

--- a/internal/mermaid/mermaid_test.go
+++ b/internal/mermaid/mermaid_test.go
@@ -1,0 +1,82 @@
+package mermaid
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	goldmarkparser "github.com/yuin/goldmark/parser"
+)
+
+func newMD() goldmark.Markdown {
+	return goldmark.New(
+		goldmark.WithExtensions(extension.GFM, Extension()),
+		goldmark.WithParserOptions(goldmarkparser.WithAutoHeadingID()),
+	)
+}
+
+func TestMermaidBlock_Passthrough(t *testing.T) {
+	md := newMD()
+	src := "```mermaid\ngraph TD\n  A --> B\n```\n"
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(src), &buf); err != nil {
+		t.Fatalf("convert error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `class="mermaid"`) {
+		t.Errorf("expected class=mermaid in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "A --&gt; B") || !strings.Contains(out, "graph TD") {
+		// HTML-escaped content expected
+		t.Errorf("expected diagram content in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "<pre>") {
+		t.Errorf("expected <div>, not <pre> for mermaid block, got:\n%s", out)
+	}
+}
+
+func TestMermaidBlock_NotAffectOtherLang(t *testing.T) {
+	md := newMD()
+	src := "```go\npackage main\n```\n"
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(src), &buf); err != nil {
+		t.Fatalf("convert error: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, `class="mermaid"`) {
+		t.Errorf("go block should not be wrapped in mermaid div, got:\n%s", out)
+	}
+}
+
+func TestInjectScript_WithBody(t *testing.T) {
+	input := []byte("<html><body>content</body></html>")
+	out := InjectScript(input)
+	if !bytes.Contains(out, []byte(ScriptTag)) {
+		t.Error("expected script tag in output")
+	}
+	if !bytes.Contains(out, []byte("content")) {
+		t.Error("original content must be preserved")
+	}
+	// Script should appear before </body>
+	scriptIdx := bytes.Index(out, []byte(ScriptTag))
+	bodyIdx := bytes.Index(out, []byte("</body>"))
+	if scriptIdx > bodyIdx {
+		t.Error("script should be injected before </body>")
+	}
+}
+
+func TestInjectScript_NoBody(t *testing.T) {
+	input := []byte("<html>no body tag</html>")
+	out := InjectScript(input)
+	if !bytes.Contains(out, []byte(ScriptTag)) {
+		t.Error("expected script appended when no </body>")
+	}
+}
+
+func TestMermaidMarker(t *testing.T) {
+	if MermaidMarker == "" {
+		t.Error("MermaidMarker must not be empty")
+	}
+}

--- a/internal/parser/markdown.go
+++ b/internal/parser/markdown.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuin/goldmark/renderer/html"
 
 	"github.com/bmf-san/gohan/internal/highlight"
+	"github.com/bmf-san/gohan/internal/mermaid"
 )
 
 // Converter converts Markdown source bytes into safe HTML.
@@ -25,6 +26,7 @@ type converterConfig struct {
 	gfm          bool
 	unsafeHTML   bool
 	highlighting *highlight.Config
+	mermaid      bool
 }
 
 // ConverterOption is a functional option for NewConverter.
@@ -47,6 +49,12 @@ func WithUnsafeHTML() ConverterOption {
 // cfg specifies the chroma theme and line-number settings.
 func WithHighlighting(cfg highlight.Config) ConverterOption {
 	return func(c *converterConfig) { c.highlighting = &cfg }
+}
+
+// WithMermaid enables client-side Mermaid diagram rendering.
+// Fenced code blocks tagged "mermaid" are output as <div class="mermaid">.
+func WithMermaid() ConverterOption {
+	return func(c *converterConfig) { c.mermaid = true }
 }
 
 // NewConverter builds a Converter with the supplied options.  When no options
@@ -75,6 +83,10 @@ func NewConverter(opts ...ConverterOption) *Converter {
 	if cfg.highlighting != nil {
 		h := highlight.New(*cfg.highlighting)
 		mdOpts = append(mdOpts, goldmark.WithExtensions(h.Extension()))
+	}
+
+	if cfg.mermaid {
+		mdOpts = append(mdOpts, goldmark.WithExtensions(mermaid.Extension()))
 	}
 
 	return &Converter{md: goldmark.New(mdOpts...)}

--- a/internal/processor/processor_impl.go
+++ b/internal/processor/processor_impl.go
@@ -26,7 +26,7 @@ func (p *SiteProcessor) Process(articles []*model.Article, cfg model.Config) ([]
 		Theme:       cfg.SyntaxHighlight.Theme,
 		LineNumbers: cfg.SyntaxHighlight.LineNumbers,
 	}
-	convOpts := []parser.ConverterOption{parser.WithGFM()}
+	convOpts := []parser.ConverterOption{parser.WithGFM(), parser.WithMermaid()}
 	if hlCfg.Theme != "" {
 		convOpts = append(convOpts, parser.WithHighlighting(hlCfg))
 	}


### PR DESCRIPTION
## Summary

Implements Mermaid diagram support for Markdown fenced code blocks (Phase 10-2, Closes #23).

**Rendering approach decision**: Client-side rendering via Mermaid.js CDN (ESM v11). No server-side SVG generation. This is the simpler approach recommended in Issue #23 — no extra Go dependencies, works in any browser, and delegates all diagram layout to Mermaid.js.

## Changes

- `internal/mermaid/mermaid.go` — goldmark `Extender` + script injection utility
- `internal/mermaid/mermaid_test.go` — 5 unit tests
- `internal/parser/markdown.go` — adds `WithMermaid()` `ConverterOption`
- `internal/processor/processor_impl.go` — always enables `WithMermaid()`
- `internal/generator/html.go` — post-processes rendered HTML to inject CDN script when needed

## How it works

1. Goldmark extension intercepts `FencedCodeBlock` nodes with `lang == "mermaid"`
2. Outputs `<div class="mermaid">HTML-escaped diagram source</div>`
3. After rendering, `writePage` checks if the output contains `class="mermaid"` — if so, injects:
   ```html
   <script type="module">import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';mermaid.initialize({startOnLoad:true});</script>
   ```
   before `</body>` (appended if no `</body>` found)

## Usage (in Markdown)

````md
```mermaid
graph TD
  A[Start] --> B{Decision}
  B -->|Yes| C[Result 1]
  B -->|No| D[Result 2]
```
````

## Tests

| Test | Description |
|---|---|
| `TestMermaidBlock_Passthrough` | `mermaid` block → `<div class="mermaid">` |
| `TestMermaidBlock_NotAffectOtherLang` | Non-mermaid blocks not affected |
| `TestInjectScript_WithBody` | Injects before `</body>` |
| `TestInjectScript_NoBody` | Appends when no `</body>` |
| `TestMermaidMarker` | Marker constant is set |

## Design Doc差分

Design Doc Section 6.1 mentions diagram support without specifying the rendering approach. Client-side CDN is chosen and documented here per Issue #23 recommendation.