### PR TITLE
fix: debounce watchLoop to prevent rapid-reload white page

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
@@ -287,11 +288,38 @@ func (s *DevServer) Start() error {
 }
 
 // watchLoop listens for file change events and triggers rebuild + SSE broadcast.
+// Events within debounceDelay are coalesced into a single rebuild to avoid
+// multiple rapid reloads when an editor emits several write/rename events for
+// one logical save.
+const debounceDelay = 100 * time.Millisecond
+
 func (s *DevServer) watchLoop(b *sseBroadcaster) {
-	for path := range s.Watcher.Events() {
-		if s.RebuildFunc != nil {
-			_ = s.RebuildFunc() // best-effort; errors go to stderr via rebuild
+	var pending string
+	timer := time.NewTimer(0)
+	<-timer.C // drain the initial tick so it doesn't fire immediately
+	for {
+		select {
+		case path, ok := <-s.Watcher.Events():
+			if !ok {
+				return
+			}
+			pending = path
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(debounceDelay)
+		case <-timer.C:
+			if pending == "" {
+				continue
+			}
+			if s.RebuildFunc != nil {
+				_ = s.RebuildFunc() // best-effort; errors go to stderr via rebuild
+			}
+			b.broadcast(pending)
+			pending = ""
 		}
-		b.broadcast(path)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -122,3 +122,54 @@ func TestInjectingResponseWriter_Buffer(t *testing.T) {
 		t.Error("expected SSE script in flushed response")
 	}
 }
+
+// mockWatcher is a FileWatcher stub for testing.
+type mockWatcher struct {
+	events chan string
+}
+
+func (m *mockWatcher) Add(_ string) error    { return nil }
+func (m *mockWatcher) Events() <-chan string  { return m.events }
+func (m *mockWatcher) Close() error          { close(m.events); return nil }
+
+func TestWatchLoop_Debounce(t *testing.T) {
+	// Verify that multiple rapid events are coalesced into a single rebuild.
+	watcher := &mockWatcher{events: make(chan string, 20)}
+
+	rebuildCount := 0
+	broadcastCount := 0
+
+	b := newSSEBroadcaster()
+	ch := b.subscribe()
+	go func() {
+		for range ch {
+			broadcastCount++
+		}
+	}()
+
+	srv := &DevServer{
+		Watcher: watcher,
+		RebuildFunc: func() error {
+			rebuildCount++
+			return nil
+		},
+	}
+
+	go srv.watchLoop(b)
+
+	// Send 5 events in rapid succession (well within debounce window).
+	for i := 0; i < 5; i++ {
+		watcher.events <- "content/post.md"
+	}
+
+	// Wait longer than the debounce delay for the single rebuild to complete.
+	time.Sleep(debounceDelay*3 + 50*time.Millisecond)
+
+	if rebuildCount != 1 {
+		t.Errorf("expected 1 rebuild, got %d (debounce not working)", rebuildCount)
+	}
+	if broadcastCount != 1 {
+		t.Errorf("expected 1 broadcast, got %d", broadcastCount)
+	}
+	b.unsubscribe(ch)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -136,21 +137,21 @@ func TestWatchLoop_Debounce(t *testing.T) {
 	// Verify that multiple rapid events are coalesced into a single rebuild.
 	watcher := &mockWatcher{events: make(chan string, 20)}
 
-	rebuildCount := 0
-	broadcastCount := 0
+	var rebuildCount atomic.Int32
+	var broadcastCount atomic.Int32
 
 	b := newSSEBroadcaster()
 	ch := b.subscribe()
 	go func() {
 		for range ch {
-			broadcastCount++
+			broadcastCount.Add(1)
 		}
 	}()
 
 	srv := &DevServer{
 		Watcher: watcher,
 		RebuildFunc: func() error {
-			rebuildCount++
+			rebuildCount.Add(1)
 			return nil
 		},
 	}
@@ -165,11 +166,11 @@ func TestWatchLoop_Debounce(t *testing.T) {
 	// Wait longer than the debounce delay for the single rebuild to complete.
 	time.Sleep(debounceDelay*3 + 50*time.Millisecond)
 
-	if rebuildCount != 1 {
-		t.Errorf("expected 1 rebuild, got %d (debounce not working)", rebuildCount)
+	if got := rebuildCount.Load(); got != 1 {
+		t.Errorf("expected 1 rebuild, got %d (debounce not working)", got)
 	}
-	if broadcastCount != 1 {
-		t.Errorf("expected 1 broadcast, got %d", broadcastCount)
+	if got := broadcastCount.Load(); got != 1 {
+		t.Errorf("expected 1 broadcast, got %d", got)
 	}
 	b.unsubscribe(ch)
 }


### PR DESCRIPTION
## Problem

When an editor saves a file it emits several fsnotify events in rapid succession (write → chmod → rename/create depending on the editor).  The old `watchLoop` processed **every** event sequentially, triggering a full rebuild + SSE broadcast each time:

```
save file
  → event 1 → rebuild → broadcast → browser reload
  → event 2 → rebuild → broadcast → browser reload  ← page still loading!
  → event 3 → rebuild → broadcast → browser reload  ← page blank again
```

Each `location.reload()` cancelled the previous in-flight request, leaving the browser on a blank/white page until the last reload settled.

## Fix

Add a **100 ms debounce** in `watchLoop`.  Events that arrive within the window are coalesced — only a single rebuild + SSE broadcast fires per logical save:

```
save file
  → event 1  ┐
  → event 2  ├─ debounce 100 ms → rebuild → broadcast → browser reload (once)
  → event 3  ┘
```

## Changes

- `internal/server/server.go` — replace the bare `for range` loop with a `select`-based debounce timer (`debounceDelay = 100 ms`)
- `internal/server/server_test.go` — add `TestWatchLoop_Debounce` that sends 5 rapid events and asserts exactly 1 rebuild and 1 broadcast