### PR TITLE
fix: resolve ContentDir/OutputDir to absolute paths before passing to processor

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -83,6 +83,11 @@ func runBuild(args []string) error {
 	// Parse content.
 	p := parser.NewFileParser(cfg.Build.ExcludeFiles...)
 	contentDir := filepath.Join(rootDir, cfg.Build.ContentDir)
+	// Resolve path fields to absolute so that processor functions that call
+	// filepath.Rel(cfg.Build.ContentDir, a.FilePath) work correctly when
+	// article FilePaths are absolute (as set by the file parser).
+	cfg.Build.ContentDir = contentDir
+	cfg.Build.OutputDir = filepath.Join(rootDir, cfg.Build.OutputDir)
 	articles, err := p.ParseAll(contentDir)
 	if err != nil {
 		return fmt.Errorf("parse content: %w", err)
@@ -163,7 +168,7 @@ func runBuild(args []string) error {
 	}
 
 	// Render HTML.
-	outDir := filepath.Join(rootDir, cfg.Build.OutputDir)
+	outDir := cfg.Build.OutputDir
 	templateDir := filepath.Join(rootDir, cfg.Theme.Dir, "templates")
 	tmpl := gohantemplate.NewEngine()
 	if loadErr := tmpl.Load(templateDir, nil); loadErr != nil {


### PR DESCRIPTION
## Problem

When `gohan build` is run from a project directory, `cfg.Build.ContentDir` holds a relative path like `"content"`. The file parser (`FileParser.ParseAll`) is called with an absolute `contentDir` path and sets `article.FilePath` to absolute paths.

This mismatch causes `filepath.Rel(cfg.Build.ContentDir, a.FilePath)` to fail silently in `processor/site.go` functions:

- `detectLocale` → returns `""` for all articles
- `computeOutputPath` → falls back to slug-only path (no locale prefix)
- `computeArticleURL` → returns wrong URL

**Observed symptoms:**
- All articles output to `public/{slug}/index.html` instead of `public/posts/{slug}/` or `public/{locale}/posts/{slug}/`
- `<html lang="">` renders empty
- `hreflang` tags render with empty locale values
- `x-default` points to wrong URL

## Fix

Resolve `cfg.Build.ContentDir` and `cfg.Build.OutputDir` to absolute paths (using the already-computed `contentDir`/`outDir` locals) before passing `cfg` to `proc.Process()`.

```go
cfg.Build.ContentDir = contentDir  // already absolute: filepath.Join(rootDir, cfg.Build.ContentDir)
cfg.Build.OutputDir = filepath.Join(rootDir, cfg.Build.OutputDir)
```

The downstream `outDir` local is then derived from `cfg.Build.OutputDir` directly.

## Tests

Existing tests in `cmd/gohan` use relative paths in fixture configs, so they continue to pass. The processor unit tests (`internal/processor`) also use relative paths in test fixtures and are unaffected.
