### PR TITLE
refactor: remove dead GenerateSitemap/GenerateFeed from OutputGenerator interface

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -7,14 +7,13 @@ import (
 
 // OutputGenerator takes the fully-rendered site data and writes all output
 // files to the configured output directory.
+//
+// Sitemap and feed generation are handled by the package-level GenerateSitemap
+// and GenerateFeeds functions, which are i18n-aware and kept separate from
+// the HTML generation step.
 type OutputGenerator interface {
-	// Generate writes all HTML pages and copies static assets into outDir.
-	// Only files in changeSet (or all files when changeSet is nil) are written.
+	// Generate writes all HTML pages, copies static assets, and generates OGP
+	// images into outDir.  Only files in changeSet (or all files when changeSet
+	// is nil) are written.
 	Generate(site *model.Site, changeSet *model.ChangeSet) error
-
-	// GenerateSitemap creates sitemap.xml inside outDir.
-	GenerateSitemap(site *model.Site) error
-
-	// GenerateFeed creates atom.xml (Atom feed) inside outDir.
-	GenerateFeed(site *model.Site) error
 }

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -301,59 +301,6 @@ func (g *HTMLGenerator) writePage(path, tmplName string, data *model.Site) error
 	return nil
 }
 
-// GenerateSitemap writes a sitemap.xml listing all article URLs.
-func (g *HTMLGenerator) GenerateSitemap(site *model.Site) error {
-	baseURL := site.Config.Site.BaseURL
-	var buf bytes.Buffer
-	buf.WriteString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
-	buf.WriteString("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n")
-	for _, a := range site.Articles {
-		slug := a.FrontMatter.Slug
-		if slug == "" {
-			slug = slugify(a.FrontMatter.Title)
-		}
-		buf.WriteString("  <url><loc>" + baseURL + "/posts/" + slug + "/</loc></url>\n")
-	}
-	buf.WriteString("</urlset>\n")
-	if err := os.MkdirAll(g.outDir, 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(g.outDir, "sitemap.xml"), buf.Bytes(), 0o644)
-}
-
-// GenerateFeed writes an atom.xml (Atom feed) listing all articles.
-func (g *HTMLGenerator) GenerateFeed(site *model.Site) error {
-	baseURL := site.Config.Site.BaseURL
-	title := site.Config.Site.Title
-	now := time.Now().UTC().Format(time.RFC3339)
-
-	var buf bytes.Buffer
-	buf.WriteString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
-	buf.WriteString("<feed xmlns=\"http://www.w3.org/2005/Atom\">\n")
-	buf.WriteString("  <title>" + title + "</title>\n")
-	buf.WriteString("  <link href=\"" + baseURL + "\"/>\n")
-	buf.WriteString("  <updated>" + now + "</updated>\n")
-	for _, a := range site.Articles {
-		slug := a.FrontMatter.Slug
-		if slug == "" {
-			slug = slugify(a.FrontMatter.Title)
-		}
-		updated := a.FrontMatter.Date.UTC().Format(time.RFC3339)
-		buf.WriteString("  <entry>\n")
-		buf.WriteString("    <title>" + a.FrontMatter.Title + "</title>\n")
-		buf.WriteString("    <link href=\"" + baseURL + "/posts/" + slug + "/\"/>\n")
-		buf.WriteString("    <updated>" + updated + "</updated>\n")
-		buf.WriteString("    <summary>" + a.Summary + "</summary>\n")
-		buf.WriteString("  </entry>\n")
-	}
-	buf.WriteString("</feed>\n")
-
-	if err := os.MkdirAll(g.outDir, 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(g.outDir, "atom.xml"), buf.Bytes(), 0o644)
-}
-
 // CopyAssets recursively copies all files from srcDir into dstDir.
 func CopyAssets(srcDir, dstDir string) error {
 	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -87,28 +86,6 @@ func TestGenerate_CopiesAssets(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(outDir, "assets", "style.css")); err != nil {
 		t.Errorf("expected copied asset: %v", err)
-	}
-}
-
-func TestGenerateSitemap(t *testing.T) {
-	outDir := t.TempDir()
-	if err := NewHTMLGenerator(outDir, &mockEngine{}, model.Config{}).GenerateSitemap(makeSite()); err != nil {
-		t.Fatalf("GenerateSitemap: %v", err)
-	}
-	data, _ := os.ReadFile(filepath.Join(outDir, "sitemap.xml"))
-	if !strings.Contains(string(data), "hello-world") || !strings.Contains(string(data), "urlset") {
-		t.Errorf("sitemap wrong:\n%s", data)
-	}
-}
-
-func TestGenerateFeed(t *testing.T) {
-	outDir := t.TempDir()
-	if err := NewHTMLGenerator(outDir, &mockEngine{}, model.Config{}).GenerateFeed(makeSite()); err != nil {
-		t.Fatalf("GenerateFeed: %v", err)
-	}
-	data, _ := os.ReadFile(filepath.Join(outDir, "atom.xml"))
-	if !strings.Contains(string(data), "Hello World") || !strings.Contains(string(data), "Test Site") {
-		t.Errorf("feed wrong:\n%s", data)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `OutputGenerator` interface had two methods (`GenerateSitemap` and `GenerateFeed`) that were never called through the interface — callers in `build.go` always used the package-level `GenerateSitemap` and `GenerateFeeds` functions directly.

`HTMLGenerator` also had its own duplicate `GenerateSitemap` / `GenerateFeed` methods that re-implemented the same logic with hardcoded `/posts/{slug}/` paths (i18n-unaware), which was already superseded by the package-level functions fixed in #60.

## Changes

- `generator.go`: `OutputGenerator` interface now only declares `Generate`
- `html.go`: removed duplicate `HTMLGenerator.GenerateSitemap` and `HTMLGenerator.GenerateFeed` methods (84 lines removed)
- `html_test.go`: removed `TestGenerateSitemap` and `TestGenerateFeed` tests for the deleted methods; removed unused `strings` import

## Impact

No behaviour change — the package-level `GenerateSitemap` and `GenerateFeeds` functions (called by `build.go`) are unchanged.