### PR TITLE
feat: add static_dir support for root-level static files

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -102,6 +102,9 @@ func runBuild(args []string) error {
 	cfg.Build.ContentDir = contentDir
 	cfg.Build.OutputDir = filepath.Join(rootDir, cfg.Build.OutputDir)
 	cfg.Build.AssetsDir = filepath.Join(rootDir, cfg.Build.AssetsDir)
+	if cfg.Build.StaticDir != "" {
+		cfg.Build.StaticDir = filepath.Join(rootDir, cfg.Build.StaticDir)
+	}
 	articles, err := p.ParseAll(contentDir)
 	if err != nil {
 		return fmt.Errorf("parse content: %w", err)

--- a/docs/DESIGN_DOC.ja.md
+++ b/docs/DESIGN_DOC.ja.md
@@ -456,7 +456,7 @@ type Site struct {
 
 type OutputGenerator interface {
     Write(articles []*ProcessedArticle, site *Site) error
-    CopyAssets(srcDir, dstDir string) error
+    CopyDir(srcDir, dstDir string) error
     GenerateSitemap(pages []string) error
     GenerateFeeds(articles []*ProcessedArticle) error
 }

--- a/docs/DESIGN_DOC.md
+++ b/docs/DESIGN_DOC.md
@@ -456,7 +456,7 @@ type Site struct {
 
 type OutputGenerator interface {
     Write(articles []*ProcessedArticle, site *Site) error
-    CopyAssets(srcDir, dstDir string) error
+    CopyDir(srcDir, dstDir string) error
     GenerateSitemap(pages []string) error
     GenerateFeeds(articles []*ProcessedArticle) error
 }

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -74,9 +74,17 @@ func (g *HTMLGenerator) Generate(site *model.Site, changeSet *model.ChangeSet) e
 	}
 
 	if g.cfg.Build.AssetsDir != "" {
-		if err := CopyAssets(g.cfg.Build.AssetsDir, filepath.Join(g.outDir, "assets")); err != nil {
+		if err := CopyDir(g.cfg.Build.AssetsDir, filepath.Join(g.outDir, "assets")); err != nil {
 			if !os.IsNotExist(err) {
 				return fmt.Errorf("copy assets: %w", err)
+			}
+		}
+	}
+
+	if g.cfg.Build.StaticDir != "" {
+		if err := CopyDir(g.cfg.Build.StaticDir, g.outDir); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("copy static: %w", err)
 			}
 		}
 	}
@@ -420,8 +428,8 @@ func (g *HTMLGenerator) writePage(path, tmplName string, data *model.Site) error
 	return nil
 }
 
-// CopyAssets recursively copies all files from srcDir into dstDir.
-func CopyAssets(srcDir, dstDir string) error {
+// CopyDir recursively copies all files from srcDir into dstDir.
+func CopyDir(srcDir, dstDir string) error {
 	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -90,7 +90,28 @@ func TestGenerate_CopiesAssets(t *testing.T) {
 	}
 }
 
-func TestCopyAssets_PreservesStructure(t *testing.T) {
+func TestGenerate_CopiesStatic(t *testing.T) {
+	staticDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(staticDir, "robots.txt"), []byte("User-agent: *"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "ads.txt"), []byte("google.com, pub-123, DIRECT, abc"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outDir := t.TempDir()
+	cfg := model.Config{Build: model.BuildConfig{Parallelism: 1, StaticDir: staticDir}}
+	if err := NewHTMLGenerator(outDir, &mockEngine{}, cfg).Generate(makeSite(), nil); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "robots.txt")); err != nil {
+		t.Errorf("expected robots.txt at output root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "ads.txt")); err != nil {
+		t.Errorf("expected ads.txt at output root: %v", err)
+	}
+}
+
+func TestCopyDir_PreservesStructure(t *testing.T) {
 	src := t.TempDir()
 	sub := filepath.Join(src, "css")
 	if err := os.MkdirAll(sub, 0o755); err != nil {
@@ -100,8 +121,8 @@ func TestCopyAssets_PreservesStructure(t *testing.T) {
 		t.Fatal(err)
 	}
 	dst := t.TempDir()
-	if err := CopyAssets(src, dst); err != nil {
-		t.Fatalf("CopyAssets: %v", err)
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("CopyDir: %v", err)
 	}
 	if got, _ := os.ReadFile(filepath.Join(dst, "css", "main.css")); string(got) != ".a{}" {
 		t.Errorf("unexpected content: %s", got)

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -30,6 +30,7 @@ type BuildConfig struct {
 	ContentDir   string   `yaml:"content_dir"`
 	OutputDir    string   `yaml:"output_dir"`
 	AssetsDir    string   `yaml:"assets_dir"`
+	StaticDir    string   `yaml:"static_dir"`
 	ExcludeFiles []string `yaml:"exclude_files"`
 	Parallelism  int      `yaml:"parallelism"`
 	PerPage      int      `yaml:"per_page"`


### PR DESCRIPTION
## Overview

Add `static_dir` configuration. Files in this directory are copied directly to the output root (e.g. `public/`) at build time.

## Background

`assets_dir` copies files to `public/assets/`, so there was no place to put root-level files like `robots.txt` or `ads.txt`. This was previously worked around with manual `cp` steps in Makefiles. Major SSGs like Hugo, Next.js, and Gatsby solve this with a `static/` directory.

## Changes

### `internal/model/config.go`
Add `StaticDir` field to `BuildConfig`:
```go
StaticDir string `yaml:"static_dir"`
```

### `cmd/gohan/build.go`
Resolve `StaticDir` to an absolute path, same pattern as `AssetsDir`.

### `internal/generator/html.go`
Add static copy step in `Generate()`, reusing `CopyDir` (renamed from `CopyAssets`):
```go
if g.cfg.Build.StaticDir != "" {
    CopyDir(g.cfg.Build.StaticDir, g.outDir)
}
```

### Rename `CopyAssets` → `CopyDir`
The function is now used for both assets and static directories, so a generic name is more appropriate.

## Usage

```yaml
build:
  static_dir: "static"
```

```
static/
  robots.txt
  ads.txt
  favicon.ico
```

→ Output to `public/robots.txt`, `public/ads.txt`, `public/favicon.ico`.

When `static_dir` is not set, behavior is unchanged (fully backward compatible).