### PR TITLE
release: v1.0.0 bug fixes

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -46,11 +46,17 @@ func runBuild(args []string) error {
 	// exclusive non-blocking flock on .gohan/build.lock.  If the lock is
 	// already held by another process we print a notice and skip this run
 	// so that public/ is never written by two processes at once.
-	lockDir := filepath.Join(rootDir, ".gohan")
-	_ = os.MkdirAll(lockDir, 0o755)
-	lockPath := filepath.Join(lockDir, "build.lock")
+	gohanDir := filepath.Join(rootDir, ".gohan")
+	// Print .gitignore hint on first run (before creating the directory).
+	if _, statErr := os.Stat(gohanDir); os.IsNotExist(statErr) {
+		fmt.Println("hint: add '.gohan/' to your .gitignore to exclude build cache")
+	}
+	_ = os.MkdirAll(gohanDir, 0o755)
+	lockPath := filepath.Join(gohanDir, "build.lock")
 	lockFile, lockErr := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0o644)
-	if lockErr == nil {
+	if lockErr != nil {
+		fmt.Fprintf(os.Stderr, "warn: build lock unavailable (%v); concurrent builds are not protected\n", lockErr)
+	} else {
 		if flockErr := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr != nil {
 			_ = lockFile.Close()
 			fmt.Println("build: another build is already running — skipping")
@@ -76,15 +82,9 @@ func runBuild(args []string) error {
 
 	cacheDir := filepath.Join(rootDir, ".gohan", "cache")
 
-	// Print .gitignore hint on first run.
-	gohanDir := filepath.Join(rootDir, ".gohan")
-	if _, statErr := os.Stat(gohanDir); os.IsNotExist(statErr) {
-		fmt.Println("hint: add '.gohan/' to your .gitignore to exclude build cache")
-	}
-
 	// Hash config for cache invalidation.
 	cfgHasher := diff.NewGitDiffEngine(rootDir)
-	configHash, _ := cfgHasher.Hash(cfgAbs)
+	configHash, configHashErr := cfgHasher.Hash(cfgAbs)
 
 	// Load manifest.
 	manifest, err := diff.ReadManifest(cacheDir)
@@ -92,8 +92,9 @@ func runBuild(args []string) error {
 		return fmt.Errorf("read manifest: %w", err)
 	}
 
-	// Full build when: --full flag, config changed, or no manifest yet.
-	forceFullBuild := *full || diff.CheckConfigChange(manifest, configHash)
+	// Full build when: --full flag, config hashing failed, config changed, or no manifest yet.
+	// If we cannot hash the config, we must assume it has changed to avoid stale output.
+	forceFullBuild := *full || configHashErr != nil || diff.CheckConfigChange(manifest, configHash)
 	if forceFullBuild && manifest != nil {
 		if clearErr := diff.ClearCache(cacheDir); clearErr != nil {
 			return fmt.Errorf("clear cache: %w", clearErr)
@@ -109,6 +110,7 @@ func runBuild(args []string) error {
 	// article FilePaths are absolute (as set by the file parser).
 	cfg.Build.ContentDir = contentDir
 	cfg.Build.OutputDir = filepath.Join(rootDir, cfg.Build.OutputDir)
+	cfg.Build.AssetsDir = filepath.Join(rootDir, cfg.Build.AssetsDir)
 	articles, err := p.ParseAll(contentDir)
 	if err != nil {
 		return fmt.Errorf("parse content: %w", err)
@@ -214,12 +216,6 @@ func runBuild(args []string) error {
 	}
 	if err := generator.GenerateFeeds(outDir, cfg.Site.BaseURL, cfg.Site.Title, processed); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: feeds: %v\n", err)
-	}
-
-	// Copy assets.
-	assetsDir := filepath.Join(rootDir, cfg.Build.AssetsDir)
-	if err := generator.CopyAssets(assetsDir, outDir); err != nil {
-		fmt.Fprintf(os.Stderr, "warn: copy assets: %v\n", err)
 	}
 
 	// Update manifest.

--- a/cmd/gohan/new.go
+++ b/cmd/gohan/new.go
@@ -23,9 +23,9 @@ func runNew(args []string) error {
 	}
 	slug := fs.Arg(0)
 
-	// Validate slug: no path separators, no spaces
-	if strings.ContainsAny(slug, "/\\") {
-		return fmt.Errorf("slug must not contain path separators: %q", slug)
+	// Validate slug: no path separators, no whitespace
+	if strings.ContainsAny(slug, "/\\ \t") {
+		return fmt.Errorf("slug must not contain path separators or whitespace: %q", slug)
 	}
 
 	// Determine directory

--- a/cmd/gohan/serve.go
+++ b/cmd/gohan/serve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/bmf-san/gohan/internal/config"
 	"github.com/bmf-san/gohan/internal/server"
 )
 
@@ -25,9 +26,18 @@ func runServe(args []string) error {
 		fmt.Printf("serve: initial build warning: %v\n", err)
 	}
 
-	// Determine output directory from config (best-effort; fallback to "public")
-	rootDir := filepath.Dir(*configPath)
+	// Determine project root and output directory from config.
+	cfgAbs, err := filepath.Abs(*configPath)
+	if err != nil {
+		return fmt.Errorf("resolve config path: %w", err)
+	}
+	rootDir := filepath.Dir(cfgAbs)
+
+	// Load config to get the actual output directory; fall back to "public".
 	outDir := filepath.Join(rootDir, "public")
+	if cfg, cfgErr := config.New(rootDir).Load(); cfgErr == nil {
+		outDir = filepath.Join(rootDir, cfg.Build.OutputDir)
+	}
 
 	// rebuildFn triggers a differential build on file change
 	rebuildFn := func() error {
@@ -35,6 +45,7 @@ func runServe(args []string) error {
 	}
 
 	srv := server.NewDevServer(*host, *port, outDir, rebuildFn)
+	srv.RootDir = rootDir // resolve watch dirs relative to project root (M-6)
 	fmt.Printf("serve: listening on http://%s:%d\n", *host, *port)
 	return srv.Start()
 }

--- a/docs/guide/cli.ja.md
+++ b/docs/guide/cli.ja.md
@@ -11,8 +11,8 @@
 | `gohan build` | サイトをビルド（デフォルトで差分ビルド） |
 | `gohan build --full` | フルビルドを強制実行 |
 | `gohan build --dry-run` | ファイルを書き出さずにビルドをシミュレート |
-| `gohan new post --slug=<s> --title=<t>` | 新規記事スケルトンを作成 |
-| `gohan new page --slug=<s> --title=<t>` | 新規ページスケルトンを作成 |
+| `gohan new [--type=post] [--title=<t>] <slug>` | 新規記事スケルトンを作成 |
+| `gohan new --type=page [--title=<t>] <slug>` | 新規ページスケルトンを作成 |
 | `gohan serve` | ライブリロード付き開発サーバーを起動 |
 | `gohan version` | バージョン情報を表示 |
 
@@ -37,12 +37,19 @@
 
 Front Matter が事前入力されたコンテンツスケルトンを作成します。
 
-**サブコマンド**
+**フラグ**
 
-| サブコマンド | 説明 |
+| フラグ | 説明 |
 |---|---|
-| `gohan new post --slug=<s> [--title=<t>]` | `content/posts/<slug>.md` を作成 |
-| `gohan new page --slug=<s> [--title=<t>]` | `content/pages/<slug>.md` を作成 |
+| `--type` | コンテンツタイプ: `post`（デフォルト）または `page` |
+| `--title` | 記事タイトル（省略時はスラッグをタイトルケースに変換） |
+
+**使用例**
+
+| 使用例 | 説明 |
+|---|---|
+| `gohan new [--type=post] [--title=<t>] <slug>` | `content/posts/<slug>.md` を作成 |
+| `gohan new --type=page [--title=<t>] <slug>` | `content/pages/<slug>.md` を作成 |
 
 `--title` を省略した場合、スラッグからタイトルが自動生成されます（例: `my-post` → `My Post`）。
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -11,8 +11,8 @@
 | `gohan build` | Build the site (incremental by default) |
 | `gohan build --full` | Force a full rebuild |
 | `gohan build --dry-run` | Simulate a build without writing files |
-| `gohan new post --slug=<s> --title=<t>` | Create a new post skeleton |
-| `gohan new page --slug=<s> --title=<t>` | Create a new page skeleton |
+| `gohan new [--type=post] [--title=<t>] <slug>` | Create a new post skeleton |
+| `gohan new --type=page [--title=<t>] <slug>` | Create a new page skeleton |
 | `gohan serve` | Start the live-reload development server |
 | `gohan version` | Print version information |
 
@@ -37,12 +37,19 @@ By default, only files that have changed since the last build are regenerated (i
 
 Creates a new content skeleton with pre-filled Front Matter.
 
-**Subcommands**
+**Flags**
 
-| Subcommand | Description |
+| Flag | Description |
 |---|---|
-| `gohan new post --slug=<s> [--title=<t>]` | Create `content/posts/<slug>.md` |
-| `gohan new page --slug=<s> [--title=<t>]` | Create `content/pages/<slug>.md` |
+| `--type` | Content type: `post` (default) or `page` |
+| `--title` | Article title (defaults to slug converted to title case) |
+
+**Usage**
+
+| Usage | Description |
+|---|---|
+| `gohan new [--type=post] [--title=<t>] <slug>` | Create `content/posts/<slug>.md` |
+| `gohan new --type=page [--title=<t>] <slug>` | Create `content/pages/<slug>.md` |
 
 If `--title` is omitted, gohan derives a title from the slug (e.g. `my-post` → `My Post`).
 

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -62,10 +63,14 @@ func (g *HTMLGenerator) Generate(site *model.Site, changeSet *model.ChangeSet) e
 	wg.Wait()
 	close(errc)
 
+	var errs []error
 	for err := range errc {
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	if g.cfg.Build.AssetsDir != "" {
@@ -155,11 +160,11 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 				sortByDateDesc(filtered)
 				var basePath, baseURLPath string
 				if locale == g.cfg.I18n.DefaultLocale {
-					basePath = filepath.Join("tags", t.Name)
-					baseURLPath = "/tags/" + t.Name
+					basePath = filepath.Join("tags", tagNorm(t.Name))
+					baseURLPath = "/tags/" + tagNorm(t.Name)
 				} else {
-					basePath = filepath.Join(locale, "tags", t.Name)
-					baseURLPath = "/" + locale + "/tags/" + t.Name
+					basePath = filepath.Join(locale, "tags", tagNorm(t.Name))
+					baseURLPath = "/" + locale + "/tags/" + tagNorm(t.Name)
 				}
 				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, locale)...)
 			}
@@ -179,8 +184,8 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 				continue
 			}
 			sortByDateDesc(filtered)
-			basePath := filepath.Join("tags", t.Name)
-			baseURLPath := "/tags/" + t.Name
+			basePath := filepath.Join("tags", tagNorm(t.Name))
+			baseURLPath := "/tags/" + tagNorm(t.Name)
 			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, "")...)
 		}
 	}
@@ -208,11 +213,11 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 				sortByDateDesc(filtered)
 				var basePath, baseURLPath string
 				if locale == g.cfg.I18n.DefaultLocale {
-					basePath = filepath.Join("categories", c.Name)
-					baseURLPath = "/categories/" + c.Name
+					basePath = filepath.Join("categories", tagNorm(c.Name))
+					baseURLPath = "/categories/" + tagNorm(c.Name)
 				} else {
-					basePath = filepath.Join(locale, "categories", c.Name)
-					baseURLPath = "/" + locale + "/categories/" + c.Name
+					basePath = filepath.Join(locale, "categories", tagNorm(c.Name))
+					baseURLPath = "/" + locale + "/categories/" + tagNorm(c.Name)
 				}
 				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, locale)...)
 			}
