### PR TITLE
docs: fix gohan new syntax, add Sites Built with gohan section

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,7 @@ theme:
 EOF
 
 # 3. 最初の記事を作成
-gohan new post --slug=hello-world --title="Hello, World!"
+gohan new --title="Hello, World!" hello-world
 
 # 4. サイトをビルド
 gohan build
@@ -133,6 +133,14 @@ books:
 ## 設計
 
 アーキテクチャと設計方針については [docs/DESIGN_DOC.ja.md](docs/DESIGN_DOC.ja.md) を参照してください。
+
+---
+
+## gohan を使っているサイト
+
+| サイト | 説明 |
+|---|---|
+| [bmf-tech.com](https://bmf-tech.com) ([ソース](https://github.com/bmf-san/bmf-tech)) | 個人テックブログ — i18n (EN/JA)・700+ 記事・Cloudflare Pages 配信 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ theme:
 EOF
 
 # 3. Create your first article
-gohan new post --slug=hello-world --title="Hello, World!"
+gohan new --title="Hello, World!" hello-world
 
 # 4. Build the site
 gohan build
@@ -133,6 +133,14 @@ See [docs/DESIGN_DOC.md §20](docs/DESIGN_DOC.md) for the full plugin architectu
 ## Design
 
 For architecture and design decisions see [docs/DESIGN_DOC.md](docs/DESIGN_DOC.md).
+
+---
+
+## Sites Built with gohan
+
+| Site | Description |
+|---|---|
+| [bmf-tech.com](https://bmf-tech.com) ([source](https://github.com/bmf-san/bmf-tech)) | Personal tech blog — i18n (EN/JA), 700+ articles, Cloudflare Pages |
 
 ---
 

--- a/docs/guide/getting-started.ja.md
+++ b/docs/guide/getting-started.ja.md
@@ -77,7 +77,7 @@ syntax_highlight:
 ### ステップ 3: 最初の記事を作成する
 
 ```bash
-gohan new post --slug=hello-world --title="Hello, World!"
+gohan new --title="Hello, World!" hello-world
 ```
 
 `content/posts/hello-world.md` が作成されます。編集して本文を追加しましょう:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -77,7 +77,7 @@ See [Configuration](configuration.md) for all available fields.
 ### Step 3: Create your first article
 
 ```bash
-gohan new post --slug=hello-world --title="Hello, World!"
+gohan new --title="Hello, World!" hello-world
 ```
 
 This creates `content/posts/hello-world.md`. Edit it to add body content:


### PR DESCRIPTION
## Summary

Documentation updates for v1.0.0.

## Changes

### README.md / README.ja.md
- Fix `gohan new` command syntax in Quick Start: old `--slug` flag removed, positional `<slug>` argument is now used
- Add **"Sites Built with gohan"** section linking to [bmf-tech.com](https://bmf-tech.com) as a real-world example

### docs/guide/getting-started.md / getting-started.ja.md
- Fix `gohan new` command syntax in Step 3 (same as above)