### PR TITLE
fix: detect HTML Content-Type in Write when WriteHeader was not called

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -153,6 +153,13 @@ func (w *injectingResponseWriter) WriteHeader(code int) {
 }
 
 func (w *injectingResponseWriter) Write(b []byte) (int, error) {
+	// http.FileServer may call Write without calling WriteHeader first (implicit
+	// 200). Detect HTML from Content-Type at first Write if not yet determined.
+	if w.header == 0 {
+		ct := w.Header().Get("Content-Type")
+		w.isHTML = strings.Contains(ct, "text/html")
+		w.header = http.StatusOK
+	}
 	if !w.isHTML {
 		// Propagate non-200 status codes (e.g. 404) that were stored by
 		// WriteHeader but not yet forwarded to the underlying ResponseWriter.


### PR DESCRIPTION
## Problem

`injectingResponseWriter` failed to buffer HTML responses when `http.FileServer` called `Write` without first calling `WriteHeader` (which is the default behavior for 200 OK responses).

In that case `isHTML` remained `false`, so the HTML was written directly to the underlying `ResponseWriter` instead of being buffered — meaning the SSE reload script was never injected and the `Content-Length` header was never removed. This caused the page to appear blank on reload in the dev server.

## Root Cause

```go
func (w *injectingResponseWriter) WriteHeader(code int) {
    ct := w.Header().Get("Content-Type")
    w.isHTML = strings.Contains(ct, "text/html") // never called for 200 OK
    w.header = code
}
```

`http.FileServer` only calls `WriteHeader` for non-200 status codes. For 200 OK it calls `Write` directly, so `isHTML` was never set to `true`.

## Fix

Check `Content-Type` at the first `Write` call if `WriteHeader` has not been called yet (`w.header == 0`).

```go
func (w *injectingResponseWriter) Write(b []byte) (int, error) {
    if w.header == 0 {
        ct := w.Header().Get("Content-Type")
        w.isHTML = strings.Contains(ct, "text/html")
        w.header = http.StatusOK
    }
    ...
}
```