@@ -232,8 +237,8 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 				continue
 			}
 			sortByDateDesc(filtered)
-			basePath := filepath.Join("categories", c.Name)
-			baseURLPath := "/categories/" + c.Name
+			basePath := filepath.Join("categories", tagNorm(c.Name))
+			baseURLPath := "/categories/" + tagNorm(c.Name)
 			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, "")...)
 		}
 	}
@@ -445,6 +450,9 @@ func copyFile(src, dst string) error {
 }
 
 // slugify converts s to a lowercase hyphen-separated URL slug.
+// Only ASCII letters, digits, and hyphens are kept; spaces and underscores
+// become hyphens. Returns "untitled" when the input produces an empty result
+// (e.g. all non-ASCII characters with no slug in front-matter).
 func slugify(s string) string {
 	var out []byte
 	for i := 0; i < len(s); i++ {
@@ -458,7 +466,29 @@ func slugify(s string) string {
 			out = append(out, c)
 		}
 	}
+	if len(out) == 0 {
+		return "untitled"
+	}
 	return string(out)
+}
+
+// tagNorm normalises a tag or category name for use in URL paths and
+// filesystem directories. ASCII letters are lowercased and spaces become
+// hyphens; non-ASCII characters (e.g. Japanese) are left intact.
+// This keeps tagNorm consistent with the tagURL / categoryURL template helpers.
+func tagNorm(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + 32)
+		case r == ' ':
+			b.WriteByte('-')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // siteFor creates a site copy with a custom article list.

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -112,9 +112,24 @@ func TestSlugify(t *testing.T) {
 	for _, c := range []struct{ in, want string }{
 		{"Hello World", "hello-world"}, {"My Post", "my-post"},
 		{"already-fine", "already-fine"}, {"CamelCase", "camelcase"},
+		{"", "untitled"}, {"コードレビュー", "untitled"}, // non-ASCII → "untitled" fallback
 	} {
 		if got := slugify(c.in); got != c.want {
 			t.Errorf("slugify(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTagNorm(t *testing.T) {
+	for _, c := range []struct{ in, want string }{
+		{"Go Programming", "go-programming"},
+		{"コードレビュー", "コードレビュー"},
+		{"Machine Learning", "machine-learning"},
+		{"already-fine", "already-fine"},
+		{"CamelCase", "camelcase"},
+	} {
+		if got := tagNorm(c.in); got != c.want {
+			t.Errorf("tagNorm(%q) = %q, want %q", c.in, got, c.want)
 		}
 	}
 }

--- a/internal/plugin/amazonbooks/amazonbooks.go
+++ b/internal/plugin/amazonbooks/amazonbooks.go
@@ -28,6 +28,7 @@ package amazonbooks
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/bmf-san/gohan/internal/model"
 )
@@ -105,7 +106,7 @@ func (a *AmazonBooks) TemplateData(article *model.ProcessedArticle, cfg map[stri
 			ASIN:     asin,
 			Title:    title,
 			ImageURL: fmt.Sprintf(imageURLTemplate, asin),
-			LinkURL:  fmt.Sprintf(linkURLTemplate, asin, tag),
+			LinkURL:  fmt.Sprintf(linkURLTemplate, asin, url.QueryEscape(tag)),
 		})
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -63,10 +65,11 @@ func (fw *FsnotifyWatcher) loop() {
 				default: // drop if buffer full
 				}
 			}
-		case _, ok := <-fw.watcher.Errors:
+		case err, ok := <-fw.watcher.Errors:
 			if !ok {
 				return
 			}
+			fmt.Fprintf(os.Stderr, "warn: file watcher: %v\n", err)
 		case <-fw.done:
 			return
 		}
