### PR TITLE
docs: add ArchiveYears and CurrentTaxonomy to Site struct and template tables

### DIFF
--- a/docs/guide/templates.ja.md
+++ b/docs/guide/templates.ja.md
@@ -36,9 +36,11 @@ type Site struct {
     Articles        []*ProcessedArticle // ページに対応する記事一覧（絞り込み済み）
     Tags            []Taxonomy          // サイト全体のタグ一覧
     Categories      []Taxonomy          // サイト全体のカテゴリー一覧
+    ArchiveYears    []int               // 記事が存在する年の一覧（新しい順）
     Pagination      *Pagination         // ページング情報。ページネーション無効または一覧ページ以外は nil
     CurrentLocale   string              // 現在ページのロケールコード（例: "en", "ja"）。i18n 未設定時は空
     RelatedArticles []*ProcessedArticle // 現在記事と同一カテゴリーを持つ関連記事（記事ページのみ。他ページは nil）
+    CurrentTaxonomy *Taxonomy           // 一覧表示中のタグまたはカテゴリー。他ページは nil
 }
 ```
 
@@ -111,11 +113,11 @@ type Taxonomy struct {
 
 | テンプレート | `.Articles` の内容 | 追加フィールド |
 |---|---|---|
-| `index.html` | サイト全体の全記事 | `.Pagination` |
+| `index.html` | サイト全体の全記事 | `.Pagination`、`.ArchiveYears`、`.Tags`、`.Categories` |
 | `article.html` | その記事 1 件のみ | `.RelatedArticles`、`.CurrentLocale` |
-| `tag.html` | そのタグを持つ記事 | `.Pagination` |
-| `category.html` | そのカテゴリーを持つ記事 | `.Pagination` |
-| `archive.html` | その年の記事 | — |
+| `tag.html` | そのタグを持つ記事 | `.Pagination`、`.CurrentTaxonomy` |
+| `category.html` | そのカテゴリーを持つ記事 | `.Pagination`、`.CurrentTaxonomy` |
+| `archive.html` | その年の記事 | `.CurrentLocale` |
 
 > **`article.html` の注意:** `{{range .Articles}}` ループの内側では `$` でルートフィールドにアクセスします。例: `$.RelatedArticles`、`$.CurrentLocale`、`$.Config`。
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -36,9 +36,11 @@ type Site struct {
     Articles        []*ProcessedArticle // Articles for the current page (filtered)
     Tags            []Taxonomy          // All tags across the site
     Categories      []Taxonomy          // All categories across the site
+    ArchiveYears    []int               // Unique years that have articles, sorted newest-first
     Pagination      *Pagination         // Paging metadata; nil when pagination is disabled or for non-listing pages
     CurrentLocale   string              // Locale for the current page (e.g. "en", "ja"); empty when i18n is not configured
     RelatedArticles []*ProcessedArticle // Articles sharing at least one category with the current article (article pages only; nil on all other pages)
+    CurrentTaxonomy *Taxonomy           // The tag or category being listed; nil on all other pages
 }
 ```
 
@@ -134,11 +136,11 @@ type Taxonomy struct {
 
 | Template | `.Articles` contains | Extra fields available |
 |---|---|---|
-| `index.html` | All articles on the site | `.Pagination` |
+| `index.html` | All articles on the site | `.Pagination`, `.ArchiveYears`, `.Tags`, `.Categories` |
 | `article.html` | The single article being rendered | `.RelatedArticles`, `.CurrentLocale` |
-| `tag.html` | Articles that have this tag | `.Pagination` |
-| `category.html` | Articles that belong to this category | `.Pagination` |
-| `archive.html` | Articles published in this year | — |
+| `tag.html` | Articles that have this tag | `.Pagination`, `.CurrentTaxonomy` |
+| `category.html` | Articles that belong to this category | `.Pagination`, `.CurrentTaxonomy` |
+| `archive.html` | Articles published in this year | `.CurrentLocale` |
 
 > **Note on `article.html`:** inside a `{{range .Articles}}` loop, use `$` to access root-level fields — e.g. `$.RelatedArticles`, `$.CurrentLocale`, `$.Config`.
 


### PR DESCRIPTION
## Summary

Update `docs/guide/templates.md` and `docs/guide/templates.ja.md` to document two fields that were missing from the `Site` struct reference.

## Changes

### `ArchiveYears []int` (added in PR #99)
- Added to the `Site` struct code block with comment
- Added to the per-template extra fields table for `index.html`

### `CurrentTaxonomy *Taxonomy` (existed but undocumented)
- Added to the `Site` struct code block with comment
- Added to the per-template extra fields table for `tag.html` and `category.html`

### Per-template extra fields table updates
| Template | Before | After |
|---|---|---|
| `index.html` | `.Pagination` | `.Pagination`, `.ArchiveYears`, `.Tags`, `.Categories` |
| `tag.html` | `.Pagination` | `.Pagination`, `.CurrentTaxonomy` |
| `category.html` | `.Pagination` | `.Pagination`, `.CurrentTaxonomy` |
| `archive.html` | — | `.CurrentLocale` |