### PR TITLE
feat: add year-level archive pages and pagination template functions

### DIFF
--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -267,6 +267,28 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 		})
 	}
 
+	// Year-level archive pages: public/archives/<year>/index.html
+	yearArchives := map[int][]*model.ProcessedArticle{}
+	for _, a := range site.Articles {
+		if a.FrontMatter.Date.IsZero() {
+			continue
+		}
+		yearArchives[a.FrontMatter.Date.Year()] = append(yearArchives[a.FrontMatter.Date.Year()], a)
+	}
+	for year, articles := range yearArchives {
+		as := make([]*model.ProcessedArticle, len(articles))
+		copy(as, articles)
+		sortByDateDesc(as)
+		y := year
+		jobs = append(jobs, writeJob{
+			path: filepath.Join(g.outDir, "archives",
+				fmt.Sprintf("%04d", y),
+				"index.html"),
+			tmpl: "archive.html",
+			data: siteFor(site, as),
+		})
+	}
+
 	return jobs
 }
 

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -53,7 +53,8 @@ func TestGenerate_WritesExpectedFiles(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 	for _, rel := range []string{"index.html", "posts/hello-world/index.html",
-		"tags/go/index.html", "categories/tech/index.html", "archives/2024/03/index.html"} {
+		"tags/go/index.html", "categories/tech/index.html", "archives/2024/03/index.html",
+		"archives/2024/index.html"} {
 		if _, err := os.Stat(filepath.Join(outDir, rel)); err != nil {
 			t.Errorf("missing %s: %v", rel, err)
 		}
@@ -384,6 +385,10 @@ func TestGenerate_SkipsDateZeroArchive(t *testing.T) {
 	badArchive := filepath.Join(outDir, "archives", "0001", "01")
 	if _, err := os.Stat(badArchive); err == nil {
 		t.Errorf("archives/0001/01 should NOT be created for date-zero articles")
+	}
+	badYearArchive := filepath.Join(outDir, "archives", "0001")
+	if _, err := os.Stat(badYearArchive); err == nil {
+		t.Errorf("archives/0001 should NOT be created for date-zero articles")
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -130,7 +130,7 @@ type mockWatcher struct {
 }
 
 func (m *mockWatcher) Add(_ string) error    { return nil }
-func (m *mockWatcher) Events() <-chan string  { return m.events }
+func (m *mockWatcher) Events() <-chan string { return m.events }
 func (m *mockWatcher) Close() error          { close(m.events); return nil }
 
 func TestWatchLoop_Debounce(t *testing.T) {

--- a/internal/template/template_engine.go
+++ b/internal/template/template_engine.go
@@ -92,6 +92,40 @@ func builtinFuncs() template.FuncMap {
 		"markdownify": func(s string) (template.HTML, error) {
 			return conv.Convert([]byte(s))
 		},
+		// paginationPages returns a slice of page numbers (and -1 for ellipsis)
+		// suitable for rendering a pagination control. For example, for
+		// current=5 total=10 it returns [1 -1 4 5 6 -1 10].
+		"paginationPages": func(current, total int) []int {
+			if total <= 1 {
+				return nil
+			}
+			pages := []int{}
+			addPage := func(p int) {
+				if len(pages) > 0 && pages[len(pages)-1] == -1 && p == -1 {
+					return
+				}
+				pages = append(pages, p)
+			}
+			for p := 1; p <= total; p++ {
+				if p == 1 || p == total || (p >= current-2 && p <= current+2) {
+					addPage(p)
+				} else if len(pages) > 0 && pages[len(pages)-1] != -1 {
+					addPage(-1) // ellipsis
+				}
+			}
+			return pages
+		},
+		// pageURL returns the URL for page number p within a base URL path.
+		// Page 1 returns baseURL+"/" (or "/" when baseURL is empty).
+		"pageURL": func(baseURL string, p int) string {
+			if p <= 1 {
+				if baseURL == "" {
+					return "/"
+				}
+				return baseURL + "/"
+			}
+			return fmt.Sprintf("%s/page/%d/", baseURL, p)
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Generate `public/archives/<year>/index.html` for each year that has articles (previously only `public/archives/<year>/<month>/index.html` was generated)
- Add `paginationPages(current, total int) []int` builtin template function that returns page numbers with `-1` as ellipsis placeholder
- Add `pageURL(baseURL string, page int) string` builtin template function for constructing pagination links

## Motivation

The `/archives/{year}/` pages were unstyled (returning 404 or empty) because gohan only generated month-level archive pages. Year-level pages were linked from the site but never generated.

The `paginationPages` and `pageURL` template functions are required by the pagination partial in bmf-tech's theme template.

## Changes

- `internal/generator/html.go`: add year-level archive page generation loop
- `internal/generator/html_test.go`: add `archives/2024/index.html` to expected files; add zero-date check for year path
- `internal/template/template_engine.go`: add `paginationPages` and `pageURL` to `builtinFuncs`