### PR TITLE
feat(sitemap): include locale index pages in sitemap.xml for i18n sites

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -188,7 +188,7 @@ func runBuild(args []string) error {
 	}
 
 	// Sitemap + feeds.
-	if err := generator.GenerateSitemap(outDir, cfg.Site.BaseURL, processed); err != nil {
+	if err := generator.GenerateSitemap(outDir, cfg.Site.BaseURL, processed, *cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: sitemap: %v\n", err)
 	}
 	if err := generator.GenerateFeeds(outDir, cfg.Site.BaseURL, cfg.Site.Title, processed); err != nil {

--- a/internal/generator/sitemap.go
+++ b/internal/generator/sitemap.go
@@ -14,7 +14,9 @@ import (
 // When articles have Translations populated (i18n), xhtml:link hreflang
 // alternates are included for SEO.
 // Articles are sorted newest-first. baseURL must not have a trailing slash.
-func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle) error {
+// When cfg has I18n.Locales configured, the locale index pages (/ and /ja/
+// etc.) are prepended to the sitemap as important entry points.
+func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle, cfg model.Config) error {
 	sorted := make([]*model.ProcessedArticle, len(articles))
 	copy(sorted, articles)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -36,6 +38,21 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle)
 		buf.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">` + "\n")
 	} else {
 		buf.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` + "\n")
+	}
+
+	// Prepend locale index pages (/, /ja/, ...) when i18n is configured.
+	if len(cfg.I18n.Locales) > 0 {
+		for _, loc := range cfg.I18n.Locales {
+			var indexURL string
+			if loc == cfg.I18n.DefaultLocale {
+				indexURL = baseURL + "/"
+			} else {
+				indexURL = baseURL + "/" + loc + "/"
+			}
+			buf.WriteString("  <url>\n")
+			buf.WriteString("    <loc>" + indexURL + "</loc>\n")
+			buf.WriteString("  </url>\n")
+		}
 	}
 
 	for _, a := range sorted {

--- a/internal/generator/sitemap_feed_test.go
+++ b/internal/generator/sitemap_feed_test.go
@@ -22,7 +22,7 @@ func makeArticles() []*model.ProcessedArticle {
 
 func TestGenerateSitemap_Valid(t *testing.T) {
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", makeArticles()); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", makeArticles(), model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -40,7 +40,7 @@ func TestGenerateSitemap_Valid(t *testing.T) {
 
 func TestGenerateSitemap_Empty(t *testing.T) {
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", nil); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", nil, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap empty: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -51,7 +51,7 @@ func TestGenerateSitemap_Empty(t *testing.T) {
 
 func TestGenerateSitemap_WellFormedXML(t *testing.T) {
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", makeArticles()); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", makeArticles(), model.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -137,7 +137,7 @@ func TestGenerateSitemap_HreflangAlternates(t *testing.T) {
 		},
 	}
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", articles); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", articles, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -153,6 +153,24 @@ func TestGenerateSitemap_HreflangAlternates(t *testing.T) {
 	}
 }
 
+func TestGenerateSitemap_I18nIndexPages(t *testing.T) {
+	dir := t.TempDir()
+	cfg := model.Config{}
+	cfg.I18n.DefaultLocale = "en"
+	cfg.I18n.Locales = []string{"en", "ja"}
+	if err := GenerateSitemap(dir, "https://example.com", nil, cfg); err != nil {
+		t.Fatalf("GenerateSitemap: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
+	s := string(data)
+	if !strings.Contains(s, "https://example.com/") {
+		t.Errorf("expected EN index URL https://example.com/ in sitemap:\n%s", s)
+	}
+	if !strings.Contains(s, "https://example.com/ja/") {
+		t.Errorf("expected JA index URL https://example.com/ja/ in sitemap:\n%s", s)
+	}
+}
+
 func TestGenerateSitemap_UsesPrecomputedURL(t *testing.T) {
 	dir := t.TempDir()
 	articles := []*model.ProcessedArticle{
@@ -161,7 +179,7 @@ func TestGenerateSitemap_UsesPrecomputedURL(t *testing.T) {
 			URL:     "/ja/posts/my-url/",
 		},
 	}
-	if err := GenerateSitemap(dir, "https://example.com", articles); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", articles, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))


### PR DESCRIPTION
## Overview

When `i18n.locales` was configured, the sitemap was missing the locale homepage URLs.

**Before:** Article URLs only (e.g. 590 entries)
**After:** Homepage URLs prepended (e.g. 592 entries)

```xml
https://example.com/
https://example.com/ja/
```

## Changes

### `internal/generator/sitemap.go`

- Added `model.Config` argument to `GenerateSitemap`
- When `cfg.I18n.Locales` is configured, prepend each locale's index URL to the sitemap
  - `DefaultLocale` → `baseURL + "/"`
  - Other locales → `baseURL + "/" + locale + "/"`

### `cmd/gohan/build.go`

- Pass `*cfg` to the `GenerateSitemap` call

### `internal/generator/sitemap_feed_test.go`

- Updated existing test arguments to `model.Config{}`
- Added `TestGenerateSitemap_I18nIndexPages`: verifies that `/` and `/ja/` are generated for en/ja locale config