### PR TITLE
fix: add explicit GITHUB_TOKEN permissions to CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -53,6 +55,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
@@ -75,6 +79,8 @@ jobs:
   vuln:
     name: Vulnerability Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
@@ -94,6 +100,8 @@ jobs:
   goreleaser:
     name: GoReleaser Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Resolves all 4 CodeQL `actions/missing-workflow-permissions` code scanning alerts by adding explicit `permissions` blocks to each job in `.github/workflows/ci.yml`.

## Changes

Added `permissions: contents: read` to all 4 jobs:
- `test`
- `lint`
- `vuln`
- `goreleaser`

## Motivation

The [principle of least privilege](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) recommends explicitly restricting `GITHUB_TOKEN` permissions rather than relying on repository-level defaults. This satisfies the CodeQL security rule `actions/missing-workflow-permissions`.