@@ -224,6 +227,7 @@ type DevServer struct {
 	Host        string
 	Port        int
 	OutDir      string
+	RootDir     string // project root; WatchDirs are resolved relative to this when set
 	Watcher     FileWatcher
 	RebuildFunc func() error // called on file change; may be nil
 }
@@ -292,7 +296,13 @@ func (s *DevServer) Start() error {
 	}
 	if s.Watcher != nil {
 		for _, dir := range WatchDirs {
-			_ = s.Watcher.Add(dir) // ignore missing dirs
+			path := dir
+			if s.RootDir != "" {
+				path = filepath.Join(s.RootDir, dir)
+			}
+			if err := s.Watcher.Add(path); err != nil {
+				fmt.Fprintf(os.Stderr, "warn: watch %s: %v\n", path, err)
+			}
 		}
 		go s.watchLoop(broadcaster)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -21,6 +21,9 @@ func TestNewDevServer(t *testing.T) {
 	if srv.OutDir != "public" {
 		t.Errorf("expected outDir public, got %s", srv.OutDir)
 	}
+	if srv.RootDir != "" {
+		t.Errorf("expected empty RootDir by default, got %s", srv.RootDir)
+	}
 }
 
 func TestSSEBroadcaster(t *testing.T) {


### PR DESCRIPTION
## Summary

Bug fixes for the v1.0.0 release, addressing issues identified during code review.

## Changes

### `cmd/gohan/build.go`
- **H-2**: Capture `configHashErr` properly (was silently ignored)
- **H-3**: Make `AssetsDir` absolute path; remove flat copy logic
- **H-5**: Show `.gitignore` hint before `MkdirAll`
- **L-7**: Add lock file warning message

### `cmd/gohan/new.go`
- **H-4**: Slug validation now includes space/tab check (`strings.ContainsAny`)

### `cmd/gohan/serve.go`
- Load config for `output_dir`; pass `RootDir` to `DevServer`

### `internal/generator/html.go`
- **M-4**: Use `errors.Join` for multi-error aggregation
- **M-7**: Add `tagNorm()` helper for consistent tag normalization
- **L-5**: `slugify` returns `"untitled"` for empty/non-ASCII input

### `internal/server/server.go`
- **M-5**: Log `fsnotify` errors instead of silently dropping them
- **M-6**: Add `RootDir` field; resolve watch paths relative to `RootDir`

### `internal/plugin/amazonbooks/amazonbooks.go`
- **L-4**: Use `url.QueryEscape(tag)` for safe URL encoding

### `docs/guide/cli.md` + `docs/guide/cli.ja.md`
- Update `gohan new` CLI syntax: `gohan new post --slug=<s>` → `gohan new [--type=post|page] [--title=<t>] <slug>`

## Tests

- `TestTagNorm`: covers tag normalization edge cases
- `TestSlugify`: covers empty string and non-ASCII input
- `TestNewDevServer`: verifies `RootDir` field is set correctly

All existing tests pass.