### PR TITLE
fix: use atomic file writes to prevent white-page race in dev server

### DIFF
--- a/internal/generator/atomic.go
+++ b/internal/generator/atomic.go
@@ -1,0 +1,39 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic writes data to path atomically: it creates a temporary file
+// in the same directory, writes the content, then renames it to path.
+//
+// Using os.Rename (which maps to rename(2) on POSIX) is atomic, so the
+// HTTP file-server never reads a partially-written file. Without this,
+// os.WriteFile would truncate the target file to 0 bytes before writing,
+// causing the dev server to serve an empty response and the browser to show
+// a white page during a rebuild.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".gohan-tmp-")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+
+	_, werr := tmp.Write(data)
+	cerr := tmp.Close()
+	if werr != nil {
+		_ = os.Remove(tmpName)
+		return werr
+	}
+	if cerr != nil {
+		_ = os.Remove(tmpName)
+		return cerr
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/generator/atomic_test.go
+++ b/internal/generator/atomic_test.go
@@ -1,0 +1,87 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomic_Basic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.html")
+	data := []byte("<html>hello</html>")
+
+	if err := writeFileAtomic(path, data, 0o644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("content mismatch: got %q, want %q", got, data)
+	}
+}
+
+func TestWriteFileAtomic_Overwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.html")
+
+	// 初回書き込み
+	if err := writeFileAtomic(path, []byte("first"), 0o644); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	// 上書き
+	want := []byte("second")
+	if err := writeFileAtomic(path, want, 0o644); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != string(want) {
+		t.Fatalf("overwrite: got %q, want %q", got, want)
+	}
+}
+
+func TestWriteFileAtomic_NoTempLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.html")
+
+	if err := writeFileAtomic(path, []byte("data"), 0o644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	// 一時ファイル (.gohan-tmp-*) が残っていないこと
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "out.html" {
+			t.Errorf("unexpected file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestWriteFileAtomic_Permissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.html")
+
+	if err := writeFileAtomic(path, []byte("data"), 0o600); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("permissions: got %04o, want %04o", got, 0o600)
+	}
+}
+
+func TestWriteFileAtomic_InvalidDir(t *testing.T) {
+	// 存在しないディレクトリへの書き込みはエラーになること
+	err := writeFileAtomic("/nonexistent-dir/out.html", []byte("data"), 0o644)
+	if err == nil {
+		t.Fatal("expected error for nonexistent dir, got nil")
+	}
+}

--- a/internal/generator/feed.go
+++ b/internal/generator/feed.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"bytes"
 	"encoding/xml"
 	"os"
 	"path/filepath"
@@ -133,18 +134,17 @@ func articleLink(baseURL string, a *model.ProcessedArticle) string {
 }
 
 func writeXML(path string, v interface{}) error {
-	f, err := os.Create(path)
-	if err != nil {
+	var buf bytes.Buffer
+	if _, err := buf.WriteString(xml.Header); err != nil {
 		return err
 	}
-	defer func() { _ = f.Close() }()
-	if _, err := f.WriteString(xml.Header); err != nil {
-		return err
-	}
-	enc := xml.NewEncoder(f)
+	enc := xml.NewEncoder(&buf)
 	enc.Indent("", "  ")
 	if err := enc.Encode(v); err != nil {
 		return err
 	}
-	return enc.Flush()
+	if err := enc.Flush(); err != nil {
+		return err
+	}
+	return writeFileAtomic(path, buf.Bytes(), 0o644)
 }

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -3,7 +3,6 @@ package generator
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -387,7 +386,7 @@ func (g *HTMLGenerator) writePage(path, tmplName string, data *model.Site) error
 	if bytes.Contains(pageBytes, []byte(mermaid.MermaidMarker)) {
 		pageBytes = mermaid.InjectScript(pageBytes)
 	}
-	if err := os.WriteFile(path, pageBytes, 0o644); err != nil {
+	if err := writeFileAtomic(path, pageBytes, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil
@@ -412,18 +411,15 @@ func copyFile(src, dst string) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return err
 	}
-	in, err := os.Open(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = in.Close() }()
-	out, err := os.Create(dst)
+	info, err := os.Stat(src)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = out.Close() }()
-	_, err = io.Copy(out, in)
-	return err
+	return writeFileAtomic(dst, data, info.Mode().Perm())
 }
 
 // slugify converts s to a lowercase hyphen-separated URL slug.

--- a/internal/generator/sitemap.go
+++ b/internal/generator/sitemap.go
@@ -90,5 +90,5 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle,
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(outDir, "sitemap.xml"), []byte(buf.String()), 0o644)
+	return writeFileAtomic(filepath.Join(outDir, "sitemap.xml"), []byte(buf.String()), 0o644)
 }

--- a/internal/model/site.go
+++ b/internal/model/site.go
@@ -18,6 +18,7 @@ type Pagination struct {
 	TotalItems  int
 	PrevURL     string // empty string if no previous page
 	NextURL     string // empty string if no next page
+	BaseURL     string // URL path prefix used to construct PrevURL/NextURL (e.g. "/tags/go")
 }
 
 // FileWatcher is the interface for watching file system changes.


### PR DESCRIPTION
## Problem

When `gohan serve` triggers a rebuild, all file writes used `os.WriteFile` or `os.Create` which **truncate the file to 0 bytes before writing**. If the HTTP server handles a request during that window, it serves an empty HTML file → blank white page in the browser.

```
rebuild start
  → os.WriteFile(public/index.html, ...)
       ↑ truncate to 0 bytes  ← browser GET hits here → 200 OK with 0 bytes → white page
       ↑ write content...
rebuild done
```

## Fix

Added `writeFileAtomic()` helper in `internal/generator/atomic.go` that:

1. Creates a temp file in the **same directory** as the target (ensures same filesystem for atomic rename)
2. Writes all content to the temp file
3. Sets correct permissions
4. Calls `os.Rename(tmp, target)` — a single atomic syscall (`rename(2)`)

The HTTP server now always sees either the **old complete file** or the **new complete file**. The 0-byte window is eliminated.

## Changes

- `internal/generator/atomic.go` — new `writeFileAtomic()` helper
- `internal/generator/html.go` — `writePage()` and `copyFile()` converted to atomic writes
- `internal/generator/feed.go` — `writeXML()` converted to atomic write
- `internal/generator/sitemap.go` — `GenerateSitemap()` converted to atomic write

## Testing

All existing tests pass: `go test ./...`
