### PR TITLE
feat: set up GoReleaser and release workflow (Phase 11)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,71 @@
+# GoReleaser configuration for gohan
+# https://goreleaser.com
+
+version: 2
+
+project_name: gohan
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+
+builds:
+  - id: gohan
+    main: ./cmd/gohan
+    binary: gohan
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    # Exclude windows/arm64 — not broadly needed yet
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: gohan
+    builds:
+      - gohan
+    # .tar.gz for Unix; .zip for Windows
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: bmf-san
+    name: gohan
+  draft: false
+  prerelease: auto
+  name_template: "v{{ .Version }}"

--- a/cmd/gohan/main.go
+++ b/cmd/gohan/main.go
@@ -5,6 +5,13 @@ import (
 	"os"
 )
 
+// Version information injected by GoReleaser via ldflags.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
 	if len(os.Args) < 2 {
 		printUsage()
@@ -28,6 +35,8 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
+	case "version":
+		fmt.Printf("gohan %s (commit: %s, built: %s)\n", version, commit, date)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)
 		printUsage()
@@ -39,9 +48,10 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, `Usage: gohan <command> [flags]
 
 Commands:
-  build   Build the site
-  new     Create a new article or page
-  serve   Start the development server
+  build    Build the site
+  new      Create a new article or page
+  serve    Start the development server
+  version  Print version information
 
 Run 'gohan <command> --help' for command-specific flags.`)
 }


### PR DESCRIPTION
## Summary

Sets up automated cross-platform binary releases via GoReleaser (Phase 11, Closes #24).

## Changes

- `.goreleaser.yaml` — cross-platform build configuration
- `.github/workflows/release.yml` — release workflow triggered on `v*` tags
- `cmd/gohan/main.go` — version variables injected by ldflags + `gohan version` subcommand

## Release targets

| OS | Arch | Archive |
|---|---|---|
| Linux | amd64 | `.tar.gz` |
| Linux | arm64 | `.tar.gz` |
| macOS | amd64 | `.tar.gz` |
| macOS | arm64 (M1/M2) | `.tar.gz` |
| Windows | amd64 | `.zip` |

## How to release

```bash
git tag v0.1.0
git push origin v0.1.0
# → GitHub Actions triggers GoReleaser → creates GitHub Release with binaries
```

## Install

```bash
go install github.com/bmf-san/gohan@latest
```

## Design Doc Diffs

Design Doc Section 13 specifies GoReleaser + GitHub Actions — fully implemented as specified. No discrepancies.