### PR TITLE
test: improve coverage to 84.6%; add codecov.yml threshold (80%)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 5%

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -147,3 +147,39 @@ func TestParseNameStatus(t *testing.T) {
 		t.Errorf("deleted: %v", cs.DeletedFiles)
 	}
 }
+
+func TestGitDiffEngine_Hash(t *testing.T) {
+	content := "gohan hash test"
+	path := writeTemp(t, content)
+	defer func() { _ = os.Remove(path) }()
+
+	eng := NewGitDiffEngine(filepath.Dir(path))
+	got, err := eng.Hash(path)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	sum := sha256.Sum256([]byte(content))
+	want := hex.EncodeToString(sum[:])
+	if got != want {
+		t.Errorf("Hash: got %s, want %s", got, want)
+	}
+}
+
+func TestGitDiffEngine_Hash_Missing(t *testing.T) {
+	eng := NewGitDiffEngine(t.TempDir())
+	_, err := eng.Hash("/no/such/file.txt")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestDetectChanges_NonGitDir(t *testing.T) {
+	dir := t.TempDir()
+	cs, err := DetectChanges(dir, "HEAD~1", "HEAD")
+	if err != nil {
+		t.Fatalf("DetectChanges on non-git dir: %v", err)
+	}
+	if len(cs.AddedFiles)+len(cs.ModifiedFiles)+len(cs.DeletedFiles) != 0 {
+		t.Errorf("expected empty ChangeSet for non-git dir, got %+v", cs)
+	}
+}

--- a/internal/template/template_engine_test.go
+++ b/internal/template/template_engine_test.go
@@ -214,3 +214,97 @@ func TestToSlug(t *testing.T) {
 		}
 	}
 }
+
+func TestEngine_Builtin_PaginationPages(t *testing.T) {
+	fns := builtinFuncs()
+	fn, ok := fns["paginationPages"].(func(int, int) []int)
+	if !ok {
+		t.Fatal("paginationPages not found in builtinFuncs")
+	}
+
+	// total <= 1 returns nil
+	if got := fn(1, 0); got != nil {
+		t.Errorf("paginationPages(1,0): got %v, want nil", got)
+	}
+	if got := fn(1, 1); got != nil {
+		t.Errorf("paginationPages(1,1): got %v, want nil", got)
+	}
+
+	// small range: all pages shown
+	got := fn(2, 3)
+	want := []int{1, 2, 3}
+	if len(got) != len(want) {
+		t.Errorf("paginationPages(2,3): got %v, want %v", got, want)
+	} else {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("paginationPages(2,3)[%d]: got %d, want %d", i, got[i], want[i])
+			}
+		}
+	}
+
+	// large range: ellipsis inserted
+	got = fn(5, 10)
+	if len(got) == 0 {
+		t.Fatal("paginationPages(5,10): got empty slice")
+	}
+	if got[0] != 1 {
+		t.Errorf("paginationPages(5,10): first page should be 1, got %d", got[0])
+	}
+	if got[len(got)-1] != 10 {
+		t.Errorf("paginationPages(5,10): last page should be 10, got %d", got[len(got)-1])
+	}
+	hasEllipsis := false
+	for _, p := range got {
+		if p == -1 {
+			hasEllipsis = true
+			break
+		}
+	}
+	if !hasEllipsis {
+		t.Errorf("paginationPages(5,10): expected ellipsis (-1) in %v", got)
+	}
+
+	// current at start: ellipsis only at end
+	got = fn(1, 10)
+	if got[0] != 1 {
+		t.Errorf("paginationPages(1,10): got[0]=%d", got[0])
+	}
+	if got[len(got)-1] != 10 {
+		t.Errorf("paginationPages(1,10): last=%d", got[len(got)-1])
+	}
+
+	// no consecutive -1
+	for i := 1; i < len(got); i++ {
+		if got[i] == -1 && got[i-1] == -1 {
+			t.Errorf("paginationPages(1,10): consecutive ellipsis at %d", i)
+		}
+	}
+}
+
+func TestEngine_Builtin_PageURL(t *testing.T) {
+	fns := builtinFuncs()
+	fn, ok := fns["pageURL"].(func(string, int) string)
+	if !ok {
+		t.Fatal("pageURL not found in builtinFuncs")
+	}
+
+	cases := []struct {
+		baseURL string
+		p       int
+		want    string
+	}{
+		{"", 1, "/"},
+		{"", 0, "/"},
+		{"/tags/go", 1, "/tags/go/"},
+		{"/tags/go", 0, "/tags/go/"},
+		{"/tags/go", 2, "/tags/go/page/2/"},
+		{"/categories/web", 3, "/categories/web/page/3/"},
+	}
+	for _, c := range cases {
+		got := fn(c.baseURL, c.p)
+		if got != c.want {
+			t.Errorf("pageURL(%q, %d): got %q, want %q", c.baseURL, c.p, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add tests for previously under-covered packages and configure a Codecov 80% coverage threshold to keep coverage from regressing.

## Coverage Before / After

| Package | Before | After |
|---|---|---|
| `internal/template` | 63.5% | 96.2% |
| `internal/diff` | 78.7% | 81.5% |
| **Total** | **83.2%** | **84.6%** |

## Changes

### Tests added

**`internal/template/template_engine_test.go`**
- `TestEngine_Builtin_PaginationPages` — covers all branches of `paginationPages` (total≤1, small range, large range with ellipsis, first page)
- `TestEngine_Builtin_PageURL` — covers all patterns of `pageURL` (p≤1 with/without baseURL, p>1)

**`internal/diff/git_test.go`**
- `TestGitDiffEngine_Hash` — happy path for `(*GitDiffEngine).Hash()`
- `TestGitDiffEngine_Hash_Missing` — error path for a non-existent file
- `TestDetectChanges_NonGitDir` — confirms that a non-Git directory returns an empty `ChangeSet`

### `codecov.yml` added

```yaml
coverage:
  status:
    project:
      default:
        target: 80%
        threshold: 1%
    patch:
      default:
        target: 80%
        threshold: 5%
```

- The `project` status check fails if overall coverage drops below 80%
- The `patch` check also requires 80% on changed lines (5% tolerance)