### PR TITLE
fix: add tests for concurrent build lock; fix errcheck lint

### DIFF
--- a/cmd/gohan/build_test.go
+++ b/cmd/gohan/build_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -128,5 +129,38 @@ func TestRunBuild_DraftArticlesExcludedByDefault(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("build with draft article: %v", err)
+	}
+}
+
+// TestRunBuild_ConcurrentBuildSkipped verifies that when another process already
+// holds the exclusive build lock, runBuild returns nil immediately (skips).
+func TestRunBuild_ConcurrentBuildSkipped(t *testing.T) {
+	dir := t.TempDir()
+	cfg := []byte("site:\n  title: Test\n  base_url: http://localhost\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), cfg, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-acquire the exclusive lock that runBuild will try to obtain.
+	lockDir := filepath.Join(dir, ".gohan")
+	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lockFile, err := os.OpenFile(filepath.Join(lockDir, "build.lock"), os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lockFile.Close() }()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("could not acquire pre-lock: %v", err)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
+
+	// runBuild should detect the held lock and skip without error.
+	if err := runBuild([]string{"--config=" + filepath.Join(dir, "config.yaml")}); err != nil {
+		t.Fatalf("expected nil when lock held, got: %v", err)
 	}
 }

--- a/cmd/gohan/serve_test.go
+++ b/cmd/gohan/serve_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -21,5 +23,30 @@ func TestRunServe_DefaultFlagsAccepted(t *testing.T) {
 	err := runServe([]string{"--port=19999", "--host=127.0.0.1", "--unknown"})
 	if err == nil {
 		t.Fatal("expected parse error")
+	}
+}
+
+// TestRunServe_InvalidHostFails exercises the post-parse code path:
+// initial build (with missing config, non-fatal), then srv.Start() which
+// returns an error because the host string is invalid.
+func TestRunServe_InvalidHostFails(t *testing.T) {
+	dir := t.TempDir()
+	// Write a minimal config so runBuild doesn't error on missing file.
+	cfg := []byte("site:\n  title: Test\n  base_url: http://localhost\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), cfg, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// "invalid host" causes net.Listen to fail immediately, so srv.Start() returns an error.
+	err := runServe([]string{
+		"--config=" + filepath.Join(dir, "config.yaml"),
+		"--host=256.256.256.256",
+		"--port=19876",
+	})
+	if err == nil {
+		t.Fatal("expected error from srv.Start() with invalid host")
 	}
 }


### PR DESCRIPTION
## Summary

The concurrent build flock commit (`03acbce`) was pushed directly to `main` without tests, causing the CI coverage check to drop from ~80% to 79.6% (below the 80% threshold). This PR restores coverage to 80.6% and fixes a lint error introduced in the test.

## Changes

- **`cmd/gohan/build_test.go`**: `TestRunBuild_ConcurrentBuildSkipped`
  Pre-acquires `LOCK_EX` on `.gohan/build.lock`, then calls `runBuild` and verifies it returns `nil` (skip path).
- **`cmd/gohan/serve_test.go`**: `TestRunServe_InvalidHostFails`
  Passes an invalid host (`256.256.256.256`) to `runServe` to exercise the post-parse code path; expects `srv.Start()` to return an error.
- **Lint fix**: `defer lockFile.Close()` → `defer func() { _ = lockFile.Close() }()` to satisfy `errcheck`.

## Coverage

| Before | After |
|--------|-------|
| 79.6%  | 80.6% |

Threshold: 80%