### PR TITLE
fix: use locale-aware article URL in feed.go

### DIFF
--- a/internal/generator/feed.go
+++ b/internal/generator/feed.go
@@ -83,11 +83,7 @@ func writeRSS(outDir, baseURL, title string, articles []*model.ProcessedArticle)
 		PubDate:     now,
 	}
 	for _, a := range articles {
-		s := a.FrontMatter.Slug
-		if s == "" {
-			s = slugify(a.FrontMatter.Title)
-		}
-		link := baseURL + "/posts/" + s + "/"
+		link := articleLink(baseURL, a)
 		ch.Items = append(ch.Items, rssItem{
 			Title:       a.FrontMatter.Title,
 			Link:        link,
@@ -112,18 +108,28 @@ func writeAtom(outDir, baseURL, title string, articles []*model.ProcessedArticle
 		Updated: updated,
 	}
 	for _, a := range articles {
-		s := a.FrontMatter.Slug
-		if s == "" {
-			s = slugify(a.FrontMatter.Title)
-		}
 		feed.Entries = append(feed.Entries, atomEntry{
 			Title:   a.FrontMatter.Title,
-			Link:    atomLink{Href: baseURL + "/posts/" + s + "/"},
+			Link:    atomLink{Href: articleLink(baseURL, a)},
 			Updated: a.FrontMatter.Date.UTC().Format(time.RFC3339),
 			Summary: a.Summary,
 		})
 	}
 	return writeXML(filepath.Join(outDir, "atom.xml"), feed)
+}
+
+// articleLink returns the full URL for an article.
+// When a.URL is set (i18n mode), it is appended to baseURL.
+// Otherwise the URL is constructed from the article slug.
+func articleLink(baseURL string, a *model.ProcessedArticle) string {
+	if a.URL != "" {
+		return baseURL + a.URL
+	}
+	s := a.FrontMatter.Slug
+	if s == "" {
+		s = slugify(a.FrontMatter.Title)
+	}
+	return baseURL + "/posts/" + s + "/"
 }
 
 func writeXML(path string, v interface{}) error {

--- a/internal/generator/sitemap_feed_test.go
+++ b/internal/generator/sitemap_feed_test.go
@@ -173,3 +173,55 @@ func TestGenerateSitemap_UsesPrecomputedURL(t *testing.T) {
 		t.Errorf("sitemap should NOT use slug when URL is set:\n%s", s)
 	}
 }
+
+func TestGenerateFeeds_I18nUsesPrecomputedURL(t *testing.T) {
+	dir := t.TempDir()
+	date := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	articles := []*model.ProcessedArticle{
+		{
+			Article: model.Article{FrontMatter: model.FrontMatter{
+				Title: "Japanese Post",
+				Slug:  "ja-post",
+				Date:  date,
+			}},
+			URL:    "/ja/posts/ja-post/",
+			Locale: "ja",
+		},
+	}
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"feed.xml", "atom.xml"} {
+		data, _ := os.ReadFile(filepath.Join(dir, name))
+		s := string(data)
+		if !strings.Contains(s, "/ja/posts/ja-post/") {
+			t.Errorf("%s: expected locale-aware URL /ja/posts/ja-post/:\n%s", name, s)
+		}
+		if strings.Contains(s, "https://example.com/posts/ja-post/") {
+			t.Errorf("%s: should NOT fall back to /posts/ when URL is set:\n%s", name, s)
+		}
+	}
+}
+
+func TestGenerateFeeds_NoURLFallsBackToSlug(t *testing.T) {
+	dir := t.TempDir()
+	articles := []*model.ProcessedArticle{
+		{
+			Article: model.Article{FrontMatter: model.FrontMatter{
+				Title: "Plain Post",
+				Slug:  "plain-post",
+				Date:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			}},
+			// URL is empty (no i18n)
+		},
+	}
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"feed.xml", "atom.xml"} {
+		data, _ := os.ReadFile(filepath.Join(dir, name))
+		if !strings.Contains(string(data), "/posts/plain-post/") {
+			t.Errorf("%s: expected /posts/plain-post/ fallback:\n%s", name, data)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`feed.go` was building RSS/Atom item links as `baseURL + "/posts/" + slug + "/"`, ignoring the locale entirely. For i18n sites where non-default-locale articles live at `/ja/posts/hello/`, this produced incorrect feed URLs.

### Changes

#### `internal/generator/feed.go`
- Extract `articleLink(baseURL, a)` helper that uses `a.URL` (pre-computed locale-aware path) when set, and falls back to the slug-based path only when `a.URL` is empty (no i18n configured).
- `writeRSS` and `writeAtom` both use `articleLink()`.

### New tests
- `TestGenerateFeeds_I18nUsesPrecomputedURL` — verifies `/ja/posts/` appears in both `feed.xml` and `atom.xml`
- `TestGenerateFeeds_NoURLFallsBackToSlug` — verifies non-i18n sites still get `/posts/{slug}/`

### Closes
- i18n support for feed.go: Fix hardcoded post URLs