### PR TITLE
chore: update go directive to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bmf-san/gohan
 
-go 1.25.3
+go 1.26.0
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
## 概要

ローカル環境が Go 1.26.0 にアップグレードされたため、`go.mod` の go directive を更新します。

## 変更内容

- `go.mod`: `go 1.25.3` → `go 1.26.0`（`go get go@1.26.0 && go mod tidy`）

## 確認事項

- [x] `go test ./...` 全パス

## 手順

PR #68 を先にマージして main を v0.1.2 の状態に戻した後、このPRをマージし、v0.1.3 タグを切ってください。