### PR TITLE
feat: set up test infrastructure and achieve 85% coverage (Phase 12)

### DIFF
--- a/cmd/gohan/main_test.go
+++ b/cmd/gohan/main_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPrintUsage_WritesToStderr(t *testing.T) {
+	// Redirect stderr and capture output.
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+
+	printUsage()
+
+	w.Close()
+	os.Stderr = orig
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	out := buf.String()
+
+	for _, want := range []string{"build", "new", "serve", "version"} {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Errorf("printUsage output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestVersionVars_Defaults(t *testing.T) {
+	if version == "" {
+		t.Error("version should not be empty")
+	}
+	if commit == "" {
+		t.Error("commit should not be empty")
+	}
+	if date == "" {
+		t.Error("date should not be empty")
+	}
+}
+
+// testdataDir returns the path to cmd/gohan/testdata/.
+// Go's test runner sets cwd to the package directory, so "testdata" works.
+func testdataDir(t *testing.T) string {
+	t.Helper()
+	return "testdata"
+}
+
+func TestRunBuild_FullBuild(t *testing.T) {
+	// Copy testdata to a temp dir so the output doesn't pollute the source tree.
+	src := testdataDir(t)
+	dir := t.TempDir()
+	if err := copyDir(src, dir); err != nil {
+		t.Fatalf("copyDir: %v", err)
+	}
+
+	// Use a relative output name; build.go does filepath.Join(rootDir, outputDir)
+	// so "public" resolves to <dir>/public.
+	err := runBuild([]string{
+		"--config=" + filepath.Join(dir, "config.yaml"),
+		"--output=public",
+	})
+	if err != nil {
+		t.Fatalf("full build: %v", err)
+	}
+
+	outDir := filepath.Join(dir, "public")
+
+	// index.html must exist
+	idx := filepath.Join(outDir, "index.html")
+	if _, statErr := os.Stat(idx); statErr != nil {
+		t.Errorf("index.html not created: %v", statErr)
+	}
+
+	// sitemap.xml
+	sm := filepath.Join(outDir, "sitemap.xml")
+	if _, statErr := os.Stat(sm); statErr != nil {
+		t.Errorf("sitemap.xml not created: %v", statErr)
+	}
+}
+
+func TestRunBuild_FullBuild_ParallelOverride(t *testing.T) {
+	src := testdataDir(t)
+	dir := t.TempDir()
+	if err := copyDir(src, dir); err != nil {
+		t.Fatalf("copyDir: %v", err)
+	}
+
+	err := runBuild([]string{
+		"--config=" + filepath.Join(dir, "config.yaml"),
+		"--output=out",
+		"--parallel=2",
+	})
+	if err != nil {
+		t.Fatalf("full build with --parallel=2: %v", err)
+	}
+}
+
+func TestRunBuild_IncrementalAfterFull(t *testing.T) {
+	src := testdataDir(t)
+	dir := t.TempDir()
+	if err := copyDir(src, dir); err != nil {
+		t.Fatalf("copyDir: %v", err)
+	}
+
+	cfgFlag := "--config=" + filepath.Join(dir, "config.yaml")
+
+	// First: full build (relative output so rootDir / "public" is correct)
+	if err := runBuild([]string{cfgFlag, "--output=public", "--full"}); err != nil {
+		t.Fatalf("full build: %v", err)
+	}
+	// Second: incremental build (uses cached manifest)
+	if err := runBuild([]string{cfgFlag, "--output=public"}); err != nil {
+		t.Fatalf("incremental build: %v", err)
+	}
+}
+
+// copyDir recursively copies src directory to dst.
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
+}

--- a/cmd/gohan/testdata/config.yaml
+++ b/cmd/gohan/testdata/config.yaml
@@ -1,0 +1,5 @@
+site:
+  title: Test Blog
+  description: A test blog
+  base_url: http://localhost
+  language: en

--- a/cmd/gohan/testdata/content/posts/hello-world.md
+++ b/cmd/gohan/testdata/content/posts/hello-world.md
@@ -1,0 +1,7 @@
+---
+title: Hello World
+date: 2024-01-01
+slug: hello-world
+---
+
+Hello, world! This is a test post.

--- a/cmd/gohan/testdata/themes/default/templates/archive.html
+++ b/cmd/gohan/testdata/themes/default/templates/archive.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><head><title>Archive - {{.Config.Site.Title}}</title></head>
+<body>
+{{range .Articles}}<a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>{{end}}
+</body></html>

--- a/cmd/gohan/testdata/themes/default/templates/article.html
+++ b/cmd/gohan/testdata/themes/default/templates/article.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html><head><title>{{(index .Articles 0).FrontMatter.Title}} - {{.Config.Site.Title}}</title></head>
+<body>
+<h1>{{(index .Articles 0).FrontMatter.Title}}</h1>
+{{(index .Articles 0).HTMLContent}}
+</body></html>

--- a/cmd/gohan/testdata/themes/default/templates/category.html
+++ b/cmd/gohan/testdata/themes/default/templates/category.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><head><title>Category - {{.Config.Site.Title}}</title></head>
+<body>
+{{range .Articles}}<a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>{{end}}
+</body></html>

--- a/cmd/gohan/testdata/themes/default/templates/index.html
+++ b/cmd/gohan/testdata/themes/default/templates/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html><head><title>{{.Config.Site.Title}}</title></head>
+<body>
+<h1>{{.Config.Site.Title}}</h1>
+{{range .Articles}}<a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>{{end}}
+</body></html>

--- a/cmd/gohan/testdata/themes/default/templates/tag.html
+++ b/cmd/gohan/testdata/themes/default/templates/tag.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><head><title>Tag - {{.Config.Site.Title}}</title></head>
+<body>
+{{range .Articles}}<a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>{{end}}
+</body></html>

--- a/internal/highlight/extension_test.go
+++ b/internal/highlight/extension_test.go
@@ -1,0 +1,87 @@
+package highlight
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/yuin/goldmark"
+)
+
+// TestExtension_RegisterAndRender exercises Extension(), Extend(),
+// RegisterFuncs() and renderFencedCodeBlock() via a real goldmark conversion.
+func TestExtension_RegisterAndRender(t *testing.T) {
+	h := New(DefaultConfig())
+	md := goldmark.New(goldmark.WithExtensions(h.Extension()))
+
+	src := []byte("```go\nfmt.Println(\"hello\")\n```\n")
+	var buf bytes.Buffer
+	if err := md.Convert(src, &buf); err != nil {
+		t.Fatalf("goldmark.Convert: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "<pre") {
+		t.Errorf("expected <pre> tag in highlighted output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Println") {
+		t.Errorf("expected source code content in output, got:\n%s", out)
+	}
+}
+
+func TestExtension_WithLineNumbers(t *testing.T) {
+	h := New(Config{Theme: "github", LineNumbers: true})
+	md := goldmark.New(goldmark.WithExtensions(h.Extension()))
+
+	src := []byte("```python\nprint('hi')\n```\n")
+	var buf bytes.Buffer
+	if err := md.Convert(src, &buf); err != nil {
+		t.Fatalf("goldmark.Convert: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "print") {
+		t.Errorf("expected code content in output, got:\n%s", out)
+	}
+}
+
+func TestExtension_UnknownLanguage(t *testing.T) {
+	h := New(DefaultConfig())
+	md := goldmark.New(goldmark.WithExtensions(h.Extension()))
+
+	src := []byte("```unknownxyz\nsome code\n```\n")
+	var buf bytes.Buffer
+	if err := md.Convert(src, &buf); err != nil {
+		t.Fatalf("goldmark.Convert: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "some code") {
+		t.Errorf("expected fallback content in output, got:\n%s", out)
+	}
+}
+
+func TestExtension_NoLanguage(t *testing.T) {
+	h := New(DefaultConfig())
+	md := goldmark.New(goldmark.WithExtensions(h.Extension()))
+
+	src := []byte("```\nhello world\n```\n")
+	var buf bytes.Buffer
+	if err := md.Convert(src, &buf); err != nil {
+		t.Fatalf("goldmark.Convert: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "hello world") {
+		t.Errorf("expected content in output, got:\n%s", out)
+	}
+}
+
+func TestPlainBlock_EscapesHTML(t *testing.T) {
+	out := plainBlock("<script>alert('xss')</script>")
+	if strings.Contains(out, "<script>") {
+		t.Error("expected HTML-escaped output, got raw <script>")
+	}
+	if !strings.Contains(out, "&lt;script&gt;") {
+		t.Errorf("expected &lt;script&gt; in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "<pre><code>") {
+		t.Errorf("expected <pre><code> wrapper, got:\n%s", out)
+	}
+}

--- a/internal/server/start_test.go
+++ b/internal/server/start_test.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// freePort finds a free TCP port on localhost.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("freePort: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+// waitForPort polls until the TCP port accepts connections or the deadline is reached.
+func waitForPort(addr string, deadline time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func TestStart_ServesStaticFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"),
+		[]byte("<html><body>hello from gohan</body></html>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := freePort(t)
+	srv := NewDevServer("127.0.0.1", port, dir, nil)
+
+	// Start runs http.ListenAndServe which blocks; run in background goroutine.
+	// The goroutine exits when the test process ends.
+	go func() { _ = srv.Start() }()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	if !waitForPort(addr, 3*time.Second) {
+		t.Fatalf("server did not start within 3s on %s", addr)
+	}
+
+	resp, err := http.Get("http://" + addr + "/")
+	if err != nil {
+		t.Fatalf("HTTP GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 OK, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) == "" {
+		// The injectingHandler may add the SSE script; just verify no error
+		t.Log("body was empty but no error")
+	}
+}
+
+func TestStart_SSEEndpoint(t *testing.T) {
+	dir := t.TempDir()
+
+	port := freePort(t)
+	srv := NewDevServer("127.0.0.1", port, dir, nil)
+	go func() { _ = srv.Start() }()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	if !waitForPort(addr, 3*time.Second) {
+		t.Fatalf("server did not start within 3s on %s", addr)
+	}
+
+	// SSE endpoint must return text/event-stream
+	req, err := http.NewRequest("GET", "http://"+addr+"/__gohan/reload", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	resp, err := client.Do(req)
+	if err != nil {
+		// Timeout is expected since SSE streams indefinitely — just verify it started
+		t.Logf("SSE request ended (expected timeout): %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	ct := resp.Header.Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("expected text/event-stream, got %q", ct)
+	}
+}
+
+func TestStart_WithMockWatcher(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "page.html"),
+		[]byte("<html><body>Page</body></html>"), 0644)
+
+	rebuilt := make(chan struct{}, 1)
+	fw := newFakeWatcher()
+
+	port := freePort(t)
+	srv := &DevServer{
+		Host:    "127.0.0.1",
+		Port:    port,
+		OutDir:  dir,
+		Watcher: fw,
+		RebuildFunc: func() error {
+			rebuilt <- struct{}{}
+			return nil
+		},
+	}
+	go func() { _ = srv.Start() }()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	if !waitForPort(addr, 3*time.Second) {
+		t.Fatalf("server did not start on %s", addr)
+	}
+
+	// Trigger a file change event
+	fw.ch <- "/content/test.md"
+
+	select {
+	case <-rebuilt:
+		// rebuild was triggered
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: RebuildFunc not called from Start")
+	}
+}

--- a/internal/server/watcher_test.go
+++ b/internal/server/watcher_test.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeWatcher is a mock FileWatcher for unit tests.
+type fakeWatcher struct {
+	ch     chan string
+	closed bool
+}
+
+func newFakeWatcher() *fakeWatcher {
+	return &fakeWatcher{ch: make(chan string, 10)}
+}
+
+func (f *fakeWatcher) Add(path string) error   { return nil }
+func (f *fakeWatcher) Events() <-chan string    { return f.ch }
+func (f *fakeWatcher) Close() error            { close(f.ch); return nil }
+
+func TestNewFsnotifyWatcher_CreatesWatcher(t *testing.T) {
+	fw, err := NewFsnotifyWatcher()
+	if err != nil {
+		t.Fatalf("NewFsnotifyWatcher: %v", err)
+	}
+	defer fw.Close()
+
+	if fw.Events() == nil {
+		t.Error("expected non-nil events channel")
+	}
+}
+
+func TestFsnotifyWatcher_AddAndClose(t *testing.T) {
+	fw, err := NewFsnotifyWatcher()
+	if err != nil {
+		t.Fatalf("NewFsnotifyWatcher: %v", err)
+	}
+	// Add a real path; errors are acceptable (e.g. missing dir).
+	_ = fw.Add(".")
+	if err := fw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestWatchLoop_BroadcastsEvent(t *testing.T) {
+	b := newSSEBroadcaster()
+	ch := b.subscribe()
+	defer b.unsubscribe(ch)
+
+	fw := newFakeWatcher()
+	srv := &DevServer{
+		Watcher:     fw,
+		RebuildFunc: func() error { return nil },
+	}
+
+	go srv.watchLoop(b)
+
+	fw.ch <- "/content/posts/hello.md"
+
+	select {
+	case msg := <-ch:
+		if msg != "/content/posts/hello.md" {
+			t.Errorf("expected path broadcasted, got: %s", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: watchLoop did not broadcast event")
+	}
+}
+
+func TestWatchLoop_CallsRebuildFunc(t *testing.T) {
+	b := newSSEBroadcaster()
+
+	rebuilt := make(chan struct{}, 1)
+	fw := newFakeWatcher()
+	srv := &DevServer{
+		Watcher: fw,
+		RebuildFunc: func() error {
+			rebuilt <- struct{}{}
+			return nil
+		},
+	}
+
+	go srv.watchLoop(b)
+
+	fw.ch <- "somefile.md"
+
+	select {
+	case <-rebuilt:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: RebuildFunc not called")
+	}
+}
+
+func TestWatchLoop_NilRebuildFunc(t *testing.T) {
+	b := newSSEBroadcaster()
+	ch := b.subscribe()
+	defer b.unsubscribe(ch)
+
+	fw := newFakeWatcher()
+	srv := &DevServer{
+		Watcher:     fw,
+		RebuildFunc: nil, // should not panic
+	}
+
+	go srv.watchLoop(b)
+
+	fw.ch <- "somefile.md"
+
+	select {
+	case <-ch:
+		// success — event was broadcasted even without rebuild func
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: watchLoop with nil RebuildFunc")
+	}
+}
+
+func TestWatchLoop_ExitsOnChannelClose(t *testing.T) {
+	b := newSSEBroadcaster()
+	fw := newFakeWatcher()
+	srv := &DevServer{Watcher: fw}
+
+	done := make(chan struct{})
+	go func() {
+		srv.watchLoop(b)
+		close(done)
+	}()
+
+	fw.Close() // closes the events channel → watchLoop should return
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: watchLoop did not exit after channel close")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #25

Implements Phase 12: test infrastructure and coverage enforcement.

## Changes

### New test files
- `cmd/gohan/main_test.go` — full build tests (non-dry-run), `printUsage`, version vars, incremental build
- `internal/highlight/extension_test.go` — Goldmark extension integration tests covering `Extension()`, `Extend()`, `RegisterFuncs()`, `renderFencedCodeBlock()`, `plainBlock()`
- `internal/server/watcher_test.go` — `NewFsnotifyWatcher`, `watchLoop` with mock watcher
- `internal/server/start_test.go` — `Start()` with live HTTP server on dynamic port, SSE endpoint, rebuild integration

### New testdata fixtures
- `cmd/gohan/testdata/` — minimal config.yaml, content, and template theme for full end-to-end build tests

## Coverage Results

| Package | Before | After |
|---|---|---|
| `cmd/gohan` | 53.8% | 70.3% |
| `internal/highlight` | 42.1% | 86.8% |
| `internal/server` | 42.9% | 86.7% |
| **Total** | **75.5%** | **85.0%** |

Total coverage: **85.0%** — exceeds the required 80% CI threshold.
