### PR TITLE
fix: wire up ValidateArticleTaxonomies and LoadTaxonomyRegistry in build

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -108,9 +108,28 @@ func runBuild(args []string) error {
 	proc.BuildTranslationMap(processed)
 
 	// Build taxonomy.
-	taxo, err := proc.BuildTaxonomyRegistry(processed, *cfg)
-	if err != nil {
-		return fmt.Errorf("build taxonomy: %w", err)
+	// If tags.yaml / categories.yaml exist in the content directory they are
+	// treated as the authoritative registry and every article is validated
+	// against them.  When the files are absent the registry is derived from
+	// the articles themselves (no validation errors are possible).
+	var taxo *model.TaxonomyRegistry
+	loaded, loadErr := processor.LoadTaxonomyRegistry(contentDir)
+	if loadErr != nil {
+		return fmt.Errorf("load taxonomy registry: %w", loadErr)
+	}
+	if len(loaded.Tags) > 0 || len(loaded.Categories) > 0 {
+		taxo = loaded
+		if errs := processor.ValidateArticleTaxonomies(processed, taxo); len(errs) > 0 {
+			for _, e := range errs {
+				fmt.Fprintf(os.Stderr, "warn: taxonomy: %v\n", e)
+			}
+		}
+	} else {
+		computed, err := proc.BuildTaxonomyRegistry(processed, *cfg)
+		if err != nil {
+			return fmt.Errorf("build taxonomy: %w", err)
+		}
+		taxo = computed
 	}
 
 	site := &model.Site{


### PR DESCRIPTION
## Summary

`build.go` was calling `BuildTaxonomyRegistry` but never `ValidateArticleTaxonomies`, meaning tag/category mismatches were silently ignored at build time.

### Changes

#### `cmd/gohan/build.go`

**New taxonomy build flow:**

1. Call `processor.LoadTaxonomyRegistry(contentDir)` — looks for `tags.yaml` and `categories.yaml` in the content directory root.
2. **If YAML files have entries:** use the loaded registry as the authoritative source, then call `processor.ValidateArticleTaxonomies(processed, taxo)`. Violations are printed to `stderr` as warnings (build continues, giving authors a chance to fix mismatches without a hard failure).
3. **If no YAML files:** fall back to `proc.BuildTaxonomyRegistry(processed, cfg)` — same behaviour as before. In this path `ValidateArticleTaxonomies` would always pass (registry = derived from the same articles), but the call site is now correctly written for future YAML-first taxonomy workflows.

### Closes
- `ValidateArticleTaxonomies` never called from the build pipeline