### PR TITLE
fix: forward non-200 status code in flush when Write is never called (304 blank page on reload)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -175,6 +175,13 @@ func (w *injectingResponseWriter) Write(b []byte) (int, error) {
 
 func (w *injectingResponseWriter) flush() {
 	if !w.isHTML {
+		// Forward any stored status code that was never written to the underlying
+		// ResponseWriter (e.g. 304 Not Modified, where Write is never called).
+		// Without this, Go's net/http falls back to an implicit 200 OK with an
+		// empty body, causing the browser to show a blank page on reload.
+		if !w.headerWritten && w.header != 0 && w.header != http.StatusOK {
+			w.wrapped.WriteHeader(w.header)
+		}
 		return
 	}
 	// Remove Content-Length set by http.FileServer: the injected SSE script


### PR DESCRIPTION
## Problem

When the browser reloads a page, it sends a conditional request (`If-Modified-Since` or `If-None-Match`). `http.FileServer` responds with **304 Not Modified** and calls `WriteHeader(304)` — but never calls `Write` (since 304 has no body).

In `injectingResponseWriter`, when `WriteHeader(304)` is called:
- `isHTML = false` (Content-Type is not set for 304 responses)
- `header = 304` is stored

Then in `flush()`:
```go
if !w.isHTML {
    return  // early return — 304 is never forwarded!
}
```

Since `flush()` returns early without calling `w.wrapped.WriteHeader(304)`, Go's `net/http` falls back to an **implicit `200 OK` with an empty body**. The browser receives `200 OK + Content-Length: 0` and renders a blank page.

## Root Cause

`flush()` only forwarded the status code through the HTML injection path. Non-HTML responses where `Write` was never called (e.g. 304, 204) had no path to forward the stored status code.

## Fix

Forward any stored non-200 status code in `flush()` before returning early:

```go
func (w *injectingResponseWriter) flush() {
    if !w.isHTML {
        if !w.headerWritten && w.header != 0 && w.header != http.StatusOK {
            w.wrapped.WriteHeader(w.header)
        }
        return
    }
    ...
}
```

## Verification

Before fix:
```
$ curl -D - -H "If-Modified-Since: <last-modified value>" http://localhost:1313/about/
HTTP/1.1 200 OK
Content-Length: 0         ← blank page
```

After fix:
```
$ curl -D - -H "If-Modified-Since: <last-modified value>" http://localhost:1313/about/
HTTP/1.1 304 Not Modified ← correct
```