### PR TITLE
feat: add ValidateOutputPaths to detect duplicate output paths at build time

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -124,6 +124,14 @@ func runBuild(args []string) error {
 	// Link translations across locales (no-op when i18n is not configured).
 	proc.BuildTranslationMap(processed)
 
+	// Validate that no two articles resolve to the same output path.
+	// Duplicate output paths cause silent page overwrites during HTML generation.
+	if errs := processor.ValidateOutputPaths(processed); len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "warn: output path: %v\n", e)
+		}
+	}
+
 	// Build taxonomy.
 	// If tags.yaml / categories.yaml exist in the content directory they are
 	// treated as the authoritative registry and every article is validated

--- a/internal/processor/taxonomy.go
+++ b/internal/processor/taxonomy.go
@@ -77,6 +77,22 @@ func ValidateArticleTaxonomies(articles []*model.ProcessedArticle, registry *mod
 	return errs
 }
 
+// ValidateOutputPaths checks that no two articles resolve to the same output
+// path, which would cause one page to silently overwrite the other during
+// HTML generation.  It returns one error per duplicate pair.
+func ValidateOutputPaths(articles []*model.ProcessedArticle) []error {
+	seen := make(map[string]string, len(articles)) // OutputPath -> FilePath
+	var errs []error
+	for _, a := range articles {
+		if prev, ok := seen[a.OutputPath]; ok {
+			errs = append(errs, fmt.Errorf("duplicate output path %q: %q and %q", a.OutputPath, prev, a.FilePath))
+		} else {
+			seen[a.OutputPath] = a.FilePath
+		}
+	}
+	return errs
+}
+
 // BuildTagIndex returns a map from tag name to the articles that use that tag.
 func BuildTagIndex(articles []*model.ProcessedArticle) map[string][]*model.ProcessedArticle {
 	idx := make(map[string][]*model.ProcessedArticle)

--- a/internal/processor/taxonomy_test.go
+++ b/internal/processor/taxonomy_test.go
@@ -95,6 +95,40 @@ func TestValidateArticleTaxonomies_UnknownCategory(t *testing.T) {
 	}
 }
 
+func TestValidateOutputPaths_NoDuplicates(t *testing.T) {
+	articles := []*model.ProcessedArticle{
+		{Article: *testArticle("a.md", "", "", nil, nil, time.Time{}), OutputPath: "public/posts/a/index.html"},
+		{Article: *testArticle("b.md", "", "", nil, nil, time.Time{}), OutputPath: "public/posts/b/index.html"},
+	}
+	if errs := ValidateOutputPaths(articles); len(errs) != 0 {
+		t.Errorf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidateOutputPaths_Duplicate(t *testing.T) {
+	articles := []*model.ProcessedArticle{
+		{Article: *testArticle("a.md", "", "", nil, nil, time.Time{}), OutputPath: "public/posts/same/index.html"},
+		{Article: *testArticle("b.md", "", "", nil, nil, time.Time{}), OutputPath: "public/posts/same/index.html"},
+	}
+	errs := ValidateOutputPaths(articles)
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateOutputPaths_MultipleCollisions(t *testing.T) {
+	articles := []*model.ProcessedArticle{
+		{Article: *testArticle("a.md", "", "", nil, nil, time.Time{}), OutputPath: "public/posts/same/index.html"},
+		{Article: *testArticle("b.md", "", "", nil, nil, time.Time{}), OutputPath: "public/posts/same/index.html"},
+		{Article: *testArticle("c.md", "", "", nil, nil, time.Time{}), OutputPath: "public/posts/other/index.html"},
+		{Article: *testArticle("d.md", "", "", nil, nil, time.Time{}), OutputPath: "public/posts/other/index.html"},
+	}
+	errs := ValidateOutputPaths(articles)
+	if len(errs) != 2 {
+		t.Errorf("expected 2 errors, got %d: %v", len(errs), errs)
+	}
+}
+
 func TestBuildTagIndex(t *testing.T) {
 	articles := []*model.ProcessedArticle{
 		{Article: *testArticle("a.md", "", "", []string{"go", "ssg"}, nil, time.Time{})},


### PR DESCRIPTION
## Summary

When two articles resolve to the same `OutputPath`, HTML generation silently overwrites one page with the other. This adds `ValidateOutputPaths()` to detect such collisions during `gohan build` and emit a warning to stderr.

## Problem

Duplicate `OutputPath` collisions can occur when:

- Two source files in different directories share the same filename (e.g. `posts/hello.md`)
- Multiple articles declare the same `slug:` in front matter
- i18n locales produce path conflicts

Previously, all of these cases produced no error or warning — one page would silently disappear from the output.

## Changes

- `internal/processor/taxonomy.go`: add `ValidateOutputPaths(articles []*model.ProcessedArticle) []error`  
  Uses a `seen map[string]string` to detect collisions and returns one error per duplicate pair.
- `internal/processor/taxonomy_test.go`: add 3 test cases (no duplicates / single collision / multiple collisions)
- `cmd/gohan/build.go`: call `ValidateOutputPaths` immediately after `BuildTranslationMap`; print `warn: output path: ...` to stderr for each collision (build continues)

## Behaviour

Follows the same warn-level pattern as `ValidateArticleTaxonomies` — the build is not aborted, but each collision is reported:

```
warn: output path: duplicate output path "public/posts/hello/index.html": "content/posts/hello.md" and "content/en/posts/hello.md"
```

## Tests

```
ok  github.com/bmf-san/gohan/internal/processor  (all pass)
ok  github.com/bmf-san/gohan/cmd/gohan           (all pass)
```