### PR TITLE
fix: delete Content-Length before injecting SSE script to fix blank page

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -161,6 +161,10 @@ func (w *injectingResponseWriter) flush() {
 	if !w.isHTML {
 		return
 	}
+	// Remove Content-Length set by http.FileServer: the injected SSE script
+	// makes the actual body larger, so the original value is wrong.
+	// Deleting it lets net/http use chunked transfer encoding instead.
+	w.wrapped.Header().Del("Content-Length")
 	if w.header != 0 {
 		w.wrapped.WriteHeader(w.header)
 	}


### PR DESCRIPTION
## 問題

`gohan serve` でブラウザが真っ白になる。

## 原因

`injectingResponseWriter` は HTML ボディをバッファリングして `</body>` 直前に SSE live-reload `<script>` を注入してからフラッシュする。しかし `http.FileServer` はレスポンスヘッダーに元のファイルサイズを `Content-Length` として既にセットしていた。

`flush()` が `wrapped.WriteHeader()` を呼ぶ時点でその `Content-Length` は注入後の実際のボディより小さくなっており、Go の `net/http` はボディを **0バイト** しか送信しない（Content-Length 不一致の保護動作）。その結果ブラウザはヘッダーだけ受け取り、ボディが届かず真っ白になる。

## 修正

`flush()` 内で `wrapped.Header().Del("Content-Length")` を呼び出してから `WriteHeader()` を実行する。これにより `net/http` が chunked transfer encoding を使って正しいボディを送信する。

## 確認

```
$ curl -v http://localhost:1313/
# Before: transfer closed with 5202 bytes remaining to read (0 bytes received)
# After:  5319 bytes received (5202 original + ~117 bytes SSE script)
```

全サーバーユニットテスト通過確認済み。
