### PR TITLE
feat: add ArchiveYears to model.Site for template use

### DIFF
--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -563,10 +563,11 @@ func tagNorm(s string) string {
 // siteFor creates a site copy with a custom article list.
 func siteFor(base *model.Site, articles []*model.ProcessedArticle) *model.Site {
 	return &model.Site{
-		Config:     base.Config,
-		Articles:   articles,
-		Tags:       base.Tags,
-		Categories: base.Categories,
+		Config:       base.Config,
+		Articles:     articles,
+		Tags:         base.Tags,
+		Categories:   base.Categories,
+		ArchiveYears: base.ArchiveYears,
 	}
 }
 
@@ -602,11 +603,28 @@ func localeTaxonomyBase(base *model.Site, articles []*model.ProcessedArticle) *m
 		cats = base.Categories
 	}
 	return &model.Site{
-		Config:     base.Config,
-		Articles:   base.Articles,
-		Tags:       tags,
-		Categories: cats,
+		Config:       base.Config,
+		Articles:     base.Articles,
+		Tags:         tags,
+		Categories:   cats,
+		ArchiveYears: archiveYears(articles),
 	}
+}
+
+// archiveYears returns the unique years present in articles, sorted newest-first.
+func archiveYears(articles []*model.ProcessedArticle) []int {
+	seen := make(map[int]bool)
+	for _, a := range articles {
+		if !a.FrontMatter.Date.IsZero() {
+			seen[a.FrontMatter.Date.Year()] = true
+		}
+	}
+	years := make([]int, 0, len(seen))
+	for y := range seen {
+		years = append(years, y)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(years)))
+	return years
 }
 
 // siteWithPagination creates a site copy with a custom article list and pagination metadata.

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -683,6 +683,61 @@ func TestGenerate_SkipsDateZeroArchiveI18n(t *testing.T) {
 	}
 }
 
+func TestArchiveYears_SortedDesc(t *testing.T) {
+	articles := []*model.ProcessedArticle{
+		{Article: model.Article{FrontMatter: model.FrontMatter{Date: time.Date(2023, 5, 1, 0, 0, 0, 0, time.UTC)}}},
+		{Article: model.Article{FrontMatter: model.FrontMatter{Date: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)}}},
+		{Article: model.Article{FrontMatter: model.FrontMatter{Date: time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC)}}}, // duplicate year
+		{Article: model.Article{FrontMatter: model.FrontMatter{Date: time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)}}},
+		{Article: model.Article{FrontMatter: model.FrontMatter{}}}, // zero date — must be skipped
+	}
+	got := archiveYears(articles)
+	want := []int{2025, 2024, 2023}
+	if len(got) != len(want) {
+		t.Fatalf("archiveYears: got %v, want %v", got, want)
+	}
+	for i, y := range want {
+		if got[i] != y {
+			t.Errorf("archiveYears[%d]: got %d, want %d", i, got[i], y)
+		}
+	}
+}
+
+func TestArchiveYears_Empty(t *testing.T) {
+	if got := archiveYears(nil); len(got) != 0 {
+		t.Errorf("archiveYears(nil): expected empty, got %v", got)
+	}
+}
+
+func TestLocaleTaxonomyBase_SetsArchiveYears(t *testing.T) {
+	base := &model.Site{Config: model.Config{}}
+	articles := []*model.ProcessedArticle{
+		{Article: model.Article{FrontMatter: model.FrontMatter{Tags: []string{"go"}, Date: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}}},
+		{Article: model.Article{FrontMatter: model.FrontMatter{Tags: []string{"go"}, Date: time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC)}}},
+	}
+	got := localeTaxonomyBase(base, articles)
+	want := []int{2024, 2022}
+	if len(got.ArchiveYears) != len(want) {
+		t.Fatalf("ArchiveYears: got %v, want %v", got.ArchiveYears, want)
+	}
+	for i, y := range want {
+		if got.ArchiveYears[i] != y {
+			t.Errorf("ArchiveYears[%d]: got %d, want %d", i, got.ArchiveYears[i], y)
+		}
+	}
+}
+
+func TestSiteFor_PropagatesArchiveYears(t *testing.T) {
+	base := &model.Site{
+		Config:       model.Config{},
+		ArchiveYears: []int{2025, 2024, 2023},
+	}
+	got := siteFor(base, nil)
+	if len(got.ArchiveYears) != 3 || got.ArchiveYears[0] != 2025 {
+		t.Errorf("siteFor: ArchiveYears not propagated: %v", got.ArchiveYears)
+	}
+}
+
 func TestArticleOutputPath_UsesOutputPath(t *testing.T) {
 	outDir := "/abs/public"
 	cfg := model.Config{Build: model.BuildConfig{OutputDir: "public"}}

--- a/internal/model/site.go
+++ b/internal/model/site.go
@@ -6,6 +6,7 @@ type Site struct {
 	Articles        []*ProcessedArticle
 	Tags            []Taxonomy
 	Categories      []Taxonomy
+	ArchiveYears    []int               // unique years that have articles, sorted newest-first
 	Pagination      *Pagination         // nil when pagination is disabled or not a listing page
 	CurrentLocale   string              // locale for the current page; empty when i18n is not configured
 	RelatedArticles []*ProcessedArticle // articles sharing at least one category with the current article (article pages only)


### PR DESCRIPTION
## Summary

Add `ArchiveYears []int` to `model.Site` so themes can render archive year links dynamically without hardcoding them in templates.

## Changes

### `internal/model/site.go`
- Added `ArchiveYears []int` field — unique years that have articles, sorted newest-first

### `internal/generator/html.go`
- Added `archiveYears(articles)` helper — extracts unique years from article dates, sorted descending
- `localeTaxonomyBase` now computes `ArchiveYears` from the locale-filtered articles so each locale's index page only shows years where that locale has articles
- `siteFor` propagates `ArchiveYears` from base

### `internal/generator/html_test.go`
- `TestArchiveYears_SortedDesc` — deduplication and descending sort
- `TestArchiveYears_Empty` — nil input
- `TestLocaleTaxonomyBase_SetsArchiveYears` — field is set correctly
- `TestSiteFor_PropagatesArchiveYears` — field is carried through

## Template usage (bmf-tech side)

```html
{{range .ArchiveYears}}
<a href="{{$locPfx}}/archives/{{.}}/" class="badge badge-light text-secondary">{{.}}</a>
{{end}}
```

This replaces 12 hardcoded year links and automatically picks up new years as articles are added.