### PR TITLE
feat: add CurrentTaxonomy to Site template context for tag/category pages

### DIFF
--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -119,13 +119,13 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 				basePath = locale
 				baseURLPath = "/" + locale
 			}
-			jobs = append(jobs, paginatedJobs(site, locArticles, g.outDir, "index.html", basePath, baseURLPath, perPage, locale)...)
+			jobs = append(jobs, paginatedJobs(site, locArticles, g.outDir, "index.html", basePath, baseURLPath, perPage, locale, nil)...)
 		}
 	} else {
 		allArticles := make([]*model.ProcessedArticle, len(site.Articles))
 		copy(allArticles, site.Articles)
 		sortByDateDesc(allArticles)
-		jobs = append(jobs, paginatedJobs(site, allArticles, g.outDir, "index.html", "", "", perPage, "")...)
+		jobs = append(jobs, paginatedJobs(site, allArticles, g.outDir, "index.html", "", "", perPage, "", nil)...)
 	}
 
 	// Article pages: use pre-computed output path and respect FrontMatter.Template.
@@ -175,7 +175,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 					basePath = filepath.Join(locale, "tags", tagNorm(t.Name))
 					baseURLPath = "/" + locale + "/tags/" + tagNorm(t.Name)
 				}
-				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, locale)...)
+				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, locale, &t)...)
 			}
 		}
 	} else {
@@ -195,7 +195,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 			sortByDateDesc(filtered)
 			basePath := filepath.Join("tags", tagNorm(t.Name))
 			baseURLPath := "/tags/" + tagNorm(t.Name)
-			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, "")...)
+			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, "", &t)...)
 		}
 	}
 
@@ -228,7 +228,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 					basePath = filepath.Join(locale, "categories", tagNorm(c.Name))
 					baseURLPath = "/" + locale + "/categories/" + tagNorm(c.Name)
 				}
-				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, locale)...)
+				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, locale, &c)...)
 			}
 		}
 	} else {
@@ -248,7 +248,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 			sortByDateDesc(filtered)
 			basePath := filepath.Join("categories", tagNorm(c.Name))
 			baseURLPath := "/categories/" + tagNorm(c.Name)
-			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, "")...)
+			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, "", &c)...)
 		}
 	}
 
@@ -309,6 +309,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 // paginatedJobs returns writeJobs for a paginated listing page.
 // basePath is the filesystem path prefix relative to outDir (e.g. "tags/go").
 // baseURLPath is the URL prefix for computing PrevURL/NextURL.
