### PR TITLE
docs: make guide and README English-first, add Japanese .ja.md versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.10.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,6 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.10.1

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,118 @@
+# gohan
+
+[![CI](https://github.com/bmf-san/gohan/actions/workflows/ci.yml/badge.svg)](https://github.com/bmf-san/gohan/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/bmf-san/gohan.svg)](https://pkg.go.dev/github.com/bmf-san/gohan)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+Go で実装されたシンプルな静的サイトジェネレーター（SSG）。差分ビルド・シンタックスハイライト・Mermaid 図・ライブリロード開発サーバーを備えます。
+
+> English version: [README.md](README.md)
+
+---
+
+## 特徴
+
+- **差分ビルド** — 変更されたファイルのみを再生成し、ビルド時間を最小化
+- **Markdown + Front Matter** — GFM (GitHub Flavored Markdown) 対応
+- **シンタックスハイライト** — [chroma](https://github.com/alecthomas/chroma) によるコードブロックのスタイリング
+- **Mermaid 図** — ` + "`mermaid`" + ` フェンスコードブロックをインタラクティブな図に変換
+- **タクソノミー** — タグ・カテゴリーページを自動生成
+- **Atom フィード / サイトマップ** — `atom.xml`・`sitemap.xml` を自動生成
+- **ライブリロード開発サーバー** — `gohan serve` でファイル変更を検知してブラウザを自動リロード
+- **カスタマイズ可能なテーマ** — Go `html/template` による完全制御
+
+---
+
+## インストール
+
+```bash
+go install github.com/bmf-san/gohan/cmd/gohan@latest
+```
+
+ソースからビルドする場合:
+
+```bash
+git clone https://github.com/bmf-san/gohan.git
+cd gohan
+make install
+```
+
+ビルド済みバイナリは [GitHub Releases](https://github.com/bmf-san/gohan/releases) からダウンロードできます。
+
+---
+
+## クイックスタート
+
+```bash
+# 1. プロジェクトディレクトリを作成
+mkdir myblog && cd myblog
+
+# 2. config.yaml を作成（全オプションは docs/guide/configuration.ja.md を参照）
+cat > config.yaml << 'EOF'
+site:
+  title: My Blog
+  base_url: https://example.com
+  language: ja
+build:
+  content_dir: content
+  output_dir: public
+theme:
+  name: default
+EOF
+
+# 3. 最初の記事を作成
+gohan new post --slug=hello-world --title="Hello, World!"
+
+# 4. サイトをビルド
+gohan build
+
+# 5. 開発サーバーでプレビュー
+gohan serve   # http://127.0.0.1:1313 を開く
+```
+
+---
+
+## ユーザーガイド
+
+詳細なドキュメントは **[docs/guide/](docs/guide/README.ja.md)** を参照してください:
+
+| ガイド | 内容 |
+|---|---|
+| [Getting Started](docs/guide/getting-started.ja.md) | インストール、最初のサイト作成、ビルド、プレビュー |
+| [Configuration](docs/guide/configuration.ja.md) | `config.yaml` の全フィールドと Front Matter |
+| [Templates](docs/guide/templates.ja.md) | テーマテンプレート・変数・組み込み関数 |
+| [Taxonomy](docs/guide/taxonomy.ja.md) | タグ・カテゴリー・アーカイブページ |
+
+---
+
+## CLI リファレンス
+
+| コマンド | 説明 |
+|---|---|
+| `gohan build` | サイトをビルド（デフォルトで差分ビルド） |
+| `gohan build --full` | フルビルドを強制実行 |
+| `gohan build --dry-run` | ファイルを書き出さずにビルドをシミュレート |
+| `gohan new post --slug=<s> --title=<t>` | 新規記事スケルトンを作成 |
+| `gohan new page --slug=<s> --title=<t>` | 新規ページスケルトンを作成 |
+| `gohan serve` | ライブリロード付き開発サーバーを起動 |
+| `gohan version` | バージョン情報を表示 |
+
+---
+
+## 開発者向け
+
+```bash
+make test      # テストを実行（race detector 有効）
+make coverage  # テストを実行してカバレッジを表示
+make lint      # golangci-lint を実行
+make build     # gohan バイナリをビルド
+make clean     # ビルド成果物を削除
+```
+
+設計ドキュメントは [docs/DESIGN_DOC.ja.md](docs/DESIGN_DOC.ja.md) を参照してください。
+
+---
+
+## ライセンス
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,35 +4,32 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/bmf-san/gohan.svg)](https://pkg.go.dev/github.com/bmf-san/gohan)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**gohan** は Go で実装されたシンプルな静的サイトジェネレーター（SSG）です。
-個人ブログや小規模サイト向けに、差分ビルドによる高速な HTML 生成を提供します。
+A simple, fast static site generator written in Go — featuring incremental builds, syntax highlighting, Mermaid diagrams, and a live-reload dev server.
 
-> A simple, fast static site generator written in Go — featuring incremental builds, syntax highlighting, Mermaid diagrams, and a live-reload dev server.
-
----
-
-## 特徴 / Features
-
-- **差分ビルド** — 変更されたファイルのみを再生成し、ビルド時間を最小化
-- **Markdown + Front Matter** — GFM (GitHub Flavored Markdown) 対応
-- **シンタックスハイライト** — [chroma](https://github.com/alecthomas/chroma) ベースのコードブロックとカラーテーマ
-- **Mermaid 図** — ` ```mermaid ``` ` フェンスコードブロックをインタラクティブな図に変換
-- **タクソノミー** — タグ・カテゴリーによる記事分類とページ生成
-- **Atom フィード / サイトマップ** — `atom.xml`・`sitemap.xml` を自動生成
-- **開発サーバー** — ファイル変更を検知してブラウザをライブリロード (`gohan serve`)
-- **テーマ** — Go `html/template` による完全カスタマイズ可能なテーマ
+> 日本語版: [README.ja.md](README.ja.md)
 
 ---
 
-## インストール / Installation
+## Features
 
-### go install（推奨）
+- **Incremental builds** — Regenerate only changed files, minimising build time
+- **Markdown + Front Matter** — GitHub Flavored Markdown with YAML metadata
+- **Syntax highlighting** — Code blocks styled with [chroma](https://github.com/alecthomas/chroma)
+- **Mermaid diagrams** — Fenced ` + "`" + `mermaid` + "`" + ` blocks render as interactive diagrams
+- **Taxonomy** — Tag and category pages generated automatically
+- **Atom feed & sitemap** — `atom.xml` and `sitemap.xml` generated automatically
+- **Live-reload dev server** — `gohan serve` watches files and reloads the browser
+- **Customisable themes** — Full control via Go `html/template`
+
+---
+
+## Installation
 
 ```bash
 go install github.com/bmf-san/gohan/cmd/gohan@latest
 ```
 
-### ソースからビルド
+Or build from source:
 
 ```bash
 git clone https://github.com/bmf-san/gohan.git
@@ -40,317 +37,82 @@ cd gohan
 make install
 ```
 
-### バイナリダウンロード
-
-[GitHub Releases](https://github.com/bmf-san/gohan/releases) から各プラットフォーム向けのビルド済みバイナリをダウンロードできます。
+Pre-built binaries are available on [GitHub Releases](https://github.com/bmf-san/gohan/releases).
 
 ---
 
-## クイックスタート / Quick Start
-
-### 1. プロジェクトディレクトリの作成
+## Quick Start
 
 ```bash
+# 1. Create a project directory
 mkdir myblog && cd myblog
-```
 
-### 2. `config.yaml` の作成
-
-```yaml
+# 2. Add config.yaml (see docs/guide/configuration.md for all options)
+cat > config.yaml << 'EOF'
 site:
   title: My Blog
-  description: A simple blog
   base_url: https://example.com
-  language: ja
-
+  language: en
 build:
   content_dir: content
   output_dir: public
-  assets_dir: assets
-  parallelism: 4
-
 theme:
   name: default
+EOF
 
-syntax_highlight:
-  theme: github
-  line_numbers: false
-```
+# 3. Create your first article
+gohan new post --slug=hello-world --title="Hello, World!"
 
-### 3. 記事の作成
-
-```bash
-gohan new post --slug=hello-world --title="Hello World"
-# または手動で content/posts/hello-world.md を作成
-```
-
-Front Matter の例:
-
-```markdown
----
-title: Hello World
-date: 2024-01-01
-slug: hello-world
-tags:
-  - go
-  - blog
-categories:
-  - tech
-draft: false
----
-
-# Hello World
-
-記事の本文を Markdown で書きます。
-```
-
-### 4. テーマテンプレートの配置
-
-`themes/default/templates/` ディレクトリに以下のテンプレートファイルを作成します:
-
-```
-themes/
-└── default/
-    └── templates/
-        ├── index.html      # サイトトップページ
-        ├── article.html    # 記事ページ
-        ├── tag.html        # タグ一覧ページ
-        ├── category.html   # カテゴリー一覧ページ
-        └── archive.html    # アーカイブページ
-```
-
-テンプレートには Go の `html/template` 構文が使えます。テンプレートに渡されるデータは [`model.Site`](internal/model/model.go) 型です。
-
-```html
-<!-- themes/default/templates/index.html -->
-<!DOCTYPE html>
-<html lang="{{.Config.Site.Language}}">
-<head>
-  <meta charset="UTF-8">
-  <title>{{.Config.Site.Title}}</title>
-</head>
-<body>
-  <h1>{{.Config.Site.Title}}</h1>
-  <ul>
-    {{range .Articles}}
-    <li>
-      <a href="/posts/{{.FrontMatter.Slug}}/">
-        {{.FrontMatter.Title}}
-      </a>
-      <span>{{formatDate "2006-01-02" .FrontMatter.Date}}</span>
-    </li>
-    {{end}}
-  </ul>
-</body>
-</html>
-```
-
-### 5. ビルド
-
-```bash
+# 4. Build the site
 gohan build
+
+# 5. Preview locally with live reload
+gohan serve   # open http://127.0.0.1:1313
 ```
 
-出力先は `public/` ディレクトリです。
+---
 
-### 6. 開発サーバーの起動
+## User Guide
+
+For full documentation see **[docs/guide/](docs/guide/README.md)**:
+
+| Guide | Description |
+|---|---|
+| [Getting Started](docs/guide/getting-started.md) | Installation, first site, build & preview |
+| [Configuration](docs/guide/configuration.md) | All `config.yaml` fields and Front Matter |
+| [Templates](docs/guide/templates.md) | Theme templates, variables, built-in functions |
+| [Taxonomy](docs/guide/taxonomy.md) | Tags, categories, and archive pages |
+
+---
+
+## CLI Reference
+
+| Command | Description |
+|---|---|
+| `gohan build` | Build the site (incremental by default) |
+| `gohan build --full` | Force a full rebuild |
+| `gohan build --dry-run` | Simulate a build without writing files |
+| `gohan new post --slug=<s> --title=<t>` | Create a new post skeleton |
+| `gohan new page --slug=<s> --title=<t>` | Create a new page skeleton |
+| `gohan serve` | Start the live-reload development server |
+| `gohan version` | Print version information |
+
+---
+
+## For Developers
 
 ```bash
-gohan serve
-# http://localhost:1313 でライブプレビュー
+make test      # Run all tests with the race detector
+make coverage  # Run tests and report coverage percentage
+make lint      # Run golangci-lint
+make build     # Compile the gohan binary
+make clean     # Remove build artifacts
 ```
 
-ファイルを保存するたびにブラウザが自動でリロードされます。
+For architecture and design decisions see [docs/DESIGN_DOC.md](docs/DESIGN_DOC.md).
 
 ---
 
-## ディレクトリ構成 / Directory Structure
+## License
 
-```
-.
-├── config.yaml           # サイト設定
-├── content/
-│   ├── posts/            # ブログ記事（タグ・カテゴリー・アーカイブ対象）
-│   │   └── my-post.md
-│   └── pages/            # 静的ページ（About, Contact など）
-│       └── about.md
-├── assets/               # CSS・画像などの静的ファイル
-│   └── style.css
-├── themes/
-│   └── default/
-│       └── templates/    # Go html/template テンプレート
-│           ├── index.html
-│           ├── article.html
-│           ├── tag.html
-│           ├── category.html
-│           └── archive.html
-└── public/               # ビルド出力（.gitignore 推奨）
-```
-
----
-
-## 設定リファレンス / Configuration Reference
-
-`config.yaml` の全フィールド:
-
-```yaml
-site:
-  title: "サイトタイトル"          # required: サイト名
-  description: "サイトの説明"      # optional: メタ description
-  base_url: "https://example.com"  # required: ベース URL（末尾スラッシュなし）
-  language: "ja"                   # optional: サイト言語 (default: "en")
-
-build:
-  content_dir: "content"           # optional: コンテンツディレクトリ (default: "content")
-  output_dir: "public"             # optional: 出力ディレクトリ (default: "public")
-  assets_dir: "assets"             # optional: アセットディレクトリ (default: "assets")
-  exclude_files: []                # optional: ビルドから除外するファイルパターン
-  parallelism: 4                   # optional: 並列処理数 (default: 4)
-
-theme:
-  name: "default"                  # optional: テーマ名 (default: "default")
-  dir: "themes/default"            # optional: テーマディレクトリ (default: "themes/<name>")
-  params:                          # optional: テーマカスタムパラメーター
-    primary_color: "#0066cc"
-
-syntax_highlight:
-  theme: "github"                  # optional: chroma テーマ名 (default: "github")
-  line_numbers: false              # optional: 行番号表示 (default: false)
-```
-
-### chroma テーマ一覧
-
-よく使われるテーマ: `github`, `monokai`, `dracula`, `solarized-dark`, `nord`, `vs`
-
-全テーマは [chroma styles](https://xyproto.github.io/splash/docs/) を参照してください。
-
----
-
-## CLI コマンドリファレンス / CLI Reference
-
-### `gohan build`
-
-サイトをビルドします。
-
-```
-gohan build [flags]
-
-Flags:
-  --config string       設定ファイルのパス (default: "config.yaml")
-  --output string       出力ディレクトリの上書き
-  --full                差分ビルドをスキップして全記事を再生成
-  --parallel int        並列処理数の上書き (0 = config 値を使用)
-  --dry-run             ファイルを書き出さずにビルドをシミュレート
-  --log-format string   ログフォーマット: text または json (default: "text")
-```
-
-### `gohan new`
-
-新しい記事・ページのスケルトンを作成します。
-
-```
-gohan new <type> [flags]
-
-Types:
-  post   content/posts/<slug>.md を作成
-  page   content/pages/<slug>.md を作成
-
-Flags:
-  --slug string    記事のスラッグ (required)
-  --title string   記事のタイトル（省略時は slug から自動生成）
-```
-
-例:
-
-```bash
-gohan new post --slug=my-first-post --title="はじめての投稿"
-gohan new page --slug=about --title="このサイトについて"
-```
-
-### `gohan serve`
-
-差分ビルド + ライブリロード付き開発サーバーを起動します。
-
-```
-gohan serve [flags]
-
-Flags:
-  --config string   設定ファイルのパス (default: "config.yaml")
-  --port int        listen ポート (default: 1313)
-  --host string     bind アドレス (default: "127.0.0.1")
-```
-
-### `gohan version`
-
-バージョン情報を表示します。
-
-```bash
-$ gohan version
-gohan v1.0.0 (commit: abc1234, built: 2024-01-01T00:00:00Z)
-```
-
----
-
-## テンプレート変数 / Template Variables
-
-テンプレートには `model.Site` 型の値が渡されます。
-
-| 変数 | 型 | 説明 |
-|---|---|---|
-| `.Config.Site.Title` | `string` | サイトタイトル |
-| `.Config.Site.Description` | `string` | サイト説明 |
-| `.Config.Site.BaseURL` | `string` | ベース URL |
-| `.Config.Site.Language` | `string` | サイト言語 |
-| `.Config.Theme.Params` | `map[string]string` | テーマカスタムパラメーター |
-| `.Articles` | `[]*ProcessedArticle` | 記事一覧（ページにより絞り込み済み） |
-| `.Tags` | `[]Taxonomy` | タグ一覧 |
-| `.Categories` | `[]Taxonomy` | カテゴリー一覧 |
-
-### 記事フィールド (`.Articles` の各要素)
-
-| フィールド | 型 | 説明 |
-|---|---|---|
-| `.FrontMatter.Title` | `string` | 記事タイトル |
-| `.FrontMatter.Date` | `time.Time` | 公開日 |
-| `.FrontMatter.Slug` | `string` | URL スラッグ |
-| `.FrontMatter.Tags` | `[]string` | タグ一覧 |
-| `.FrontMatter.Categories` | `[]string` | カテゴリー一覧 |
-| `.FrontMatter.Description` | `string` | 記事の説明 |
-| `.FrontMatter.Draft` | `bool` | 下書きフラグ |
-| `.HTMLContent` | `template.HTML` | レンダリング済み HTML |
-| `.Summary` | `string` | 記事の要約（先頭 200 文字） |
-
-### 組み込みテンプレート関数
-
-| 関数 | シグネチャ | 説明 |
-|---|---|---|
-| `formatDate` | `formatDate layout time` | 日付フォーマット（例: `formatDate "2006-01-02" .FrontMatter.Date`） |
-| `tagURL` | `tagURL name` | タグページの URL を生成 |
-| `categoryURL` | `categoryURL name` | カテゴリーページの URL を生成 |
-| `markdownify` | `markdownify str` | Markdown 文字列を HTML に変換 |
-
----
-
-## 開発者向け / For Developers
-
-```bash
-# テスト実行
-make test
-
-# カバレッジ確認
-make coverage
-
-# リント
-make lint
-
-# クリーン
-make clean
-```
-
-詳細な設計ドキュメントは [docs/DESIGN_DOC.md](docs/DESIGN_DOC.md) を参照してください。
-
----
-
-## ライセンス / License
-
-[MIT License](LICENSE) — Copyright (c) bmf-san
+[MIT](LICENSE)

--- a/cmd/gohan/main_test.go
+++ b/cmd/gohan/main_test.go
@@ -19,11 +19,11 @@ func TestPrintUsage_WritesToStderr(t *testing.T) {
 
 	printUsage()
 
-	w.Close()
+	_ = w.Close()
 	os.Stderr = orig
 
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	out := buf.String()
 
 	for _, want := range []string{"build", "new", "serve", "version"} {

--- a/cmd/gohan/new_test.go
+++ b/cmd/gohan/new_test.go
@@ -24,8 +24,10 @@ func TestRunNew_UnknownType(t *testing.T) {
 func TestRunNew_CreatePost(t *testing.T) {
 	tmpDir := t.TempDir()
 	old, _ := os.Getwd()
-	defer os.Chdir(old)
-	os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(old) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
 
 	err := runNew([]string{"my-first-post"})
 	if err != nil {
@@ -55,8 +57,10 @@ func TestRunNew_CreatePost(t *testing.T) {
 func TestRunNew_CreatePage(t *testing.T) {
 	tmpDir := t.TempDir()
 	old, _ := os.Getwd()
-	defer os.Chdir(old)
-	os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(old) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
 
 	err := runNew([]string{"--type=page", "--title=About Me", "about"})
 	if err != nil {

--- a/cmd/gohan/new_test.go
+++ b/cmd/gohan/new_test.go
@@ -80,8 +80,10 @@ func TestRunNew_CreatePage(t *testing.T) {
 func TestRunNew_ExistingFileError(t *testing.T) {
 	tmpDir := t.TempDir()
 	old, _ := os.Getwd()
-	defer os.Chdir(old)
-	os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(old) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create first time
 	if err := runNew([]string{"duplicate-slug"}); err != nil {

--- a/docs/guide/README.ja.md
+++ b/docs/guide/README.ja.md
@@ -1,0 +1,59 @@
+# gohan ユーザーガイド
+
+gohan の使い方・設定・カスタマイズについての公式ドキュメントです。
+
+> English version: [README.md](README.md)
+
+---
+
+## ガイド一覧
+
+| ドキュメント | 内容 |
+|---|---|
+| [Getting Started](getting-started.ja.md) | インストール、最初のサイト作成、ビルド、開発サーバー |
+| [Configuration](configuration.ja.md) | `config.yaml` の全フィールドリファレンス、Front Matter |
+| [Templates](templates.ja.md) | テーマテンプレートの作成・変数・組み込み関数 |
+| [Taxonomy](taxonomy.ja.md) | タグ・カテゴリー・アーカイブの管理と活用 |
+
+---
+
+## クイックリファレンス
+
+### よく使うコマンド
+
+```bash
+# 新しい記事を作成
+gohan new post --slug=my-post --title="記事タイトル"
+
+# サイトをビルド
+gohan build
+
+# 差分ビルドをスキップして全記事を再生成
+gohan build --full
+
+# ファイルを一切書き出さずにビルドをシミュレート
+gohan build --dry-run
+
+# 開発サーバーを起動 (http://127.0.0.1:1313)
+gohan serve
+
+# バージョン確認
+gohan version
+```
+
+### Makefile ターゲット
+
+```bash
+make build     # バイナリをビルド
+make test      # テストを実行
+make coverage  # カバレッジを計測・表示
+make lint      # golangci-lint を実行
+make clean     # ビルド成果物を削除
+make help      # 利用可能なターゲットを表示
+```
+
+---
+
+## 設計ドキュメント
+
+gohan の内部設計・アーキテクチャについては [DESIGN_DOC.ja.md](../DESIGN_DOC.ja.md) を参照してください。

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,57 +1,59 @@
-# gohan ユーザーガイド / User Guide
+# gohan User Guide
 
-gohan のすべての使い方・設定・カスタマイズについての公式ドキュメントです。
+Official documentation for using, configuring, and customizing gohan.
+
+> 日本語版: [README.ja.md](README.ja.md)
 
 ---
 
-## ガイド一覧
+## Guides
 
-| ドキュメント | 内容 |
+| Document | Description |
 |---|---|
-| [Getting Started](getting-started.md) | インストール、最初のサイト作成、ビルド、開発サーバー |
-| [Configuration](configuration.md) | `config.yaml` の全フィールドリファレンス、Front Matter |
-| [Templates](templates.md) | テーマテンプレートの作成・変数・組み込み関数 |
-| [Taxonomy](taxonomy.md) | タグ・カテゴリー・アーカイブの管理と活用 |
+| [Getting Started](getting-started.md) | Install gohan, create your first site, build & preview |
+| [Configuration](configuration.md) | Full `config.yaml` field reference and Front Matter |
+| [Templates](templates.md) | Create themes, template variables, and built-in functions |
+| [Taxonomy](taxonomy.md) | Manage tags, categories, and archive pages |
 
 ---
 
-## クイックリファレンス
+## Quick Reference
 
-### よく使うコマンド
+### Common commands
 
 ```bash
-# 新しい記事を作成
-gohan new post --slug=my-post --title="記事タイトル"
+# Create a new post
+gohan new post --slug=my-post --title="My Post Title"
 
-# サイトをビルド
+# Build the site
 gohan build
 
-# 差分ビルドをスキップして全記事を再生成
+# Force a full rebuild (skip diff detection)
 gohan build --full
 
-# ファイルを一切書き出さずにビルドをシミュレート
+# Simulate a build without writing any files
 gohan build --dry-run
 
-# 開発サーバーを起動 (http://127.0.0.1:1313)
+# Start the development server (http://127.0.0.1:1313)
 gohan serve
 
-# バージョン確認
+# Print version information
 gohan version
 ```
 
-### Makefile ターゲット
+### Makefile targets
 
 ```bash
-make build     # バイナリをビルド
-make test      # テストを実行
-make coverage  # カバレッジを計測・表示
-make lint      # golangci-lint を実行
-make clean     # ビルド成果物を削除
-make help      # 利用可能なターゲットを表示
+make build     # Compile the gohan binary
+make test      # Run all tests with the race detector
+make coverage  # Run tests and report coverage
+make lint      # Run golangci-lint
+make clean     # Remove build artifacts
+make help      # List available targets
 ```
 
 ---
 
-## 設計ドキュメント
+## Design Document
 
-gohan の内部設計・アーキテクチャについては [DESIGN_DOC.md](../DESIGN_DOC.md) を参照してください。
+For gohan's internal architecture and design decisions, see [DESIGN_DOC.md](../DESIGN_DOC.md).

--- a/docs/guide/configuration.ja.md
+++ b/docs/guide/configuration.ja.md
@@ -1,0 +1,174 @@
+# 設定リファレンス
+
+`config.yaml` はプロジェクトルートに置く唯一の設定ファイルです。
+
+> English version: [configuration.md](configuration.md)
+
+---
+
+## 完全な設定例
+
+```yaml
+site:
+  title: "My Blog"
+  description: "技術系個人ブログ"
+  base_url: "https://myblog.example.com"
+  language: "ja"
+
+build:
+  content_dir: "content"
+  output_dir: "public"
+  assets_dir: "assets"
+  exclude_files:
+    - "*.draft.md"
+    - "_*"
+  parallelism: 4
+
+theme:
+  name: "default"
+  dir: "themes/default"
+  params:
+    primary_color: "#0066cc"
+    footer_text: "© 2024 My Blog"
+
+syntax_highlight:
+  theme: "github"
+  line_numbers: false
+```
+
+---
+
+## `site` セクション
+
+サイト全体のメタデータを設定します。
+
+| フィールド | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `title` | string | *(required)* | サイトタイトル。テンプレートで `.Config.Site.Title` として参照 |
+| `description` | string | `""` | サイトの説明。メタタグや Atom フィードに使用 |
+| `base_url` | string | *(required)* | サイトのベース URL。末尾スラッシュなし（例: `https://example.com`） |
+| `language` | string | `"en"` | BCP 47 言語コード。`<html lang="">` に使用 |
+
+> `base_url` は `sitemap.xml` と `atom.xml` の URL 生成に使われます。末尾にスラッシュを付けないでください。
+
+---
+
+## `build` セクション
+
+ファイルパスとビルド動作を設定します。
+
+| フィールド | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `content_dir` | string | `"content"` | Markdown コンテンツのディレクトリ（プロジェクトルートからの相対パス） |
+| `output_dir` | string | `"public"` | HTML 出力先ディレクトリ |
+| `assets_dir` | string | `"assets"` | 静的ファイル（CSS、画像など）のディレクトリ |
+| `exclude_files` | []string | `[]` | ビルドから除外するファイルのグロブパターン |
+| `parallelism` | int | `4` | HTML 生成の並列数 |
+
+### `exclude_files` の例
+
+```yaml
+build:
+  exclude_files:
+    - "*.draft.md"      # .draft.md で終わるファイルを除外
+    - "_*"              # _ で始まるファイルを除外
+    - "templates/*"     # templates/ 配下を除外
+```
+
+---
+
+## `theme` セクション
+
+使用するテーマとカスタムパラメーターを設定します。
+
+| フィールド | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `name` | string | `"default"` | テーマ名。`dir` が未設定の場合 `themes/<name>` が使われる |
+| `dir` | string | `"themes/<name>"` | テーマディレクトリのパス（プロジェクトルートからの相対パス） |
+| `params` | map[string]string | `{}` | テンプレートから `.Config.Theme.Params.<key>` でアクセスできる任意のパラメーター |
+
+### テンプレートからのアクセス
+
+```html
+<style>
+  :root { --primary: {{.Config.Theme.Params.primary_color}}; }
+</style>
+<footer>{{.Config.Theme.Params.footer_text}}</footer>
+```
+
+### テーマディレクトリ構成
+
+```
+themes/
+└── <name>/
+    └── templates/      ← テンプレートファイルを置くディレクトリ
+        ├── index.html
+        ├── article.html
+        ├── tag.html
+        ├── category.html
+        └── archive.html
+```
+
+---
+
+## `syntax_highlight` セクション
+
+コードブロックのシンタックスハイライトを設定します（[chroma](https://github.com/alecthomas/chroma) 使用）。
+
+| フィールド | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `theme` | string | `"github"` | chroma のカラーテーマ名 |
+| `line_numbers` | bool | `false` | 行番号を表示するか |
+
+### 利用可能なテーマ
+
+| テーマ名 | 特徴 |
+|---|---|
+| `github` | GitHub の明るいテーマ（デフォルト） |
+| `monokai` | 暗い背景に鮮やかな色 |
+| `dracula` | ダークテーマ |
+| `solarized-dark` | Solarized ダーク |
+| `solarized-light` | Solarized ライト |
+| `nord` | 北欧風ダークテーマ |
+| `vs` | Visual Studio 風 |
+| `pygments` | Python pygments スタイル |
+
+全テーマのプレビュー: https://xyproto.github.io/splash/docs/
+
+### ハイライトを無効にする
+
+```yaml
+syntax_highlight:
+  theme: ""   # 空文字列でハイライト無効
+```
+
+---
+
+## Front Matter リファレンス
+
+各 Markdown ファイルの先頭に YAML Front Matter を記述します。
+
+```yaml
+---
+title: "記事タイトル"              # required: 記事タイトル
+date: 2024-01-15                  # required: 公開日 (YYYY-MM-DD)
+slug: "my-post"                   # optional: URL スラッグ（省略時はタイトルから生成）
+draft: false                      # optional: true の場合ビルドから除外 (default: false)
+tags:                             # optional: タグ一覧
+  - go
+  - blog
+categories:                       # optional: カテゴリー一覧
+  - tech
+description: "記事の説明"          # optional: メタ description・フィードの概要
+author: "Your Name"               # optional: 著者名
+template: "article.html"          # optional: 使用するテンプレートファイル名
+---
+```
+
+### `slug` の自動生成
+
+`slug` を省略した場合、`title` から自動生成されます:
+
+- スペース → ハイフン
+- 大文字 → 小文字
+- 例: `"Hello World"` → `hello-world`

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,17 +1,19 @@
-# Configuration Reference — 設定リファレンス
+# Configuration Reference
 
-`config.yaml` はプロジェクトルートに置く唯一の設定ファイルです。
+`config.yaml` is the single configuration file placed at the project root.
+
+> 日本語版: [configuration.ja.md](configuration.ja.md)
 
 ---
 
-## 完全な設定例
+## Complete example
 
 ```yaml
 site:
   title: "My Blog"
-  description: "技術系個人ブログ"
+  description: "A personal tech blog"
   base_url: "https://myblog.example.com"
-  language: "ja"
+  language: "en"
 
 build:
   content_dir: "content"
@@ -36,75 +38,70 @@ syntax_highlight:
 
 ---
 
-## `site` セクション
+## `site` section
 
-サイト全体のメタデータを設定します。
+Site-wide metadata.
 
-| フィールド | 型 | デフォルト | 説明 |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `title` | string | *(required)* | サイトタイトル。テンプレートで `.Config.Site.Title` として参照 |
-| `description` | string | `""` | サイトの説明。メタタグや feed に使用 |
-| `base_url` | string | *(required)* | サイトのベース URL。末尾スラッシュなし（例: `https://example.com`） |
-| `language` | string | `"en"` | サイトの言語コード（例: `"ja"`, `"en"`）。`<html lang="">` に使用 |
+| `title` | string | *(required)* | Site title. Available in templates as `.Config.Site.Title` |
+| `description` | string | `""` | Site description. Used in meta tags and the Atom feed |
+| `base_url` | string | *(required)* | Base URL without a trailing slash (e.g. `https://example.com`) |
+| `language` | string | `"en"` | BCP 47 language code used in `<html lang="">` |
 
-### メモ
-
-- `base_url` は `sitemap.xml` と `atom.xml` の URL 生成に使われます
-- `base_url` の末尾にスラッシュを付けないでください
+> `base_url` is used to generate absolute URLs in `sitemap.xml` and `atom.xml`. Do not include a trailing slash.
 
 ---
 
-## `build` セクション
+## `build` section
 
-ファイルパスとビルド動作を設定します。
+File paths and build behaviour.
 
-| フィールド | 型 | デフォルト | 説明 |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `content_dir` | string | `"content"` | Markdown コンテンツのディレクトリ（プロジェクトルートからの相対パス） |
-| `output_dir` | string | `"public"` | HTML 出力先ディレクトリ |
-| `assets_dir` | string | `"assets"` | 静的ファイル（CSS、画像など）のディレクトリ |
-| `exclude_files` | []string | `[]` | ビルドから除外するファイルのグロブパターン |
-| `parallelism` | int | `4` | HTML 生成の並列数。CPU コア数より大きくても意味はありません |
+| `content_dir` | string | `"content"` | Markdown content directory (relative to project root) |
+| `output_dir` | string | `"public"` | HTML output directory |
+| `assets_dir` | string | `"assets"` | Static files directory (CSS, images, etc.) |
+| `exclude_files` | []string | `[]` | Glob patterns for files to exclude from the build |
+| `parallelism` | int | `4` | Number of parallel HTML generation workers |
 
-### `exclude_files` の例
+### `exclude_files` examples
 
 ```yaml
 build:
   exclude_files:
-    - "*.draft.md"      # .draft.md で終わるファイルを除外
-    - "_*"              # _ で始まるファイルを除外
-    - "templates/*"     # templates/ 配下を除外
+    - "*.draft.md"   # Exclude files ending in .draft.md
+    - "_*"           # Exclude files starting with _
+    - "templates/*"  # Exclude everything under templates/
 ```
 
 ---
 
-## `theme` セクション
+## `theme` section
 
-使用するテーマとカスタムパラメーターを設定します。
+Active theme and custom parameters.
 
-| フィールド | 型 | デフォルト | 説明 |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `name` | string | `"default"` | テーマ名。`dir` が未設定の場合 `themes/<name>` が使われる |
-| `dir` | string | `"themes/<name>"` | テーマディレクトリのパス（プロジェクトルートからの相対パス） |
-| `params` | map[string]string | `{}` | テンプレートから `.Config.Theme.Params.<key>` でアクセスできる任意のパラメーター |
+| `name` | string | `"default"` | Theme name. Used to resolve `dir` when `dir` is not set |
+| `dir` | string | `"themes/<name>"` | Theme directory path (relative to project root) |
+| `params` | map[string]string | `{}` | Arbitrary parameters accessible in templates as `.Config.Theme.Params.<key>` |
 
-### テンプレートからのアクセス
+### Accessing params in templates
 
 ```html
 <style>
-  :root {
-    --primary: {{.Config.Theme.Params.primary_color}};
-  }
+  :root { --primary: {{.Config.Theme.Params.primary_color}}; }
 </style>
 <footer>{{.Config.Theme.Params.footer_text}}</footer>
 ```
 
-### テーマディレクトリ構成
+### Theme directory layout
 
 ```
 themes/
 └── <name>/
-    └── templates/      ← テンプレートファイルを置くディレクトリ
+    └── templates/      ← Place template files here
         ├── index.html
         ├── article.html
         ├── tag.html
@@ -114,64 +111,64 @@ themes/
 
 ---
 
-## `syntax_highlight` セクション
+## `syntax_highlight` section
 
-コードブロックのシンタックスハイライトを設定します（[chroma](https://github.com/alecthomas/chroma) 使用）。
+Code-block syntax highlighting powered by [chroma](https://github.com/alecthomas/chroma).
 
-| フィールド | 型 | デフォルト | 説明 |
+| Field | Type | Default | Description |
 |---|---|---|---|
-| `theme` | string | `"github"` | chroma のカラーテーマ名 |
-| `line_numbers` | bool | `false` | 行番号を表示するか |
+| `theme` | string | `"github"` | chroma colour theme name |
+| `line_numbers` | bool | `false` | Show line numbers in code blocks |
 
-### 利用可能なテーマ
+### Available themes
 
-| テーマ名 | 特徴 |
+| Theme | Style |
 |---|---|
-| `github` | GitHub の明るいテーマ（デフォルト） |
-| `monokai` | 暗い背景に鮮やかな色 |
-| `dracula` | ダークテーマ |
-| `solarized-dark` | solarized ダークテーマ |
-| `solarized-light` | solarized ライトテーマ |
-| `nord` | 北欧風ダークテーマ |
-| `vs` | Visual Studio 風 |
-| `pygments` | Python pygments スタイル |
+| `github` | Light theme (default) |
+| `monokai` | Dark background, vivid colours |
+| `dracula` | Dark theme |
+| `solarized-dark` | Solarized dark |
+| `solarized-light` | Solarized light |
+| `nord` | Nordic dark theme |
+| `vs` | Visual Studio style |
+| `pygments` | Python pygments style |
 
-全テーマのプレビュー: https://xyproto.github.io/splash/docs/
+Browse all themes: https://xyproto.github.io/splash/docs/
 
-### ハイライトを無効にする
+### Disable highlighting
 
 ```yaml
 syntax_highlight:
-  theme: ""   # 空文字列でハイライト無効
+  theme: ""  # Empty string disables highlighting
 ```
 
 ---
 
-## Front Matter リファレンス
+## Front Matter reference
 
-各 Markdown ファイルの先頭に YAML Front Matter を記述します。
+Every Markdown file begins with a YAML Front Matter block.
 
 ```yaml
 ---
-title: "記事タイトル"              # required: 記事タイトル
-date: 2024-01-15                  # required: 公開日 (YYYY-MM-DD)
-slug: "my-post"                   # optional: URL スラッグ（省略時はタイトルから生成）
-draft: false                      # optional: true の場合ビルドから除外 (default: false)
-tags:                             # optional: タグ一覧
+title: "Article title"       # required: Article title
+date: 2024-01-15             # required: Publication date (YYYY-MM-DD)
+slug: "my-post"              # optional: URL slug (auto-generated from title if omitted)
+draft: false                 # optional: Exclude from build when true (default: false)
+tags:                        # optional: Tag list
   - go
   - blog
-categories:                       # optional: カテゴリー一覧
+categories:                  # optional: Category list
   - tech
-description: "記事の説明"          # optional: メタ description、feed の概要
-author: "Your Name"               # optional: 著者名
-template: "article.html"          # optional: 使用するテンプレートファイル名
+description: "Summary"       # optional: Meta description and feed summary
+author: "Your Name"          # optional: Author name
+template: "article.html"     # optional: Override the template file
 ---
 ```
 
-### `slug` の自動生成
+### Automatic slug generation
 
-`slug` を省略した場合、`title` から自動生成されます:
+When `slug` is omitted it is derived from `title`:
 
-- スペース → ハイフン
-- 大文字 → 小文字
-- 例: `"Hello World"` → `hello-world`
+- Spaces → hyphens
+- Uppercase → lowercase
+- Example: `"Hello World"` → `hello-world`

--- a/docs/guide/getting-started.ja.md
+++ b/docs/guide/getting-started.ja.md
@@ -1,0 +1,220 @@
+# Getting Started — gohan 入門ガイド
+
+> gohan のインストールから最初のサイト作成・ローカルプレビューまでを説明します。
+
+> English version: [getting-started.md](getting-started.md)
+
+---
+
+## 前提条件
+
+- Go 1.21 以上
+- Git（差分ビルド機能を使う場合）
+
+---
+
+## インストール
+
+```bash
+go install github.com/bmf-san/gohan/cmd/gohan@latest
+```
+
+インストールを確認します:
+
+```bash
+gohan version
+# gohan v1.0.0 (commit: abc1234, built: 2024-01-01T00:00:00Z)
+```
+
+### ソースからビルド
+
+```bash
+git clone https://github.com/bmf-san/gohan.git
+cd gohan
+make install
+```
+
+### バイナリダウンロード
+
+[GitHub Releases](https://github.com/bmf-san/gohan/releases) から各プラットフォーム向けのビルド済みバイナリをダウンロードできます。
+
+---
+
+## 最初のサイトを作る
+
+### ステップ 1: プロジェクトを作成する
+
+```bash
+mkdir myblog
+cd myblog
+```
+
+### ステップ 2: `config.yaml` を作成する
+
+```yaml
+site:
+  title: My Blog
+  description: A simple personal blog
+  base_url: https://myblog.example.com
+  language: ja
+
+build:
+  content_dir: content
+  output_dir: public
+  assets_dir: assets
+  parallelism: 4
+
+theme:
+  name: default
+
+syntax_highlight:
+  theme: github
+  line_numbers: false
+```
+
+全フィールドの詳細は [Configuration](configuration.ja.md) を参照してください。
+
+### ステップ 3: 最初の記事を作成する
+
+```bash
+gohan new post --slug=hello-world --title="Hello, World!"
+```
+
+`content/posts/hello-world.md` が作成されます。編集して本文を追加しましょう:
+
+```markdown
+---
+title: Hello, World!
+date: 2024-01-15
+slug: hello-world
+tags:
+  - go
+  - blog
+categories:
+  - tech
+draft: false
+description: はじめての gohan ブログ記事
+---
+
+# Hello, World!
+
+**gohan** でブログを始めました！
+```
+
+### ステップ 4: テーマテンプレートを作成する
+
+```bash
+mkdir -p themes/default/templates
+```
+
+`themes/default/templates/index.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="{{.Config.Site.Language}}">
+<head>
+  <meta charset="UTF-8">
+  <title>{{.Config.Site.Title}}</title>
+  <link rel="stylesheet" href="/assets/style.css">
+  <link rel="alternate" type="application/atom+xml" href="/atom.xml">
+</head>
+<body>
+  <header>
+    <h1><a href="/">{{.Config.Site.Title}}</a></h1>
+  </header>
+  <main>
+    <ul>
+      {{range .Articles}}
+      <li>
+        <span>{{formatDate "2006-01-02" .FrontMatter.Date}}</span>
+        <a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>
+      </li>
+      {{end}}
+    </ul>
+  </main>
+</body>
+</html>
+```
+
+テンプレートの詳細は [テンプレートガイド](templates.ja.md) を参照してください。
+
+### ステップ 5: アセットを追加する（任意）
+
+```bash
+mkdir -p assets
+cat > assets/style.css << 'EOF'
+body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 1rem; }
+a { color: #0066cc; }
+EOF
+```
+
+### ステップ 6: サイトをビルドする
+
+```bash
+gohan build
+```
+
+`public/` ディレクトリにサイトが生成されます:
+
+```
+public/
+├── index.html
+├── sitemap.xml
+├── atom.xml
+├── posts/
+│   └── hello-world/
+│       └── index.html
+└── assets/
+    └── style.css
+```
+
+### ステップ 7: 開発サーバーで確認する
+
+```bash
+gohan serve
+# http://127.0.0.1:1313 でプレビュー
+```
+
+ファイルを保存するたびにブラウザが自動でリロードされます。
+
+---
+
+## よくある操作
+
+### 記事の下書き
+
+`draft: true` を設定した記事はビルドに含まれません:
+
+```yaml
+---
+title: 作成中の記事
+draft: true
+---
+```
+
+### 差分ビルド
+
+2 回目以降のビルドは自動的に差分ビルドになります:
+
+```bash
+gohan build          # 初回: フルビルド
+# content/ を編集
+gohan build          # 2 回目: 変更分のみ再生成
+gohan build --full   # 強制的なフルビルド
+```
+
+### 推奨 `.gitignore`
+
+```gitignore
+public/
+.gohan/
+gohan
+```
+
+---
+
+## 次のステップ
+
+- [設定リファレンス](configuration.ja.md) — すべての config.yaml オプション
+- [テンプレートガイド](templates.ja.md) — テーマのカスタマイズ
+- [タクソノミーガイド](taxonomy.ja.md) — タグ・カテゴリーの管理

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,50 +1,62 @@
-# Getting Started — gohan 入門ガイド
+# Getting Started
 
-> This guide walks you through installing gohan, creating your first site, and publishing it as static HTML.
+> This guide walks you through installing gohan, creating your first site, and previewing it locally.
 
----
-
-## 前提条件 / Prerequisites
-
-- Go 1.21 以上
-- Git（差分ビルド機能を使う場合）
+> 日本語版: [getting-started.ja.md](getting-started.ja.md)
 
 ---
 
-## インストール / Installation
+## Prerequisites
+
+- Go 1.21 or later
+- Git (required for incremental builds)
+
+---
+
+## Installation
 
 ```bash
 go install github.com/bmf-san/gohan/cmd/gohan@latest
 ```
 
-インストールを確認します:
+Verify the installation:
 
 ```bash
 gohan version
 # gohan v1.0.0 (commit: abc1234, built: 2024-01-01T00:00:00Z)
 ```
 
+### Build from source
+
+```bash
+git clone https://github.com/bmf-san/gohan.git
+cd gohan
+make install
+```
+
+### Download a binary
+
+Download a pre-built binary for your platform from [GitHub Releases](https://github.com/bmf-san/gohan/releases).
+
 ---
 
-## 最初のサイトを作る / Create Your First Site
+## Create Your First Site
 
-### ステップ 1: プロジェクトを作成する
+### Step 1: Create a project directory
 
 ```bash
 mkdir myblog
 cd myblog
 ```
 
-### ステップ 2: `config.yaml` を作成する
-
-サイト設定ファイルをプロジェクトルートに作成します。
+### Step 2: Create `config.yaml`
 
 ```yaml
 site:
   title: My Blog
   description: A simple personal blog
   base_url: https://myblog.example.com
-  language: ja
+  language: en
 
 build:
   content_dir: content
@@ -60,13 +72,15 @@ syntax_highlight:
   line_numbers: false
 ```
 
-### ステップ 3: 最初の記事を作成する
+See [Configuration](configuration.md) for all available fields.
+
+### Step 3: Create your first article
 
 ```bash
 gohan new post --slug=hello-world --title="Hello, World!"
 ```
 
-`content/posts/hello-world.md` が作成されます。編集して本文を追加しましょう:
+This creates `content/posts/hello-world.md`. Edit it to add body content:
 
 ```markdown
 ---
@@ -79,18 +93,18 @@ tags:
 categories:
   - tech
 draft: false
-description: はじめての gohan ブログ記事
+description: My first gohan post
 ---
 
 # Hello, World!
 
-**gohan** でブログを始めました！
+Welcome to my blog powered by **gohan**!
 
-## gohan の特徴
+## Features
 
-- 差分ビルドによる高速ビルド
-- Go html/template によるテーマカスタマイズ
-- Mermaid 図やシンタックスハイライトのサポート
+- Incremental builds for fast generation
+- Customizable themes with Go html/template
+- Mermaid diagrams and syntax highlighting
 
 ```go
 package main
@@ -103,9 +117,7 @@ func main() {
 ```
 ```
 
-### ステップ 4: テーマテンプレートを作成する
-
-`themes/default/templates/` ディレクトリを作成し、最小限のテンプレートを用意します:
+### Step 4: Create theme templates
 
 ```bash
 mkdir -p themes/default/templates
@@ -129,10 +141,10 @@ mkdir -p themes/default/templates
     <h1><a href="/">{{.Config.Site.Title}}</a></h1>
   </header>
   <main>
-    <ul class="post-list">
+    <ul>
       {{range .Articles}}
       <li>
-        <span class="date">{{formatDate "2006-01-02" .FrontMatter.Date}}</span>
+        <span>{{formatDate "2006-01-02" .FrontMatter.Date}}</span>
         <a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>
       </li>
       {{end}}
@@ -151,12 +163,9 @@ mkdir -p themes/default/templates
   <meta charset="UTF-8">
   <title>{{(index .Articles 0).FrontMatter.Title}} — {{.Config.Site.Title}}</title>
   <link rel="stylesheet" href="/assets/style.css">
-  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 </head>
 <body>
-  <header>
-    <a href="/">← {{.Config.Site.Title}}</a>
-  </header>
+  <header><a href="/">← {{.Config.Site.Title}}</a></header>
   <main>
     {{with (index .Articles 0)}}
     <article>
@@ -177,25 +186,25 @@ mkdir -p themes/default/templates
 </html>
 ```
 
-### ステップ 5: アセットを追加する（任意）
+See [Templates](templates.md) for the complete template reference.
+
+### Step 5: Add static assets (optional)
 
 ```bash
 mkdir -p assets
 cat > assets/style.css << 'EOF'
 body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 1rem; }
 a { color: #0066cc; }
-.date { color: #888; margin-right: 1em; }
-.tags { list-style: none; display: flex; gap: 0.5em; padding: 0; }
 EOF
 ```
 
-### ステップ 6: サイトをビルドする
+### Step 6: Build the site
 
 ```bash
 gohan build
 ```
 
-`public/` ディレクトリにサイトが生成されます:
+The site is generated in `public/`:
 
 ```
 public/
@@ -209,40 +218,42 @@ public/
     └── style.css
 ```
 
-### ステップ 7: 開発サーバーで確認する
+### Step 7: Preview with the development server
 
 ```bash
 gohan serve
-# http://127.0.0.1:1313 でプレビュー
+# Open http://127.0.0.1:1313
 ```
+
+The browser reloads automatically whenever you save a file.
 
 ---
 
-## よくある操作 / Common Operations
+## Common Operations
 
-### 記事の下書き
+### Draft articles
 
-`draft: true` を設定した記事はビルドに含まれません:
+Articles with `draft: true` are excluded from builds:
 
 ```yaml
 ---
-title: 作成中の記事
+title: Work in progress
 draft: true
 ---
 ```
 
-### 差分ビルド
+### Incremental builds
 
-2 回目以降のビルドは自動的に差分ビルドになります（変更されたファイルのみ再生成）:
+After the first build, subsequent builds are automatically incremental (only changed files are regenerated):
 
 ```bash
-gohan build          # 初回: フルビルド
-# content/ を編集
-gohan build          # 2 回目: 変更分のみ再生成
-gohan build --full   # 強制的なフルビルド
+gohan build        # First run: full build
+# edit content/
+gohan build        # Second run: only changed files
+gohan build --full # Force a full rebuild
 ```
 
-### .gitignore の設定
+### Recommended `.gitignore`
 
 ```gitignore
 public/
@@ -252,8 +263,8 @@ gohan
 
 ---
 
-## 次のステップ
+## Next Steps
 
-- [設定リファレンス](configuration.md) — すべての config.yaml オプション
-- [テンプレートガイド](templates.md) — テーマのカスタマイズ
-- [タクソノミーガイド](taxonomy.md) — タグ・カテゴリーの管理
+- [Configuration](configuration.md) — all `config.yaml` options
+- [Templates](templates.md) — customize your theme
+- [Taxonomy](taxonomy.md) — manage tags and categories

--- a/docs/guide/taxonomy.ja.md
+++ b/docs/guide/taxonomy.ja.md
@@ -1,0 +1,168 @@
+# タクソノミーガイド
+
+タクソノミーとは、記事を **タグ** や **カテゴリー** で分類する仕組みです。
+gohan は各タグ・カテゴリーに対応したページを自動生成します。
+
+> English version: [taxonomy.md](taxonomy.md)
+
+---
+
+## 記事への設定
+
+Front Matter でタグとカテゴリーを指定します:
+
+```markdown
+---
+title: Go の並行処理を理解する
+date: 2024-03-01
+slug: go-concurrency
+tags:
+  - go
+  - concurrency
+  - goroutine
+categories:
+  - tech
+  - programming
+---
+```
+
+- `tags`: 記事のキーワード。複数指定可。1 タグ 1 ページが生成されます
+- `categories`: 記事の分類。複数指定可。1 カテゴリー 1 ページが生成されます
+
+---
+
+## 生成されるページ
+
+上記の記事がある場合、以下のページが生成されます:
+
+```
+public/
+├── tags/
+│   ├── go/index.html
+│   ├── concurrency/index.html
+│   └── goroutine/index.html
+└── categories/
+    ├── tech/index.html
+    └── programming/index.html
+```
+
+---
+
+## テンプレートでのアクセス
+
+### タグ一覧ページ (`tag.html`)
+
+タグページでは `.Articles` に **そのタグを持つ記事** が絞り込まれて渡されます:
+
+```html
+<!-- themes/default/templates/tag.html -->
+<!DOCTYPE html>
+<html lang="{{.Config.Site.Language}}">
+<head>
+  <meta charset="UTF-8">
+  <title>タグ別記事 — {{.Config.Site.Title}}</title>
+</head>
+<body>
+  <header><nav><a href="/">← {{.Config.Site.Title}}</a></nav></header>
+  <main>
+    <h2>記事 ({{len .Articles}} 件)</h2>
+    <ul>
+      {{range .Articles}}
+      <li>
+        <time>{{formatDate "2006-01-02" .FrontMatter.Date}}</time>
+        <a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>
+      </li>
+      {{end}}
+    </ul>
+  </main>
+</body>
+</html>
+```
+
+### カテゴリー一覧ページ (`category.html`)
+
+カテゴリーページでは `.Articles` に **そのカテゴリーを持つ記事** が渡されます:
+
+```html
+<!-- themes/default/templates/category.html -->
+<!DOCTYPE html>
+<html lang="{{.Config.Site.Language}}">
+<head>
+  <meta charset="UTF-8">
+  <title>カテゴリー別記事 — {{.Config.Site.Title}}</title>
+</head>
+<body>
+  <main>
+    <h2>記事一覧 ({{len .Articles}} 件)</h2>
+    <ul>
+      {{range .Articles}}
+      <li>
+        <a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>
+      </li>
+      {{end}}
+    </ul>
+  </main>
+</body>
+</html>
+```
+
+### タグ・カテゴリーの全一覧
+
+`.Tags` と `.Categories` を使うと全タグ・全カテゴリーに動的リンクを生成できます:
+
+```html
+<section>
+  <h3>タグ</h3>
+  <ul>
+    {{range .Tags}}
+    <li><a href="{{tagURL .Name}}">{{.Name}}</a></li>
+    {{end}}
+  </ul>
+
+  <h3>カテゴリー</h3>
+  <ul>
+    {{range .Categories}}
+    <li><a href="{{categoryURL .Name}}">{{.Name}}</a></li>
+    {{end}}
+  </ul>
+</section>
+```
+
+---
+
+## URL の生成
+
+gohan はタグ名・カテゴリー名を URL スラッグに変換します:
+
+- スペース → ハイフン
+- 大文字 → 小文字
+- 例: `"Go Language"` → `/tags/go-language/`
+
+---
+
+## アーカイブページ
+
+公開日 (`date`) から年別のアーカイブページが自動生成されます:
+
+```
+public/
+└── archive/
+    ├── 2024/index.html
+    └── 2023/index.html
+```
+
+`archive.html` テンプレートでは `.Articles` に **その年の記事** が渡されます。
+
+---
+
+## タクソノミーの設計指針
+
+- **タグ**: 記事の具体的なキーワード（`go`, `docker`, `postgresql` など）。数が多くても構いません
+- **カテゴリー**: 大分類（`tech`, `life`, `book` など）。少め（5〜10 種類程度）を推奨します
+
+---
+
+## 関連ページ
+
+- [テンプレートガイド](templates.ja.md)
+- [設定リファレンス](configuration.ja.md)

--- a/docs/guide/taxonomy.md
+++ b/docs/guide/taxonomy.md
@@ -1,17 +1,19 @@
-# Taxonomy Guide — タクソノミーガイド
+# Taxonomy Guide
 
-タクソノミーとは、記事を **タグ** や **カテゴリー** で分類する仕組みです。
-gohan は各タグ・カテゴリーに対応したページを自動生成します。
+Taxonomy is the system for classifying articles by **tags** and **categories**.
+gohan automatically generates a dedicated page for each tag and category.
+
+> 日本語版: [taxonomy.ja.md](taxonomy.ja.md)
 
 ---
 
-## 記事への設定
+## Setting up taxonomy in articles
 
-Front Matter でタグとカテゴリーを指定します:
+Specify tags and categories in the Front Matter:
 
 ```markdown
 ---
-title: Go の並行処理を理解する
+title: Understanding Go Concurrency
 date: 2024-03-01
 slug: go-concurrency
 tags:
@@ -24,14 +26,14 @@ categories:
 ---
 ```
 
-- `tags`: 記事のキーワード。複数指定可。1 タグ 1 ページが生成されます
-- `categories`: 記事の分類。複数指定可。1 カテゴリー 1 ページが生成されます
+- `tags` — Article keywords. Multiple values allowed. One page is generated per tag.
+- `categories` — Article classification. Multiple values allowed. One page is generated per category.
 
 ---
 
-## 生成されるページ
+## Generated pages
 
-上記の記事がある場合、以下のページが生成されます:
+Given the article above, the following pages are generated:
 
 ```
 public/
@@ -46,11 +48,11 @@ public/
 
 ---
 
-## テンプレートでのアクセス
+## Accessing taxonomy in templates
 
-### タグ一覧ページ (`tag.html`)
+### Tag page (`tag.html`)
 
-タグページでは `.Articles` に **そのタグを持つ記事** が絞り込まれて渡されます:
+`.Articles` contains only the articles that have this tag:
 
 ```html
 <!-- themes/default/templates/tag.html -->
@@ -58,14 +60,12 @@ public/
 <html lang="{{.Config.Site.Language}}">
 <head>
   <meta charset="UTF-8">
-  <title>タグ別記事 — {{.Config.Site.Title}}</title>
+  <title>Tag Articles — {{.Config.Site.Title}}</title>
 </head>
 <body>
-  <header>
-    <nav><a href="/">← {{.Config.Site.Title}}</a></nav>
-  </header>
+  <header><nav><a href="/">← {{.Config.Site.Title}}</a></nav></header>
   <main>
-    <h2>記事 ({{len .Articles}} 件)</h2>
+    <h2>Articles ({{len .Articles}})</h2>
     <ul>
       {{range .Articles}}
       <li>
@@ -79,9 +79,9 @@ public/
 </html>
 ```
 
-### カテゴリー一覧ページ (`category.html`)
+### Category page (`category.html`)
 
-カテゴリーページでは `.Articles` に **そのカテゴリーを持つ記事** が渡されます:
+`.Articles` contains only the articles that belong to this category:
 
 ```html
 <!-- themes/default/templates/category.html -->
@@ -89,11 +89,11 @@ public/
 <html lang="{{.Config.Site.Language}}">
 <head>
   <meta charset="UTF-8">
-  <title>カテゴリー別記事 — {{.Config.Site.Title}}</title>
+  <title>Category Articles — {{.Config.Site.Title}}</title>
 </head>
 <body>
   <main>
-    <h2>記事一覧 ({{len .Articles}} 件)</h2>
+    <h2>Articles ({{len .Articles}})</h2>
     <ul>
       {{range .Articles}}
       <li>
@@ -106,21 +106,21 @@ public/
 </html>
 ```
 
-### タグ・カテゴリーの全一覧
+### Listing all tags and categories
 
-`.Tags` と `.Categories` を使うと全タグ・全カテゴリーに動的リンクを生成できます:
+Use `.Tags` and `.Categories` to generate dynamic links to all tags/categories:
 
 ```html
-<!-- index.html などで全タグを表示 -->
-<section class="taxonomy">
-  <h3>タグ</h3>
+<!-- e.g. in index.html -->
+<section>
+  <h3>Tags</h3>
   <ul>
     {{range .Tags}}
     <li><a href="{{tagURL .Name}}">{{.Name}}</a></li>
     {{end}}
   </ul>
 
-  <h3>カテゴリー</h3>
+  <h3>Categories</h3>
   <ul>
     {{range .Categories}}
     <li><a href="{{categoryURL .Name}}">{{.Name}}</a></li>
@@ -131,15 +131,15 @@ public/
 
 ---
 
-## URL の生成
+## URL generation
 
-gohan はタグ名・カテゴリー名を URL スラッグに変換します:
+Tag and category names are normalized to URL slugs:
 
-- スペース → ハイフン
-- 大文字 → 小文字
-- 例: `"Go Language"` → `/tags/go-language/`
+- Spaces → hyphens
+- Uppercase → lowercase
+- Example: `"Go Language"` → `/tags/go-language/`
 
-テンプレート関数:
+Template functions:
 
 ```html
 <a href="{{tagURL "Go Language"}}">Go Language</a>
@@ -151,20 +151,18 @@ gohan はタグ名・カテゴリー名を URL スラッグに変換します:
 
 ---
 
-## アーカイブページ
+## Archive pages
 
-公開日 (`date`) から年別のアーカイブページが自動生成されます:
+Year-based archive pages are generated automatically from the article `date` field:
 
 ```
 public/
 └── archive/
-    ├── 2024/
-    │   └── index.html
-    └── 2023/
-        └── index.html
+    ├── 2024/index.html
+    └── 2023/index.html
 ```
 
-`archive.html` テンプレートでは `.Articles` に **その年の記事** が渡されます:
+In `archive.html`, `.Articles` contains the articles published in that year:
 
 ```html
 <!-- themes/default/templates/archive.html -->
@@ -172,11 +170,11 @@ public/
 <html lang="{{.Config.Site.Language}}">
 <head>
   <meta charset="UTF-8">
-  <title>アーカイブ — {{.Config.Site.Title}}</title>
+  <title>Archive — {{.Config.Site.Title}}</title>
 </head>
 <body>
   <main>
-    <h2>アーカイブ ({{len .Articles}} 件)</h2>
+    <h2>Archive ({{len .Articles}} articles)</h2>
     <ul>
       {{range .Articles}}
       <li>
@@ -192,43 +190,14 @@ public/
 
 ---
 
-## 記事フィルタリング
+## Taxonomy design guidelines
 
-記事内でタグ・カテゴリーを表示する場合:
-
-```html
-<!-- article.html でタグとカテゴリーを表示 -->
-{{with (index .Articles 0)}}
-  {{if .FrontMatter.Tags}}
-  <div class="tags">
-    <span>タグ:</span>
-    {{range .FrontMatter.Tags}}
-    <a href="{{tagURL .}}">#{{.}}</a>
-    {{end}}
-  </div>
-  {{end}}
-
-  {{if .FrontMatter.Categories}}
-  <div class="categories">
-    <span>カテゴリー:</span>
-    {{range .FrontMatter.Categories}}
-    <a href="{{categoryURL .}}">{{.}}</a>
-    {{end}}
-  </div>
-  {{end}}
-{{end}}
-```
+- **Tags** — Specific keywords for the article (`go`, `docker`, `postgresql`, etc.). Having many tags is fine.
+- **Categories** — Broad classifications (`tech`, `life`, `book`, etc.). Keep them few (5–10 recommended).
 
 ---
 
-## タクソノミーの設計指針
+## Related pages
 
-- **タグ**: 記事の具体的なキーワード（`go`, `docker`, `postgresql` など）。数が多くても構いません
-- **カテゴリー**: 大分類（`tech`, `life`, `book` など）。少め（5〜10 種類程度）を推奨します
-
----
-
-## 関連ページ
-
-- [テンプレートガイド](templates.md)
-- [設定リファレンス](configuration.md)
+- [Template Guide](templates.md)
+- [Configuration](configuration.md)

--- a/docs/guide/templates.ja.md
+++ b/docs/guide/templates.ja.md
@@ -1,0 +1,189 @@
+# テンプレートガイド
+
+gohan のテーマは Go 標準ライブラリの `html/template` を使用します。
+
+> English version: [templates.md](templates.md)
+
+---
+
+## テンプレートファイル
+
+テーマディレクトリ（デフォルト: `themes/default/templates/`）にある `.html` ファイルが自動的に読み込まれます。
+
+### 必須テンプレート
+
+| ファイル | URL パターン | 説明 |
+|---|---|---|
+| `index.html` | `/` | サイトのトップページ（全記事一覧） |
+| `article.html` | `/posts/<slug>/` | 個別記事ページ |
+| `tag.html` | `/tags/<name>/` | タグ別記事一覧ページ |
+| `category.html` | `/categories/<name>/` | カテゴリー別記事一覧ページ |
+| `archive.html` | `/archive/<year>/` | 年別アーカイブページ |
+
+> テンプレートが存在しない場合、そのページは生成されません（エラーにはなりません）。
+
+---
+
+## テンプレートデータ
+
+すべてのテンプレートに `model.Site` 型の値が渡されます。
+
+### Site
+
+```go
+type Site struct {
+    Config     Config              // config.yaml の設定
+    Articles   []*ProcessedArticle // ページに対応する記事一覧（絞り込み済み）
+    Tags       []Taxonomy          // サイト全体のタグ一覧
+    Categories []Taxonomy          // サイト全体のカテゴリー一覧
+}
+```
+
+### ProcessedArticle
+
+```go
+type ProcessedArticle struct {
+    FrontMatter  FrontMatter    // YAML Front Matter
+    HTMLContent  template.HTML  // レンダリング済み HTML
+    Summary      string         // 先頭 200 文字の要約
+    OutputPath   string         // 出力ファイルパス
+    FilePath     string         // ソース Markdown ファイルパス
+    LastModified time.Time      // 最終更新日時
+}
+
+type FrontMatter struct {
+    Title       string
+    Date        time.Time
+    Draft       bool
+    Tags        []string
+    Categories  []string
+    Description string
+    Author      string
+    Slug        string
+    Template    string
+}
+```
+
+### Taxonomy
+
+```go
+type Taxonomy struct {
+    Name        string // タグ/カテゴリー名
+    Description string // 説明（任意）
+}
+```
+
+---
+
+## ページ別の `.Articles` の内容
+
+| テンプレート | `.Articles` の内容 |
+|---|---|
+| `index.html` | サイト全体の全記事 |
+| `article.html` | その記事 1 件のみ |
+| `tag.html` | そのタグを持つ記事 |
+| `category.html` | そのカテゴリーを持つ記事 |
+| `archive.html` | その年の記事 |
+
+---
+
+## 組み込み関数
+
+| 関数 | 使用例 | 説明 |
+|---|---|---|
+| `formatDate` | `{{formatDate "2006-01-02" .FrontMatter.Date}}` | 日付フォーマット |
+| `tagURL` | `{{tagURL "go"}}` → `/tags/go/` | タグページの URL |
+| `categoryURL` | `{{categoryURL "tech"}}` → `/categories/tech/` | カテゴリーページの URL |
+| `markdownify` | `{{markdownify "**bold**"}}` | Markdown を HTML に変換 |
+
+`formatDate` のレイアウト文字列は [Go の time フォーマット](https://pkg.go.dev/time#Layout) に従います:
+
+- `"2006-01-02"` → `2024-01-15`
+- `"January 2, 2006"` → `January 15, 2024`
+- `"2006年1月2日"` → `2024年1月15日`
+
+---
+
+## テンプレートの例
+
+詳細なテンプレート例は英語版 [templates.md](templates.md) に記載されています。
+
+### `index.html` — トップページ
+
+```html
+<!DOCTYPE html>
+<html lang="{{.Config.Site.Language}}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="{{.Config.Site.Description}}">
+  <title>{{.Config.Site.Title}}</title>
+  <link rel="stylesheet" href="/assets/style.css">
+  <link rel="alternate" type="application/atom+xml" title="{{.Config.Site.Title}}" href="/atom.xml">
+</head>
+<body>
+  <header>
+    <h1><a href="/">{{.Config.Site.Title}}</a></h1>
+  </header>
+  <main>
+    <ul>
+      {{range .Articles}}
+      <li>
+        <time>{{formatDate "2006年1月2日" .FrontMatter.Date}}</time>
+        <a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>
+      </li>
+      {{end}}
+    </ul>
+  </main>
+  <footer>
+    <a href="/sitemap.xml">Sitemap</a> · <a href="/atom.xml">Feed</a>
+  </footer>
+</body>
+</html>
+```
+
+---
+
+## 高度な機能
+
+### Mermaid 図
+
+Markdown に `mermaid` コードブロックを書くと自動的に図が描画されます:
+
+````text
+```mermaid
+graph TD
+    A[記事を書く] --> B[gohan build]
+    B --> C[public/ に HTML 生成]
+    C --> D[デプロイ]
+```
+````
+
+gohan は mermaid ブロックを検出すると Mermaid ランタイムスクリプトを自動挿入します。
+
+### シンタックスハイライト
+
+フェンスコードブロックは [chroma](https://github.com/alecthomas/chroma) により自動的にハイライトされます。スタイルはインライン CSS で適用されるため外部スタイルシートは不要です。
+
+### テンプレートの継承（partials）
+
+`{{define}}` と `{{template}}` を使って再利用可能なパーシャルを作成できます:
+
+```html
+<!-- _partials/header.html -->
+{{define "header"}}
+<header>
+  <h1><a href="/">{{.Config.Site.Title}}</a></h1>
+</header>
+{{end}}
+```
+
+```html
+<!-- index.html -->
+<!DOCTYPE html>
+<html>
+<body>
+  {{template "header" .}}
+  <main>...</main>
+</body>
+</html>
+```

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -1,39 +1,41 @@
-# Template Guide — テンプレートガイド
+# Template Guide
 
-gohan のテーマは Go 標準ライブラリの `html/template` を使用します。
+gohan themes are built with Go's standard `html/template` package.
+
+> 日本語版: [templates.ja.md](templates.ja.md)
 
 ---
 
-## テンプレートファイル
+## Template files
 
-テーマディレクトリ（デフォルト: `themes/default/templates/`）にある `.html` ファイルが自動的に読み込まれます。
+All `.html` files inside the theme directory (`themes/default/templates/` by default) are loaded automatically.
 
-### 必須テンプレート
+### Required templates
 
-| ファイル | URL パターン | 説明 |
+| File | URL pattern | Description |
 |---|---|---|
-| `index.html` | `/` | サイトのトップページ（全記事一覧） |
-| `article.html` | `/posts/<slug>/` | 個別記事ページ |
-| `tag.html` | `/tags/<name>/` | タグ別記事一覧ページ |
-| `category.html` | `/categories/<name>/` | カテゴリー別記事一覧ページ |
-| `archive.html` | `/archive/<year>/` | 年別アーカイブページ |
+| `index.html` | `/` | Site top page (full article list) |
+| `article.html` | `/posts/<slug>/` | Individual article page |
+| `tag.html` | `/tags/<name>/` | Tag article list page |
+| `category.html` | `/categories/<name>/` | Category article list page |
+| `archive.html` | `/archive/<year>/` | Year-based archive page |
 
-> **注意**: テンプレートが存在しない場合、そのページは生成されません（エラーにはなりません）。
+> If a template file does not exist, that page is simply not generated (no error is raised).
 
 ---
 
-## テンプレートデータ
+## Template data
 
-すべてのテンプレートに `model.Site` 型の値が渡されます。
+Every template receives a value of type `model.Site`.
 
 ### Site
 
 ```go
 type Site struct {
-    Config     Config              // config.yaml の設定
-    Articles   []*ProcessedArticle // ページに対応する記事一覧（絞り込み済み）
-    Tags       []Taxonomy          // サイト全体のタグ一覧
-    Categories []Taxonomy          // サイト全体のカテゴリー一覧
+    Config     Config              // Settings from config.yaml
+    Articles   []*ProcessedArticle // Articles for the current page (filtered)
+    Tags       []Taxonomy          // All tags across the site
+    Categories []Taxonomy          // All categories across the site
 }
 ```
 
@@ -41,9 +43,9 @@ type Site struct {
 
 ```go
 type Config struct {
-    Site  SiteConfig  // .Config.Site.*
-    Theme ThemeConfig // .Config.Theme.*
-    Build BuildConfig // .Config.Build.*
+    Site  SiteConfig
+    Theme ThemeConfig
+    Build BuildConfig
 }
 
 type SiteConfig struct {
@@ -54,8 +56,8 @@ type SiteConfig struct {
 }
 
 type ThemeConfig struct {
-    Name   string            // .Config.Theme.Name
-    Dir    string            // .Config.Theme.Dir
+    Name   string
+    Dir    string
     Params map[string]string // .Config.Theme.Params
 }
 ```
@@ -64,12 +66,12 @@ type ThemeConfig struct {
 
 ```go
 type ProcessedArticle struct {
-    FrontMatter FrontMatter    // YAML Front Matter
-    HTMLContent template.HTML  // レンダリング済み HTML
-    Summary     string         // 先頭 200 文字の要約
-    OutputPath  string         // 出力ファイルパス
-    FilePath    string         // ソース Markdown ファイルパス
-    LastModified time.Time     // 最終更新日時
+    FrontMatter  FrontMatter    // Parsed YAML Front Matter
+    HTMLContent  template.HTML  // Rendered HTML
+    Summary      string         // First ~200 characters
+    OutputPath   string         // Output file path
+    FilePath     string         // Source Markdown file path
+    LastModified time.Time      // Last modified time
 }
 
 type FrontMatter struct {
@@ -89,46 +91,44 @@ type FrontMatter struct {
 
 ```go
 type Taxonomy struct {
-    Name        string // タグ/カテゴリー名
-    Description string // 説明（任意）
+    Name        string // Tag or category name
+    Description string // Optional description
 }
 ```
 
 ---
 
-## ページ別の `.Articles` の内容
+## `.Articles` contents per template
 
-各テンプレートで `.Articles` に含まれる記事は異なります:
-
-| テンプレート | `.Articles` の内容 |
+| Template | `.Articles` contains |
 |---|---|
-| `index.html` | サイト全体の全記事 |
-| `article.html` | その記事 1 件のみ |
-| `tag.html` | そのタグを持つ記事 |
-| `category.html` | そのカテゴリーを持つ記事 |
-| `archive.html` | その年の記事 |
+| `index.html` | All articles on the site |
+| `article.html` | The single article being rendered |
+| `tag.html` | Articles that have this tag |
+| `category.html` | Articles that belong to this category |
+| `archive.html` | Articles published in this year |
 
 ---
 
-## 組み込み関数
+## Built-in functions
 
-| 関数 | 使用例 | 説明 |
+| Function | Example | Description |
 |---|---|---|
-| `formatDate` | `{{formatDate "2006-01-02" .FrontMatter.Date}}` | 日付フォーマット |
-| `tagURL` | `{{tagURL "go"}}` → `/tags/go/` | タグページの URL |
-| `categoryURL` | `{{categoryURL "tech"}}` → `/categories/tech/` | カテゴリーページの URL |
-| `markdownify` | `{{markdownify "**bold**"}}` | Markdown を HTML に変換 |
+| `formatDate` | `{{formatDate "2006-01-02" .FrontMatter.Date}}` | Format a `time.Time` value |
+| `tagURL` | `{{tagURL "go"}}` → `/tags/go/` | Generate a tag page URL |
+| `categoryURL` | `{{categoryURL "tech"}}` → `/categories/tech/` | Generate a category page URL |
+| `markdownify` | `{{markdownify "**bold**"}}` | Convert a Markdown string to HTML |
 
-`formatDate` のレイアウト文字列は [Go の time フォーマット](https://pkg.go.dev/time#Layout) に従います:
+`formatDate` uses Go's [reference time](https://pkg.go.dev/time#Layout) layout:
+
 - `"2006-01-02"` → `2024-01-15`
 - `"January 2, 2006"` → `January 15, 2024`
-- `"2006年1月2日"` → `2024年1月15日`
 
 ---
 
-## テンプレートの例
+## Template examples
 
-### `index.html` — トップページ
+### `index.html` — Top page
 
 ```html
 <!DOCTYPE html>
@@ -145,28 +145,23 @@ type Taxonomy struct {
     <h1><a href="/">{{.Config.Site.Title}}</a></h1>
     <p>{{.Config.Site.Description}}</p>
   </header>
-
   <main>
-    <h2>最新の記事</h2>
     <ul>
       {{range .Articles}}
       <li>
         <time>{{formatDate "2006-01-02" .FrontMatter.Date}}</time>
         <a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>
         {{if .FrontMatter.Tags}}
-        <span class="tags">
-          {{range .FrontMatter.Tags}}
-          <a href="{{tagURL .}}">#{{.}}</a>
-          {{end}}
+        <span>
+          {{range .FrontMatter.Tags}}<a href="{{tagURL .}}">#{{.}}</a> {{end}}
         </span>
         {{end}}
       </li>
       {{end}}
     </ul>
   </main>
-
   <footer>
-    <p><a href="/sitemap.xml">Sitemap</a> · <a href="/atom.xml">Feed</a></p>
+    <a href="/sitemap.xml">Sitemap</a> · <a href="/atom.xml">Feed</a>
     {{if .Config.Theme.Params.footer_text}}
     <p>{{.Config.Theme.Params.footer_text}}</p>
     {{end}}
@@ -175,7 +170,7 @@ type Taxonomy struct {
 </html>
 ```
 
-### `article.html` — 記事ページ
+### `article.html` — Article page
 
 ```html
 <!DOCTYPE html>
@@ -189,32 +184,19 @@ type Taxonomy struct {
   <link rel="stylesheet" href="/assets/style.css">
 </head>
 <body>
-  <header>
-    <nav><a href="/">← {{.Config.Site.Title}}</a></nav>
-  </header>
-
+  <header><nav><a href="/">← {{.Config.Site.Title}}</a></nav></header>
   <main>
     {{with (index .Articles 0)}}
     <article>
       <h1>{{.FrontMatter.Title}}</h1>
-      <div class="meta">
-        <time>{{formatDate "2006年1月2日" .FrontMatter.Date}}</time>
-        {{if .FrontMatter.Author}}
-        <span> · {{.FrontMatter.Author}}</span>
-        {{end}}
-      </div>
-
+      <time>{{formatDate "January 2, 2006" .FrontMatter.Date}}</time>
+      {{if .FrontMatter.Author}}<span> · {{.FrontMatter.Author}}</span>{{end}}
       {{if .FrontMatter.Tags}}
       <ul class="tags">
-        {{range .FrontMatter.Tags}}
-        <li><a href="{{tagURL .}}">{{.}}</a></li>
-        {{end}}
+        {{range .FrontMatter.Tags}}<li><a href="{{tagURL .}}">{{.}}</a></li>{{end}}
       </ul>
       {{end}}
-
-      <div class="content">
-        {{.HTMLContent}}
-      </div>
+      <div class="content">{{.HTMLContent}}</div>
     </article>
     {{end}}
   </main>
@@ -222,22 +204,20 @@ type Taxonomy struct {
 </html>
 ```
 
-### `tag.html` — タグ別記事一覧
+### `tag.html` — Tag page
 
 ```html
 <!DOCTYPE html>
 <html lang="{{.Config.Site.Language}}">
 <head>
   <meta charset="UTF-8">
-  <title>{{.Config.Site.Title}}</title>
+  <title>Tag: {{(index .Articles 0).FrontMatter.Tags}} — {{.Config.Site.Title}}</title>
   <link rel="stylesheet" href="/assets/style.css">
 </head>
 <body>
-  <header>
-    <nav><a href="/">← {{.Config.Site.Title}}</a></nav>
-  </header>
+  <header><nav><a href="/">← {{.Config.Site.Title}}</a></nav></header>
   <main>
-    <h2>記事一覧</h2>
+    <h2>Articles ({{len .Articles}})</h2>
     <ul>
       {{range .Articles}}
       <li>
@@ -253,54 +233,38 @@ type Taxonomy struct {
 
 ---
 
-## 高度な機能
+## Advanced features
 
-### Mermaid 図
+### Mermaid diagrams
 
-Markdown にコードブロックを書くだけで Mermaid 図が描画されます:
+Write a fenced code block with the `mermaid` language identifier:
 
-````markdown
+````text
 ```mermaid
 graph TD
-    A[記事を書く] --> B[gohan build]
-    B --> C[public/ に HTML 生成]
-    C --> D[デプロイ]
+    A[Write article] --> B[gohan build]
+    B --> C[HTML in public/]
+    C --> D[Deploy]
 ```
 ````
 
-テンプレートに Mermaid の CDN スクリプトを含めることで動作します（gohan はレンダリング時に自動挿入することもできます）:
+gohan automatically injects the Mermaid runtime script when it detects a mermaid block.
 
-```html
-<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-```
+### Syntax highlighting
 
-### シンタックスハイライト
+Fenced code blocks are highlighted automatically using [chroma](https://github.com/alecthomas/chroma). Styles are applied via inline CSS — no external stylesheet is required.
 
-````markdown
-```go
-package main
+### Template partials
 
-import "fmt"
-
-func main() {
-    fmt.Println("Hello!")
-}
-```
-````
-
-ハイライトはインライン CSS スタイルで適用されるため、外部 CSS ファイルは不要です。
-
-### テンプレートの継承（partials）
-
-`themes/default/templates/` 以下に任意のファイルを作成し、`template` アクションで読み込めます:
+Create reusable partial templates using `{{define}}` and `{{template}}`:
 
 ```
 themes/default/templates/
 ├── index.html
 ├── article.html
-├── _partials/
-│   ├── header.html    ← define "header" で定義
-│   └── footer.html    ← define "footer" で定義
+└── _partials/
+    ├── header.html   ← defines "header"
+    └── footer.html   ← defines "footer"
 ```
 
 ```html

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -141,7 +141,7 @@ func hashFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -25,7 +25,7 @@ func writeTemp(t *testing.T, content string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := f.WriteString(content); err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestIsGitRepo_GitDir(t *testing.T) {
 func TestHash_ValidFile(t *testing.T) {
 	content := "hello gohan"
 	path := writeTemp(t, content)
-	defer os.Remove(path)
+	defer func() { _ = os.Remove(path) }()
 	got, err := hashFile(path)
 	if err != nil {
 		t.Fatalf("hashFile: %v", err)

--- a/internal/generator/feed.go
+++ b/internal/generator/feed.go
@@ -131,8 +131,10 @@ func writeXML(path string, v interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	f.WriteString(xml.Header)
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(xml.Header); err != nil {
+		return err
+	}
 	enc := xml.NewEncoder(f)
 	enc.Indent("", "  ")
 	if err := enc.Encode(v); err != nil {

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -255,12 +255,12 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 	out, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 	_, err = io.Copy(out, in)
 	return err
 }

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -70,7 +70,9 @@ func TestGenerate_SlugifiesTitle(t *testing.T) {
 
 func TestGenerate_CopiesAssets(t *testing.T) {
 	srcDir := t.TempDir()
-	os.WriteFile(filepath.Join(srcDir, "style.css"), []byte("body{}"), 0o644)
+	if err := os.WriteFile(filepath.Join(srcDir, "style.css"), []byte("body{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	outDir := t.TempDir()
 	cfg := model.Config{Build: model.BuildConfig{Parallelism: 1, AssetsDir: srcDir}}
 	if err := NewHTMLGenerator(outDir, &mockEngine{}, cfg).Generate(makeSite(), nil); err != nil {
@@ -106,8 +108,12 @@ func TestGenerateFeed(t *testing.T) {
 func TestCopyAssets_PreservesStructure(t *testing.T) {
 	src := t.TempDir()
 	sub := filepath.Join(src, "css")
-	os.MkdirAll(sub, 0o755)
-	os.WriteFile(filepath.Join(sub, "main.css"), []byte(".a{}"), 0o644)
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "main.css"), []byte(".a{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	dst := t.TempDir()
 	if err := CopyAssets(src, dst); err != nil {
 		t.Fatalf("CopyAssets: %v", err)

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -6,17 +6,23 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/bmf-san/gohan/internal/model"
 )
 
-type mockEngine struct{ calls []string }
+type mockEngine struct {
+	mu    sync.Mutex
+	calls []string
+}
 
 func (m *mockEngine) Load(_ string, _ htmltemplate.FuncMap) error { return nil }
 func (m *mockEngine) Render(w io.Writer, name string, _ *model.Site) error {
+	m.mu.Lock()
 	m.calls = append(m.calls, name)
+	m.mu.Unlock()
 	_, err := io.WriteString(w, "<html>"+name+"</html>")
 	return err
 }

--- a/internal/generator/sitemap.go
+++ b/internal/generator/sitemap.go
@@ -50,9 +50,11 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
-	out.WriteString(xml.Header)
+	if _, err := out.WriteString(xml.Header); err != nil {
+		return err
+	}
 	enc := xml.NewEncoder(out)
 	enc.Indent("", "  ")
 	if err := enc.Encode(us); err != nil {

--- a/internal/generator/sitemap_feed_test.go
+++ b/internal/generator/sitemap_feed_test.go
@@ -111,7 +111,9 @@ func TestGenerateFeeds_SlugifiesTitle(t *testing.T) {
 	articles := []*model.ProcessedArticle{
 		{Article: model.Article{FrontMatter: model.FrontMatter{Title: "Hello World", Date: time.Now()}}},
 	}
-	GenerateFeeds(dir, "https://example.com", "Blog", articles)
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles); err != nil {
+		t.Fatal(err)
+	}
 	data, _ := os.ReadFile(filepath.Join(dir, "feed.xml"))
 	if !strings.Contains(string(data), "hello-world") {
 		t.Errorf("expected slugified title in feed:\n%s", data)

--- a/internal/generator/sitemap_feed_test.go
+++ b/internal/generator/sitemap_feed_test.go
@@ -51,7 +51,9 @@ func TestGenerateSitemap_Empty(t *testing.T) {
 
 func TestGenerateSitemap_WellFormedXML(t *testing.T) {
 	dir := t.TempDir()
-	GenerateSitemap(dir, "https://example.com", makeArticles())
+	if err := GenerateSitemap(dir, "https://example.com", makeArticles()); err != nil {
+		t.Fatal(err)
+	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
 	var v interface{}
 	if err := xml.Unmarshal(data, &v); err != nil {
@@ -78,7 +80,9 @@ func TestGenerateFeeds_Valid(t *testing.T) {
 
 func TestGenerateFeeds_NewestFirst(t *testing.T) {
 	dir := t.TempDir()
-	GenerateFeeds(dir, "https://example.com", "Blog", makeArticles())
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", makeArticles()); err != nil {
+		t.Fatal(err)
+	}
 	for _, name := range []string{"feed.xml", "atom.xml"} {
 		data, _ := os.ReadFile(filepath.Join(dir, name))
 		s := string(data)
@@ -90,7 +94,9 @@ func TestGenerateFeeds_NewestFirst(t *testing.T) {
 
 func TestGenerateFeeds_WellFormedXML(t *testing.T) {
 	dir := t.TempDir()
-	GenerateFeeds(dir, "https://example.com", "Blog", makeArticles())
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", makeArticles()); err != nil {
+		t.Fatal(err)
+	}
 	for _, name := range []string{"feed.xml", "atom.xml"} {
 		data, _ := os.ReadFile(filepath.Join(dir, name))
 		var v interface{}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -136,11 +136,10 @@ const sseScript = `<script>(function(){` +
 	`})()</script>`
 
 type injectingResponseWriter struct {
-	wrapped    http.ResponseWriter
-	buf        bytes.Buffer
-	header     int
-	isHTML     bool
-	headerSent bool
+	wrapped http.ResponseWriter
+	buf     bytes.Buffer
+	header  int
+	isHTML  bool
 }
 
 func (w *injectingResponseWriter) Header() http.Header { return w.wrapped.Header() }
@@ -245,7 +244,7 @@ func (s *DevServer) Start() error {
 				if !ok {
 					return
 				}
-				fmt.Fprintf(w, "data: %s\n\n", msg)
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", msg)
 				flusher.Flush()
 			}
 		}
@@ -260,7 +259,7 @@ func (s *DevServer) Start() error {
 		// Try to create a real watcher; silently skip if unavailable
 		if fw, err := NewFsnotifyWatcher(); err == nil {
 			s.Watcher = fw
-			defer fw.Close()
+			defer func() { _ = fw.Close() }()
 		}
 	}
 	if s.Watcher != nil {

--- a/internal/server/start_test.go
+++ b/internal/server/start_test.go
@@ -19,7 +19,7 @@ func freePort(t *testing.T) int {
 		t.Fatalf("freePort: %v", err)
 	}
 	port := l.Addr().(*net.TCPAddr).Port
-	l.Close()
+	_ = l.Close()
 	return port
 }
 
@@ -29,7 +29,7 @@ func waitForPort(addr string, deadline time.Duration) bool {
 	for time.Now().Before(end) {
 		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
 		if err == nil {
-			conn.Close()
+			_ = conn.Close()
 			return true
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -60,7 +60,7 @@ func TestStart_ServesStaticFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HTTP GET: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200 OK, got %d", resp.StatusCode)
@@ -97,7 +97,7 @@ func TestStart_SSEEndpoint(t *testing.T) {
 		t.Logf("SSE request ended (expected timeout): %v", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	ct := resp.Header.Get("Content-Type")
 	if ct != "text/event-stream" {
 		t.Errorf("expected text/event-stream, got %q", ct)
@@ -106,8 +106,10 @@ func TestStart_SSEEndpoint(t *testing.T) {
 
 func TestStart_WithMockWatcher(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "page.html"),
-		[]byte("<html><body>Page</body></html>"), 0644)
+	if err := os.WriteFile(filepath.Join(dir, "page.html"),
+		[]byte("<html><body>Page</body></html>"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	rebuilt := make(chan struct{}, 1)
 	fw := newFakeWatcher()

--- a/internal/server/watcher_test.go
+++ b/internal/server/watcher_test.go
@@ -7,8 +7,7 @@ import (
 
 // fakeWatcher is a mock FileWatcher for unit tests.
 type fakeWatcher struct {
-	ch     chan string
-	closed bool
+	ch chan string
 }
 
 func newFakeWatcher() *fakeWatcher {
@@ -24,7 +23,7 @@ func TestNewFsnotifyWatcher_CreatesWatcher(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFsnotifyWatcher: %v", err)
 	}
-	defer fw.Close()
+	defer func() { _ = fw.Close() }()
 
 	if fw.Events() == nil {
 		t.Error("expected non-nil events channel")
@@ -127,7 +126,7 @@ func TestWatchLoop_ExitsOnChannelClose(t *testing.T) {
 		close(done)
 	}()
 
-	fw.Close() // closes the events channel → watchLoop should return
+	_ = fw.Close() // closes the events channel → watchLoop should return
 
 	select {
 	case <-done:


### PR DESCRIPTION
## Summary

- Make all guide files English-first (pure English `.md` files)
- Add Japanese counterparts as `.ja.md` files for all guide documents
- Slim down `README.md` to English-first with brief quick start — detailed usage now references the guide
- Add `README.ja.md` (Japanese README)

## Changes

### New files
- `README.ja.md`
- `docs/guide/README.ja.md`
- `docs/guide/getting-started.ja.md`
- `docs/guide/configuration.ja.md`
- `docs/guide/templates.ja.md`
- `docs/guide/taxonomy.ja.md`

### Modified files
- `README.md` — rewritten in English, slimmed down (~120 lines), links to `docs/guide/` for details
- `docs/guide/README.md` — rewritten in English, links to `.ja.md` counterparts
- `docs/guide/getting-started.md` — rewritten in English
- `docs/guide/configuration.md` — rewritten in English
- `docs/guide/templates.md` — rewritten in English
- `docs/guide/taxonomy- `docs/guide/taxonomy- `docs/guide/taxonomy- `docs/guide/taxonomy- `docs/gui     - `docs/guide/taxorim- `docs/guide/taxonomy- `docs/guide/taxonomy- `docs/guide/tax R- `docs/guide/taxonomy- `docs/guide/taxonomy- `docs/guidted.ja.md
  configuration.md / configuration.ja.md
  templates.md / templates.ja.md
  taxonomy.md / taxonomy.ja.md
```