### PR TITLE
fix: mermaid extension conflicts with chroma by using AST transformer

### DIFF
--- a/internal/mermaid/mermaid.go
+++ b/internal/mermaid/mermaid.go
@@ -1,6 +1,13 @@
 // Package mermaid provides a goldmark extension that transforms fenced code
 // blocks tagged with "mermaid" into browser-renderable <div class="mermaid">
 // elements for client-side rendering via the Mermaid.js CDN.
+//
+// Implementation note: instead of registering a renderer for
+// ast.KindFencedCodeBlock (which would conflict with chroma or other
+// code-block renderers), this extension uses an AST transformer that replaces
+// mermaid FencedCodeBlock nodes with a custom KindMermaidBlock node before
+// rendering.  The renderer is then registered only for KindMermaidBlock,
+// leaving KindFencedCodeBlock untouched for other extensions to handle.
 package mermaid
 
 import (
@@ -9,7 +16,9 @@ import (
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	goldmarkparser "github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
 )
 
@@ -38,8 +47,82 @@ func InjectScript(htmlDoc []byte) []byte {
 	return append(htmlDoc, script...)
 }
 
-// Extension returns a goldmark.Extender that replaces the FencedCodeBlock
-// renderer for blocks whose info/language string is "mermaid".
+// KindMermaidBlock is the AST node kind for mermaid diagram blocks.
+var KindMermaidBlock = ast.NewNodeKind("MermaidBlock")
+
+// mermaidNode is a custom AST node that holds the pre-collected mermaid source.
+type mermaidNode struct {
+	ast.BaseBlock
+	source string
+}
+
+func (n *mermaidNode) Kind() ast.NodeKind { return KindMermaidBlock }
+func (n *mermaidNode) Dump(src []byte, level int) {
+	ast.DumpHelper(n, src, level, nil, nil)
+}
+
+// mermaidTransformer walks the parsed AST and replaces every FencedCodeBlock
+// whose language is "mermaid" with a mermaidNode before rendering.
+// This avoids registering for KindFencedCodeBlock and conflicting with
+// syntax-highlighting extensions such as chroma.
+type mermaidTransformer struct{}
+
+func (t *mermaidTransformer) Transform(doc *ast.Document, reader text.Reader, _ goldmarkparser.Context) {
+	src := reader.Source()
+
+	// Collect targets first; do not modify the tree while walking.
+	var targets []*ast.FencedCodeBlock
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		fcb, ok := n.(*ast.FencedCodeBlock)
+		if ok && string(fcb.Language(src)) == "mermaid" {
+			targets = append(targets, fcb)
+		}
+		return ast.WalkContinue, nil
+	})
+
+	for _, fcb := range targets {
+		parent := fcb.Parent()
+		if parent == nil {
+			continue
+		}
+		var buf bytes.Buffer
+		lines := fcb.Lines()
+		for i := 0; i < lines.Len(); i++ {
+			line := lines.At(i)
+			buf.Write(line.Value(src))
+		}
+		mn := &mermaidNode{source: buf.String()}
+		parent.InsertBefore(parent, fcb, mn)
+		parent.RemoveChild(parent, fcb)
+	}
+}
+
+// mermaidRenderer renders mermaidNode as <div class="mermaid">…</div>.
+type mermaidRenderer struct{}
+
+func (r *mermaidRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindMermaidBlock, r.renderMermaidBlock)
+}
+
+func (r *mermaidRenderer) renderMermaidBlock(
+	w util.BufWriter, _ []byte, node ast.Node, entering bool,
+) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	mn := node.(*mermaidNode)
+	_, _ = w.WriteString(`<div class="mermaid">`)
+	_, _ = w.WriteString(html.EscapeString(mn.source))
+	_, _ = w.WriteString(`</div>`)
+	return ast.WalkSkipChildren, nil
+}
+
+// Extension returns a goldmark.Extender that transforms fenced "mermaid"
+// code blocks into <div class="mermaid"> elements using an AST transformer,
+// avoiding any conflict with KindFencedCodeBlock renderers (e.g. chroma).
 func Extension() goldmark.Extender {
 	return &mermaidExtender{}
 }
