### PR TITLE
feat: locale-aware taxonomy registry loading and validation

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -149,29 +149,33 @@ func runBuild(args []string) error {
 		}
 	}
 
-	// Build taxonomy.
-	// If tags.yaml / categories.yaml exist in the content directory they are
-	// treated as the authoritative registry and every article is validated
-	// against them.  When the files are absent the registry is derived from
-	// the articles themselves (no validation errors are possible).
+	// Build taxonomy registry.
+	// When i18n is active, locale-specific files are preferred:
+	//   {contentDir}/{locale}/tags.yaml        (falls back to {contentDir}/tags.yaml)
+	//   {contentDir}/{locale}/categories.yaml  (falls back to {contentDir}/categories.yaml)
+	// When no registry files exist, the registry is derived from article frontmatter
+	// (no validation is performed).
 	var taxo *model.TaxonomyRegistry
-	loaded, loadErr := processor.LoadTaxonomyRegistry(contentDir)
-	if loadErr != nil {
-		return fmt.Errorf("load taxonomy registry: %w", loadErr)
-	}
-	if len(loaded.Tags) > 0 || len(loaded.Categories) > 0 {
-		taxo = loaded
-		if errs := processor.ValidateArticleTaxonomies(processed, taxo); len(errs) > 0 {
-			for _, e := range errs {
-				fmt.Fprintf(os.Stderr, "warn: taxonomy: %v\n", e)
+	{
+		regs, loadErr := processor.LoadLocaleAwareTaxonomyRegistries(contentDir, cfg.I18n.Locales)
+		if loadErr != nil {
+			return fmt.Errorf("load taxonomy registries: %w", loadErr)
+		}
+		merged := processor.MergeTaxonomyRegistries(regs)
+		if len(merged.Tags) > 0 || len(merged.Categories) > 0 {
+			taxo = merged
+			if errs := processor.ValidateArticleTaxonomiesLocale(processed, regs); len(errs) > 0 {
+				for _, e := range errs {
+					fmt.Fprintf(os.Stderr, "warn: taxonomy: %v\n", e)
+				}
 			}
+		} else {
+			computed, err := proc.BuildTaxonomyRegistry(processed, *cfg)
+			if err != nil {
+				return fmt.Errorf("build taxonomy: %w", err)
+			}
+			taxo = computed
 		}
-	} else {
-		computed, err := proc.BuildTaxonomyRegistry(processed, *cfg)
-		if err != nil {
-			return fmt.Errorf("build taxonomy: %w", err)
-		}
-		taxo = computed
 	}
 
 	site := &model.Site{

--- a/internal/processor/taxonomy.go
+++ b/internal/processor/taxonomy.go
@@ -49,6 +49,116 @@ func loadTaxonomyFile(path string) ([]model.Taxonomy, error) {
 	return entries, nil
 }
 
+// loadTaxonomyFileWithFallback returns entries from primary if the file exists,
+// otherwise falls back to fallback. A missing primary is not an error.
+func loadTaxonomyFileWithFallback(primary, fallback string) ([]model.Taxonomy, error) {
+	if _, err := os.Stat(primary); err == nil {
+		return loadTaxonomyFile(primary)
+	}
+	return loadTaxonomyFile(fallback)
+}
+
+// LoadLocaleAwareTaxonomyRegistries loads a taxonomy registry per locale.
+// For each locale it looks for {contentDir}/{locale}/tags.yaml (and categories.yaml),
+// falling back to the global {contentDir}/tags.yaml when the locale file is absent.
+// The returned map also has an "" (empty string) key holding the global registry.
+func LoadLocaleAwareTaxonomyRegistries(contentDir string, locales []string) (map[string]*model.TaxonomyRegistry, error) {
+	registries := make(map[string]*model.TaxonomyRegistry, len(locales)+1)
+
+	global, err := LoadTaxonomyRegistry(contentDir)
+	if err != nil {
+		return nil, err
+	}
+	registries[""] = global
+
+	for _, locale := range locales {
+		tags, err := loadTaxonomyFileWithFallback(
+			filepath.Join(contentDir, locale, "tags.yaml"),
+			filepath.Join(contentDir, "tags.yaml"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("taxonomy: locale %q tags: %w", locale, err)
+		}
+		cats, err := loadTaxonomyFileWithFallback(
+			filepath.Join(contentDir, locale, "categories.yaml"),
+			filepath.Join(contentDir, "categories.yaml"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("taxonomy: locale %q categories: %w", locale, err)
+		}
+		registries[locale] = &model.TaxonomyRegistry{Tags: tags, Categories: cats}
+	}
+	return registries, nil
+}
+
+// MergeTaxonomyRegistries returns a single registry that is the deduplicated
+// union of all registries in the map. Useful for populating site.Tags/Categories.
+func MergeTaxonomyRegistries(registries map[string]*model.TaxonomyRegistry) *model.TaxonomyRegistry {
+	tagSeen := make(map[string]bool)
+	catSeen := make(map[string]bool)
+	merged := &model.TaxonomyRegistry{}
+	for _, reg := range registries {
+		for _, t := range reg.Tags {
+			if !tagSeen[t.Name] {
+				tagSeen[t.Name] = true
+				merged.Tags = append(merged.Tags, t)
+			}
+		}
+		for _, c := range reg.Categories {
+			if !catSeen[c.Name] {
+				catSeen[c.Name] = true
+				merged.Categories = append(merged.Categories, c)
+			}
+		}
+	}
+	return merged
+}
+
+// ValidateArticleTaxonomiesLocale validates each article against its locale's
+// registry from the registries map. Falls back to the "" key when no
+// locale-specific registry is found. Only validates when the registry has entries.
+func ValidateArticleTaxonomiesLocale(articles []*model.ProcessedArticle, registries map[string]*model.TaxonomyRegistry) []error {
+	type setsPair struct {
+		tags map[string]bool
+		cats map[string]bool
+	}
+	sets := make(map[string]setsPair, len(registries))
+	for locale, reg := range registries {
+		ts := make(map[string]bool, len(reg.Tags))
+		for _, t := range reg.Tags {
+			ts[t.Name] = true
+		}
+		cs := make(map[string]bool, len(reg.Categories))
+		for _, c := range reg.Categories {
+			cs[c.Name] = true
+		}
+		sets[locale] = setsPair{ts, cs}
+	}
+
+	var errs []error
+	for _, a := range articles {
+		sp, ok := sets[a.Locale]
+		if !ok {
+			sp = sets[""]
+		}
+		if len(sp.tags) > 0 {
+			for _, t := range a.FrontMatter.Tags {
+				if !sp.tags[t] {
+					errs = append(errs, fmt.Errorf("article %q: unknown tag %q", a.FilePath, t))
+				}
+			}
+		}
+		if len(sp.cats) > 0 {
+			for _, c := range a.FrontMatter.Categories {
+				if !sp.cats[c] {
+					errs = append(errs, fmt.Errorf("article %q: unknown category %q", a.FilePath, c))
+				}
+			}
+		}
+	}
+	return errs
+}
+
 // ValidateArticleTaxonomies checks that every tag and category referenced in
 // an article exists in the registry.  It returns one error per violation.
 func ValidateArticleTaxonomies(articles []*model.ProcessedArticle, registry *model.TaxonomyRegistry) []error {

--- a/internal/processor/taxonomy_test.go
+++ b/internal/processor/taxonomy_test.go
@@ -156,3 +156,115 @@ func TestBuildCategoryIndex(t *testing.T) {
 		t.Errorf("cat web: got %d articles, want 1", len(idx["web"]))
 	}
 }
+
+// --- Locale-aware taxonomy tests ---
+
+func TestLoadLocaleAwareTaxonomyRegistries_GlobalOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeTaxFile(t, dir, "tags.yaml", "- name: go\n")
+	writeTaxFile(t, dir, "categories.yaml", "- name: tutorials\n")
+
+	regs, err := LoadLocaleAwareTaxonomyRegistries(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if regs[""] == nil || len(regs[""].Tags) != 1 {
+		t.Error("global registry should have 1 tag")
+	}
+}
+
+func TestLoadLocaleAwareTaxonomyRegistries_LocaleFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTaxFile(t, dir, "tags.yaml", "- name: go\n")
+	if err := os.MkdirAll(filepath.Join(dir, "ja"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTaxFile(t, filepath.Join(dir, "ja"), "tags.yaml", "- name: golang\n- name: 書評\n")
+
+	regs, err := LoadLocaleAwareTaxonomyRegistries(dir, []string{"en", "ja"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "en" has no locale file → falls back to global
+	if len(regs["en"].Tags) != 1 || regs["en"].Tags[0].Name != "go" {
+		t.Errorf("en should fall back to global: got %v", regs["en"].Tags)
+	}
+	// "ja" has its own file
+	if len(regs["ja"].Tags) != 2 {
+		t.Errorf("ja should have 2 tags, got %d", len(regs["ja"].Tags))
+	}
+}
+
+func TestLoadLocaleAwareTaxonomyRegistries_FallbackWhenNoFiles(t *testing.T) {
+	dir := t.TempDir()
+	regs, err := LoadLocaleAwareTaxonomyRegistries(dir, []string{"en", "ja"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, locale := range []string{"", "en", "ja"} {
+		if regs[locale] == nil {
+			t.Errorf("locale %q: registry should not be nil", locale)
+			continue
+		}
+		if len(regs[locale].Tags) != 0 || len(regs[locale].Categories) != 0 {
+			t.Errorf("locale %q: expected empty registry", locale)
+		}
+	}
+}
+
+func TestMergeTaxonomyRegistries_Deduplication(t *testing.T) {
+	regs := map[string]*model.TaxonomyRegistry{
+		"en": {Tags: []model.Taxonomy{{Name: "go"}, {Name: "arch"}}},
+		"ja": {Tags: []model.Taxonomy{{Name: "go"}, {Name: "アーキテクチャ"}}},
+	}
+	merged := MergeTaxonomyRegistries(regs)
+	if len(merged.Tags) != 3 {
+		t.Errorf("expected 3 unique tags, got %d: %v", len(merged.Tags), merged.Tags)
+	}
+}
+
+func TestValidateArticleTaxonomiesLocale_PerLocale(t *testing.T) {
+	regs := map[string]*model.TaxonomyRegistry{
+		"": {
+			Tags:       []model.Taxonomy{{Name: "go"}},
+			Categories: []model.Taxonomy{{Name: "tools"}},
+		},
+		"en": {
+			Tags:       []model.Taxonomy{{Name: "go"}, {Name: "arch"}},
+			Categories: []model.Taxonomy{{Name: "tools"}},
+		},
+		"ja": {
+			Tags:       []model.Taxonomy{{Name: "go"}, {Name: "アーキテクチャ"}},
+			Categories: []model.Taxonomy{{Name: "ツール"}},
+		},
+	}
+
+	articles := []*model.ProcessedArticle{
+		// EN article using EN tag → OK
+		{Article: *testArticle("en/a.md", "", "", []string{"arch"}, []string{"tools"}, time.Time{}), Locale: "en"},
+		// JA article using JA tag → OK
+		{Article: *testArticle("ja/b.md", "", "", []string{"アーキテクチャ"}, []string{"ツール"}, time.Time{}), Locale: "ja"},
+		// EN article using JA-only tag → error
+		{Article: *testArticle("en/c.md", "", "", []string{"アーキテクチャ"}, nil, time.Time{}), Locale: "en"},
+	}
+
+	errs := ValidateArticleTaxonomiesLocale(articles, regs)
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateArticleTaxonomiesLocale_FallbackToGlobal(t *testing.T) {
+	regs := map[string]*model.TaxonomyRegistry{
+		"": {Tags: []model.Taxonomy{{Name: "go"}}},
+	}
+	// article with locale "fr" — no "fr" key, falls back to ""
+	articles := []*model.ProcessedArticle{
+		{Article: *testArticle("fr/a.md", "", "", []string{"go"}, nil, time.Time{}), Locale: "fr"},
+		{Article: *testArticle("fr/b.md", "", "", []string{"unknown"}, nil, time.Time{}), Locale: "fr"},
+	}
+	errs := ValidateArticleTaxonomiesLocale(articles, regs)
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error (unknown tag), got %d: %v", len(errs), errs)
+	}
+}

--- a/internal/processor/taxonomy_test.go
+++ b/internal/processor/taxonomy_test.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -280,6 +281,9 @@ func TestLoadTaxonomyRegistry_InvalidCategoriesYAML(t *testing.T) {
 }
 
 func TestLoadTaxonomyFile_ReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping permission test on Windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("skipping permission test when running as root")
 	}

--- a/internal/processor/taxonomy_test.go
+++ b/internal/processor/taxonomy_test.go
@@ -268,3 +268,92 @@ func TestValidateArticleTaxonomiesLocale_FallbackToGlobal(t *testing.T) {
 		t.Errorf("expected 1 error (unknown tag), got %d: %v", len(errs), errs)
 	}
 }
+
+func TestLoadTaxonomyRegistry_InvalidCategoriesYAML(t *testing.T) {
+	dir := t.TempDir()
+	writeTaxFile(t, dir, "tags.yaml", "- name: go\n")
+	writeTaxFile(t, dir, "categories.yaml", "invalid: {[")
+	_, err := LoadTaxonomyRegistry(dir)
+	if err == nil {
+		t.Error("expected error for invalid categories YAML")
+	}
+}
+
+func TestLoadTaxonomyFile_ReadError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping permission test when running as root")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tags.yaml")
+	if err := os.WriteFile(path, []byte("- name: go\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadTaxonomyFile(path)
+	if err == nil {
+		t.Error("expected error for unreadable file")
+	}
+}
+
+func TestLoadLocaleAwareTaxonomyRegistries_ErrorOnGlobalRegistry(t *testing.T) {
+	dir := t.TempDir()
+	writeTaxFile(t, dir, "tags.yaml", "invalid: {[")
+	_, err := LoadLocaleAwareTaxonomyRegistries(dir, nil)
+	if err == nil {
+		t.Error("expected error when global tags.yaml is invalid")
+	}
+}
+
+func TestLoadLocaleAwareTaxonomyRegistries_ErrorOnLocaleTags(t *testing.T) {
+	dir := t.TempDir()
+	writeTaxFile(t, dir, "tags.yaml", "- name: go\n")
+	writeTaxFile(t, dir, "categories.yaml", "- name: tutorials\n")
+	if err := os.MkdirAll(filepath.Join(dir, "ja"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTaxFile(t, filepath.Join(dir, "ja"), "tags.yaml", "invalid: {[")
+
+	_, err := LoadLocaleAwareTaxonomyRegistries(dir, []string{"ja"})
+	if err == nil {
+		t.Error("expected error when locale tags.yaml is invalid")
+	}
+}
+
+func TestLoadLocaleAwareTaxonomyRegistries_ErrorOnLocaleCategories(t *testing.T) {
+	dir := t.TempDir()
+	writeTaxFile(t, dir, "tags.yaml", "- name: go\n")
+	writeTaxFile(t, dir, "categories.yaml", "- name: tutorials\n")
+	if err := os.MkdirAll(filepath.Join(dir, "ja"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTaxFile(t, filepath.Join(dir, "ja"), "tags.yaml", "- name: golang\n")
+	writeTaxFile(t, filepath.Join(dir, "ja"), "categories.yaml", "invalid: {[")
+
+	_, err := LoadLocaleAwareTaxonomyRegistries(dir, []string{"ja"})
+	if err == nil {
+		t.Error("expected error when locale categories.yaml is invalid")
+	}
+}
+
+func TestMergeTaxonomyRegistries_CategoriesDeduplication(t *testing.T) {
+	regs := map[string]*model.TaxonomyRegistry{
+		"en": {Categories: []model.Taxonomy{{Name: "tools"}, {Name: "news"}}},
+		"ja": {Categories: []model.Taxonomy{{Name: "tools"}, {Name: "技術"}}},
+	}
+	merged := MergeTaxonomyRegistries(regs)
+	if len(merged.Categories) != 3 {
+		t.Errorf("expected 3 unique categories, got %d: %v", len(merged.Categories), merged.Categories)
+	}
+}
+
+func TestValidateArticleTaxonomiesLocale_UnknownCategory(t *testing.T) {
+	regs := map[string]*model.TaxonomyRegistry{
+		"": {Categories: []model.Taxonomy{{Name: "tools"}}},
+	}
+	articles := []*model.ProcessedArticle{
+		{Article: *testArticle("en/a.md", "", "", nil, []string{"unknown-cat"}, time.Time{}), Locale: "en"},
+	}
+	errs := ValidateArticleTaxonomiesLocale(articles, regs)
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error for unknown category, got %d: %v", len(errs), errs)
+	}
+}


### PR DESCRIPTION
## Summary

Add support for per-locale taxonomy files so that i18n sites can maintain separate tag/category lists for each language.

## Problem

Currently `tags.yaml` and `categories.yaml` are loaded as a single global registry shared across all locales. For i18n sites this causes two issues:

1. **Validation is not locale-scoped** — a JA-only tag (e.g. `アーキテクチャ`) in the global file can be silently used in an EN article without a warning.
2. **File management** — EN and JA tags/categories are mixed in one file, making them hard to maintain.

## New behaviour

For each configured locale gohan looks for:
```
{contentDir}/{locale}/tags.yaml
{contentDir}/{locale}/categories.yaml
```

If a locale file is absent, the global `{contentDir}/tags.yaml` / `categories.yaml` is used as a fallback — **full backward compatibility** is preserved.

Validation is now **locale-scoped**: an EN article is checked against the EN registry, a JA article against the JA registry.

The site-level `Tags`/`Categories` (used for building listing pages) are the **deduplicated union** of all locale registries, so generated URLs and template behaviour are unchanged.

## Example directory layout (i18n site)

```
content/
  tags.yaml           # EN tags  (fallback for "en" locale)
  categories.yaml     # EN categories
  ja/
    tags.yaml         # JA tags  (used for "ja" locale)
    categories.yaml   # JA categories
```

## Changes

### `internal/processor/taxonomy.go`
- `loadTaxonomyFileWithFallback`: tries primary path, falls back to secondary
- `LoadLocaleAwareTaxonomyRegistries(contentDir, locales)`: builds `map[locale]*TaxonomyRegistry`
- `MergeTaxonomyRegistries(registries)`: deduplicated union for `site.Tags`/`site.Categories`
- `ValidateArticleTaxonomiesLocale(articles, registries)`: validates each article against its locale's registry, falls back to `""` key

### `cmd/gohan/build.go`
- Replace single `LoadTaxonomyRegistry` call with locale-aware loading

### `internal/processor/taxonomy_test.go`
- 6 new tests covering locale file loading, fallback, deduplication, and per-locale validation
