### PR TITLE
revert: undo direct pushes to main (go directive changes)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bmf-san/gohan
 
-go 1.24.0
+go 1.25.3
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bmf-san/gohan
 
-go 1.26.0
+go 1.24.0
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
直接 main に push してしまった以下の2コミットを revert します。

- `9991479` fix: lower go directive to 1.24.0
- `5dbd5f0` chore: update go directive to 1.26.0

これらは PR を経由せず main に直接 push されたため、このPRでリセットします。Go バージョン更新は別途 PR #69 で正しく対応します。