+// taxonomy is the tag or category being listed; nil for plain index pages.
 // When perPage <= 0, a single job with all articles and no Pagination is returned.
 func paginatedJobs(
 	site *model.Site,
@@ -316,6 +317,7 @@ func paginatedJobs(
 	outDir, tmpl, basePath, baseURLPath string,
 	perPage int,
 	currentLocale string,
+	taxonomy *model.Taxonomy,
 ) []writeJob {
 	// Build a locale-specific base so that listing pages see only the
 	// tags/categories present in the locale's articles (all of them,
@@ -330,6 +332,7 @@ func paginatedJobs(
 		}
 		d := siteFor(base, articles)
 		d.CurrentLocale = currentLocale
+		d.CurrentTaxonomy = taxonomy
 		return []writeJob{{path: path, tmpl: tmpl, data: d}}
 	}
 
@@ -390,6 +393,7 @@ func paginatedJobs(
 
 		d := siteWithPagination(base, slice, pg)
 		d.CurrentLocale = currentLocale
+		d.CurrentTaxonomy = taxonomy
 		jobs = append(jobs, writeJob{
 			path: path,
 			tmpl: tmpl,

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -187,7 +187,7 @@ func makePaginatedArticles(n int) []*model.ProcessedArticle {
 func TestPaginatedJobs_Disabled(t *testing.T) {
 	site := makeSite()
 	articles := makePaginatedArticles(5)
-	jobs := paginatedJobs(site, articles, "/out", "index.html", "", "/", 0, "")
+	jobs := paginatedJobs(site, articles, "/out", "index.html", "", "/", 0, "", nil)
 	if len(jobs) != 1 {
 		t.Fatalf("expected 1 job when pagination disabled, got %d", len(jobs))
 	}
@@ -202,7 +202,7 @@ func TestPaginatedJobs_Disabled(t *testing.T) {
 func TestPaginatedJobs_SinglePage(t *testing.T) {
 	site := makeSite()
 	articles := makePaginatedArticles(3)
-	jobs := paginatedJobs(site, articles, "/out", "index.html", "", "/", 10, "")
+	jobs := paginatedJobs(site, articles, "/out", "index.html", "", "/", 10, "", nil)
 	if len(jobs) != 1 {
 		t.Fatalf("expected 1 job for 3 articles with perPage=10, got %d", len(jobs))
 	}
@@ -222,7 +222,7 @@ func TestPaginatedJobs_SinglePage(t *testing.T) {
 func TestPaginatedJobs_MultiPage_Paths(t *testing.T) {
 	site := makeSite()
 	articles := makePaginatedArticles(5)
-	jobs := paginatedJobs(site, articles, "/out", "index.html", "", "", 2, "")
+	jobs := paginatedJobs(site, articles, "/out", "index.html", "", "", 2, "", nil)
 	// 5 articles / perPage 2 → pages 1,2,3
 	if len(jobs) != 3 {
 		t.Fatalf("expected 3 jobs, got %d", len(jobs))
@@ -244,7 +244,7 @@ func TestPaginatedJobs_MultiPage_Paths(t *testing.T) {
 func TestPaginatedJobs_MultiPage_PrevNext(t *testing.T) {
 	site := makeSite()
 	articles := makePaginatedArticles(5)
-	jobs := paginatedJobs(site, articles, "/out", "index.html", "", "/blog", 2, "")
+	jobs := paginatedJobs(site, articles, "/out", "index.html", "", "/blog", 2, "", nil)
 
 	pg1 := jobs[0].data.Pagination
 	if pg1.PrevURL != "" {
@@ -274,7 +274,7 @@ func TestPaginatedJobs_MultiPage_PrevNext(t *testing.T) {
 func TestPaginatedJobs_WithBasePath(t *testing.T) {
 	site := makeSite()
 	articles := makePaginatedArticles(3)
-	jobs := paginatedJobs(site, articles, "/out", "tag.html", "tags/go", "/tags/go", 2, "")
+	jobs := paginatedJobs(site, articles, "/out", "tag.html", "tags/go", "/tags/go", 2, "", nil)
 	// 3 articles / perPage 2 → 2 pages
 	if len(jobs) != 2 {
 		t.Fatalf("expected 2 jobs, got %d", len(jobs))
@@ -284,6 +284,39 @@ func TestPaginatedJobs_WithBasePath(t *testing.T) {
 	}
 	if jobs[1].path != filepath.Join("/out", "tags/go", "page", "2", "index.html") {
 		t.Errorf("page2 path = %q", jobs[1].path)
+	}
+}
+
+func TestPaginatedJobs_CurrentTaxonomy(t *testing.T) {
+	site := makeSite()
+	articles := makePaginatedArticles(2)
+	tax := &model.Taxonomy{Name: "go", Description: "Go language articles"}
+
+	// taxonomy is propagated to all page jobs (single page)
+	jobs := paginatedJobs(site, articles, "/out", "tag.html", "tags/go", "/tags/go", 0, "", tax)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].data.CurrentTaxonomy == nil {
+		t.Fatal("CurrentTaxonomy should not be nil for tag page")
+	}
+	if jobs[0].data.CurrentTaxonomy.Name != "go" {
+		t.Errorf("CurrentTaxonomy.Name = %q, want %q", jobs[0].data.CurrentTaxonomy.Name, "go")
+	}
+
+	// taxonomy is propagated across multiple pages
+	articles5 := makePaginatedArticles(5)
+	jobs2 := paginatedJobs(site, articles5, "/out", "tag.html", "tags/go", "/tags/go", 2, "", tax)
+	for i, j := range jobs2 {
+		if j.data.CurrentTaxonomy == nil || j.data.CurrentTaxonomy.Name != "go" {
+			t.Errorf("page %d: CurrentTaxonomy not set correctly", i+1)
+		}
+	}
+
+	// nil taxonomy on index page
+	indexJobs := paginatedJobs(site, articles, "/out", "index.html", "", "/", 0, "", nil)
+	if indexJobs[0].data.CurrentTaxonomy != nil {
+		t.Error("CurrentTaxonomy should be nil for index page")
 	}
 }
 

--- a/internal/model/site.go
+++ b/internal/model/site.go
@@ -9,6 +9,7 @@ type Site struct {
 	Pagination      *Pagination         // nil when pagination is disabled or not a listing page
 	CurrentLocale   string              // locale for the current page; empty when i18n is not configured
 	RelatedArticles []*ProcessedArticle // articles sharing at least one category with the current article (article pages only)
+	CurrentTaxonomy *Taxonomy           // set on tag and category listing pages; nil elsewhere
 }
 
 // Pagination holds computed paging metadata for listing pages.


### PR DESCRIPTION
## Summary

Expose the current tag or category as `CurrentTaxonomy (*model.Taxonomy)` on the `Site` struct so templates can render unique `<title>` and `<meta description>` on taxonomy listing pages.

## Changes

- **`internal/model/site.go`**: Add `CurrentTaxonomy *Taxonomy` field to `Site` struct. Set on tag/category listing pages; `nil` on index and article pages.
- **`internal/generator/html.go`**: Thread `taxonomy *model.Taxonomy` parameter through `paginatedJobs`; set `d.CurrentTaxonomy` in both the single-page and paginated branches. Update all 6 `buildJobs` call sites — tag/category jobs pass `&t`/`&c`, index jobs pass `nil`.
- **`internal/generator/html_test.go`**: Add `TestPaginatedJobs_CurrentTaxonomy` to verify the field is set correctly on tag pages, propagated across paginated jobs, and `nil` on index pages. Update 5 existing `paginatedJobs` call sites to compile with the new signature.

## Template usage example

```html
<title>
  {{if $isSingle}}{{$article.FrontMatter.Title}} | 
  {{else if .CurrentTaxonomy}}{{.CurrentTaxonomy.Name}} | 
  {{end}}{{.Config.Site.Title}}
</title>
```