@@ -47,45 +130,14 @@ func Extension() goldmark.Extender {
 type mermaidExtender struct{}
 
 func (e *mermaidExtender) Extend(m goldmark.Markdown) {
-	m.Renderer().AddOptions(
-		renderer.WithNodeRenderers(
-			util.Prioritized(&mermaidRenderer{}, 199), // higher priority than chroma (200)
+	m.Parser().AddOptions(
+		goldmarkparser.WithASTTransformers(
+			util.Prioritized(&mermaidTransformer{}, 100),
 		),
 	)
-}
-
-// mermaidRenderer handles FencedCodeBlock nodes with lang == "mermaid".
-// All other code blocks are passed to the default renderer.
-type mermaidRenderer struct{}
-
-func (r *mermaidRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
-	reg.Register(ast.KindFencedCodeBlock, r.renderFencedCodeBlock)
-}
-
-func (r *mermaidRenderer) renderFencedCodeBlock(
-	w util.BufWriter, source []byte, node ast.Node, entering bool,
-) (ast.WalkStatus, error) {
-	if !entering {
-		return ast.WalkContinue, nil
-	}
-	n := node.(*ast.FencedCodeBlock)
-	lang := string(n.Language(source))
-	if lang != "mermaid" {
-		// Not a mermaid block — let the next renderer handle it.
-		return ast.WalkContinue, nil
-	}
-
-	// Collect diagram source
-	var buf bytes.Buffer
-	lines := n.Lines()
-	for i := 0; i < lines.Len(); i++ {
-		line := lines.At(i)
-		buf.Write(line.Value(source))
-	}
-
-	// Output as <div class="mermaid"> for client-side rendering
-	_, _ = w.WriteString(`<div class="mermaid">`)
-	_, _ = w.WriteString(html.EscapeString(buf.String()))
-	_, _ = w.WriteString(`</div>`)
-	return ast.WalkSkipChildren, nil
+	m.Renderer().AddOptions(
+		renderer.WithNodeRenderers(
+			util.Prioritized(&mermaidRenderer{}, 500),
+		),
+	)
 }

--- a/internal/parser/combo_test.go
+++ b/internal/parser/combo_test.go
@@ -1,0 +1,24 @@
+package parser_test
+
+import (
+"strings"
+"testing"
+
+"github.com/bmf-san/gohan/internal/highlight"
+"github.com/bmf-san/gohan/internal/parser"
+)
+
+func TestConverter_MermaidPlusHighlight_CodeBlockNotDropped(t *testing.T) {
+hlCfg := highlight.Config{Theme: "github", LineNumbers: false}
+conv := parser.NewConverter(parser.WithGFM(), parser.WithMermaid(), parser.WithHighlighting(hlCfg))
+
+src := "```yaml\nfoo: bar\n```\n"
+out, err := conv.Convert([]byte(src))
+if err != nil {
+t.Fatal(err)
+}
+t.Logf("yaml output: %s", string(out))
+if !strings.Contains(string(out), "<pre") {
+t.Errorf("expected <pre> tag for yaml code block, got: %q", string(out))
+}
+}


### PR DESCRIPTION
## Problem

When both `WithMermaid()` and `WithHighlighting()` (chroma) were active, all non-mermaid fenced code blocks were silently dropped — producing empty output instead of `<pre><code>…</code></pre>`.

**Root cause**: `mermaid.Extension()` registered a renderer for `ast.KindFencedCodeBlock` at priority 199. Goldmark's `NodeRendererFuncs` is first-writer-wins, so mermaid beat chroma (priority 200). For non-mermaid blocks the mermaid renderer returned `WalkContinue` without writing anything, and `FencedCodeBlock` content lives in `Lines()` (not in AST children), so nothing got rendered.

## Fix

Replace the renderer-based approach with an **AST transformer**:

1. `mermaidTransformer` runs during the parse phase — it collects every `FencedCodeBlock` whose language is `"mermaid"` and replaces each with a custom `mermaidNode` (`KindMermaidBlock`).
2. `mermaidRenderer` is registered **only** for `KindMermaidBlock`, so `KindFencedCodeBlock` is left entirely to chroma / the default renderer.

## Regression test

Added `internal/parser/combo_test.go` — enables `WithGFM() + WithMermaid() + WithHighlighting()` together and asserts that a YAML code block produces a `<pre>` element.