### PR TITLE
fix: add URL field to Taxonomy for locale-aware language switcher

### DIFF
--- a/docs/features/i18n.ja.md
+++ b/docs/features/i18n.ja.md
@@ -104,6 +104,8 @@ I18n I18nConfig `yaml:"i18n"`
 
 ### 言語切替リンク
 
+記事ページでは `.Article.Translations` を使って翻訳版へのリンクを生成します：
+
 ```html
 {{if .Article.Translations}}
 <nav aria-label="Language">
@@ -114,6 +116,50 @@ I18n I18nConfig `yaml:"i18n"`
 </nav>
 {{end}}
 ```
+
+### 一覧ページの言語切替リンク
+
+タグ・カテゴリ一覧ページには `.Article.Translations` がありません。代わりに
+`.CurrentTaxonomy.URL`（先頭スラッシュ付き・ロケール対応）を使って別言語の URL を導出します：
+
+```html
+{{/* tag.html / category.html */}}
+{{- $altURL := "/ja/"}}
+{{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
+{{- if .CurrentTaxonomy}}
+  {{- if eq .CurrentLocale "ja"}}
+    {{/* 先頭の "/ja" を除去して EN パスを得る */}}
+    {{- $altURL = slice .CurrentTaxonomy.URL 3}}
+  {{- else}}
+    {{- $altURL = printf "/ja%s" .CurrentTaxonomy.URL}}
+  {{- end}}
+{{- end}}
+<a href="{{$altURL}}">言語を切り替える</a>
+```
+
+アーカイブ一覧ページでは `.CurrentArchivePath` を同様に使います：
+
+```html
+{{/* archive.html */}}
+{{- $altURL := "/ja/"}}
+{{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
+{{- if .CurrentArchivePath}}
+  {{- if eq .CurrentLocale "ja"}}
+    {{- $altURL = .CurrentArchivePath}}
+  {{- else}}
+    {{- $altURL = printf "/ja%s" .CurrentArchivePath}}
+  {{- end}}
+{{- end}}
+<a href="{{$altURL}}">言語を切り替える</a>
+```
+
+どちらのフィールドも gohan がすべての一覧ページで設定します：
+
+| テンプレート | フィールド | 値の例（EN） | 値の例（JA） |
+|---|---|---|---|
+| `tag.html`、`category.html` | `.CurrentTaxonomy.URL` | `/tags/go/` | `/ja/tags/go/` |
+| `archive.html`（年） | `.CurrentArchivePath` | `/archives/2024/` | `/ja/archives/2024/` |
+| `archive.html`（月） | `.CurrentArchivePath` | `/archives/2024/01/` | `/ja/archives/2024/01/` |
 
 ### ロケール条件分岐
 

--- a/docs/features/i18n.md
+++ b/docs/features/i18n.md
@@ -104,6 +104,8 @@ Index pages follow the same rule:
 
 ### Language switcher
 
+For article pages, use `.Article.Translations` to link to the translated version:
+
 ```html
 {{if .Article.Translations}}
 <nav aria-label="Language">
@@ -114,6 +116,51 @@ Index pages follow the same rule:
 </nav>
 {{end}}
 ```
+
+### Language switcher on listing pages
+
+Tag and category listing pages do not have `.Article.Translations`. Instead, use
+`.CurrentTaxonomy.URL` (which already contains a leading slash and is locale-aware)
+to derive the alternate-locale URL:
+
+```html
+{{/* tag.html / category.html */}}
+{{- $altURL := "/ja/"}}
+{{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
+{{- if .CurrentTaxonomy}}
+  {{- if eq .CurrentLocale "ja"}}
+    {{/* strip the leading "/ja" prefix to get the EN path */}}
+    {{- $altURL = slice .CurrentTaxonomy.URL 3}}
+  {{- else}}
+    {{- $altURL = printf "/ja%s" .CurrentTaxonomy.URL}}
+  {{- end}}
+{{- end}}
+<a href="{{$altURL}}">Switch language</a>
+```
+
+Archive listing pages use `.CurrentArchivePath` in the same way:
+
+```html
+{{/* archive.html */}}
+{{- $altURL := "/ja/"}}
+{{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
+{{- if .CurrentArchivePath}}
+  {{- if eq .CurrentLocale "ja"}}
+    {{- $altURL = .CurrentArchivePath}}
+  {{- else}}
+    {{- $altURL = printf "/ja%s" .CurrentArchivePath}}
+  {{- end}}
+{{- end}}
+<a href="{{$altURL}}">Switch language</a>
+```
+
+Both fields are set by gohan for every listing page:
+
+| Template | Field | Example value (EN) | Example value (JA) |
+|---|---|---|---|
+| `tag.html`, `category.html` | `.CurrentTaxonomy.URL` | `/tags/go/` | `/ja/tags/go/` |
+| `archive.html` (year) | `.CurrentArchivePath` | `/archives/2024/` | `/ja/archives/2024/` |
+| `archive.html` (month) | `.CurrentArchivePath` | `/archives/2024/01/` | `/ja/archives/2024/01/` |
 
 ### Locale-aware conditional content
 

--- a/docs/guide/templates.ja.md
+++ b/docs/guide/templates.ja.md
@@ -39,8 +39,9 @@ type Site struct {
     ArchiveYears    []int               // 記事が存在する年の一覧（新しい順）
     Pagination      *Pagination         // ページング情報。ページネーション無効または一覧ページ以外は nil
     CurrentLocale   string              // 現在ページのロケールコード（例: "en", "ja"）。i18n 未設定時は空
-    RelatedArticles []*ProcessedArticle // 現在記事と同一カテゴリーを持つ関連記事（記事ページのみ。他ページは nil）
-    CurrentTaxonomy *Taxonomy           // 一覧表示中のタグまたはカテゴリー。他ページは nil
+    RelatedArticles    []*ProcessedArticle // 現在記事と同一カテゴリーを持つ関連記事（記事ページのみ。他ページは nil）
+    CurrentTaxonomy    *Taxonomy           // 一覧表示中のタグまたはカテゴリー。他ページは nil
+    CurrentArchivePath string              // アーカイブページでのロケール非依存パス（例: "/archives/2024/01/"）。他ページは空文字
 }
 ```
 
@@ -104,6 +105,7 @@ type FrontMatter struct {
 type Taxonomy struct {
     Name        string // タグ/カテゴリー名
     Description string // 説明（任意）
+    URL         string // レンダリング時に設定されるロケール対応の正規 URL パス（例: "/ja/tags/go/"）。paginatedJobs 外では空文字
 }
 ```
 
@@ -115,9 +117,9 @@ type Taxonomy struct {
 |---|---|---|
 | `index.html` | サイト全体の全記事 | `.Pagination`、`.ArchiveYears`、`.Tags`、`.Categories` |
 | `article.html` | その記事 1 件のみ | `.RelatedArticles`、`.CurrentLocale` |
-| `tag.html` | そのタグを持つ記事 | `.Pagination`、`.CurrentTaxonomy` |
-| `category.html` | そのカテゴリーを持つ記事 | `.Pagination`、`.CurrentTaxonomy` |
-| `archive.html` | その年の記事 | `.CurrentLocale` |
+| `tag.html` | そのタグを持つ記事 | `.Pagination`、`.CurrentTaxonomy`（`.CurrentTaxonomy.URL` 設定済み） |
+| `category.html` | そのカテゴリーを持つ記事 | `.Pagination`、`.CurrentTaxonomy`（`.CurrentTaxonomy.URL` 設定済み） |
+| `archive.html` | その年/月の記事 | `.CurrentLocale`、`.CurrentArchivePath` |
 
 > **`article.html` の注意:** `{{range .Articles}}` ループの内側では `$` でルートフィールドにアクセスします。例: `$.RelatedArticles`、`$.CurrentLocale`、`$.Config`。
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -39,8 +39,9 @@ type Site struct {
     ArchiveYears    []int               // Unique years that have articles, sorted newest-first
     Pagination      *Pagination         // Paging metadata; nil when pagination is disabled or for non-listing pages
     CurrentLocale   string              // Locale for the current page (e.g. "en", "ja"); empty when i18n is not configured
-    RelatedArticles []*ProcessedArticle // Articles sharing at least one category with the current article (article pages only; nil on all other pages)
-    CurrentTaxonomy *Taxonomy           // The tag or category being listed; nil on all other pages
+    RelatedArticles    []*ProcessedArticle // Articles sharing at least one category with the current article (article pages only; nil on all other pages)
+    CurrentTaxonomy    *Taxonomy           // The tag or category being listed; nil on all other pages
+    CurrentArchivePath string              // Set on archive pages; locale-neutral path, e.g. "/archives/2024/01/"; empty on all other pages
 }
 ```
 
@@ -127,6 +128,7 @@ type FrontMatter struct {
 type Taxonomy struct {
     Name        string // Tag or category name
     Description string // Optional description
+    URL         string // Locale-aware canonical URL path set at render time, e.g. "/ja/tags/go/"; empty outside paginatedJobs
 }
 ```
 
@@ -138,9 +140,9 @@ type Taxonomy struct {
 |---|---|---|
 | `index.html` | All articles on the site | `.Pagination`, `.ArchiveYears`, `.Tags`, `.Categories` |
 | `article.html` | The single article being rendered | `.RelatedArticles`, `.CurrentLocale` |
-| `tag.html` | Articles that have this tag | `.Pagination`, `.CurrentTaxonomy` |
-| `category.html` | Articles that belong to this category | `.Pagination`, `.CurrentTaxonomy` |
-| `archive.html` | Articles published in this year | `.CurrentLocale` |
+| `tag.html` | Articles that have this tag | `.Pagination`, `.CurrentTaxonomy` (`.CurrentTaxonomy.URL` set) |
+| `category.html` | Articles that belong to this category | `.Pagination`, `.CurrentTaxonomy` (`.CurrentTaxonomy.URL` set) |
+| `archive.html` | Articles published in this year/month | `.CurrentLocale`, `.CurrentArchivePath` |
 
 > **Note on `article.html`:** inside a `{{range .Articles}}` loop, use `$` to access root-level fields — e.g. `$.RelatedArticles`, `$.CurrentLocale`, `$.Config`.
 

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -378,6 +378,12 @@ func paginatedJobs(
 	// Build a locale-specific base so that listing pages see only the
 	// tags/categories present in the locale's articles (all of them,
 	// not just the current page slice).
+	// Attach locale-aware URL to taxonomy so templates can build language-switcher links.
+	if taxonomy != nil && baseURLPath != "" {
+		taxCopy := *taxonomy
+		taxCopy.URL = baseURLPath + "/"
+		taxonomy = &taxCopy
+	}
 	base := localeTaxonomyBase(site, articles)
 	if perPage <= 0 {
 		var path string

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -286,6 +286,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 				k := key
 				d := siteFor(site, as)
 				d.CurrentLocale = locale
+				d.CurrentArchivePath = fmt.Sprintf("/archives/%04d/%02d/", k.year, int(k.month))
 				jobs = append(jobs, writeJob{
 					path: filepath.Join(g.outDir, archivePrefix, "archives",
 						fmt.Sprintf("%04d", k.year),
@@ -303,6 +304,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 				y := year
 				d := siteFor(site, as)
 				d.CurrentLocale = locale
+				d.CurrentArchivePath = fmt.Sprintf("/archives/%04d/", y)
 				jobs = append(jobs, writeJob{
 					path: filepath.Join(g.outDir, archivePrefix, "archives",
 						fmt.Sprintf("%04d", y),

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -27,6 +27,28 @@ func (m *mockEngine) Render(w io.Writer, name string, _ *model.Site) error {
 	return err
 }
 
+// captureEngine records each Render call with its template name and a copy of the Site data.
+type captureRender struct {
+	tmpl string
+	data *model.Site
+}
+
+type captureEngine struct {
+	mu      sync.Mutex
+	renders []captureRender
+}
+
+func (c *captureEngine) Load(_ string, _ htmltemplate.FuncMap) error { return nil }
+func (c *captureEngine) Render(w io.Writer, name string, data *model.Site) error {
+	// Copy the site value so mutations after Render don't affect captured state.
+	dataCopy := *data
+	c.mu.Lock()
+	c.renders = append(c.renders, captureRender{tmpl: name, data: &dataCopy})
+	c.mu.Unlock()
+	_, err := io.WriteString(w, "<html>"+name+"</html>")
+	return err
+}
+
 func makeSite() *model.Site {
 	now := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
 	return &model.Site{
@@ -317,6 +339,97 @@ func TestPaginatedJobs_CurrentTaxonomy(t *testing.T) {
 	indexJobs := paginatedJobs(site, articles, "/out", "index.html", "", "/", 0, "", nil)
 	if indexJobs[0].data.CurrentTaxonomy != nil {
 		t.Error("CurrentTaxonomy should be nil for index page")
+	}
+}
+
+func TestPaginatedJobs_TaxonomyURL(t *testing.T) {
+	site := makeSite()
+	articles := makePaginatedArticles(2)
+	tax := &model.Taxonomy{Name: "go"}
+
+	// EN tag: baseURLPath="/tags/go" → URL set to "/tags/go/"
+	jobs := paginatedJobs(site, articles, "/out", "tag.html", "tags/go", "/tags/go", 0, "en", tax)
+	if jobs[0].data.CurrentTaxonomy == nil {
+		t.Fatal("CurrentTaxonomy should not be nil")
+	}
+	if got, want := jobs[0].data.CurrentTaxonomy.URL, "/tags/go/"; got != want {
+		t.Errorf("Taxonomy.URL = %q, want %q", got, want)
+	}
+
+	// JA tag: baseURLPath="/ja/tags/go" → URL set to "/ja/tags/go/"
+	jobs2 := paginatedJobs(site, articles, "/out", "tag.html", "ja/tags/go", "/ja/tags/go", 0, "ja", tax)
+	if got, want := jobs2[0].data.CurrentTaxonomy.URL, "/ja/tags/go/"; got != want {
+		t.Errorf("JA Taxonomy.URL = %q, want %q", got, want)
+	}
+
+	// Empty baseURLPath: URL should not be set (remains "")
+	jobs3 := paginatedJobs(site, articles, "/out", "index.html", "", "", 0, "", tax)
+	if jobs3[0].data.CurrentTaxonomy != nil && jobs3[0].data.CurrentTaxonomy.URL != "" {
+		t.Errorf("Taxonomy.URL should be empty when baseURLPath is empty, got %q", jobs3[0].data.CurrentTaxonomy.URL)
+	}
+}
+
+func TestGenerate_ArchiveCurrentArchivePath(t *testing.T) {
+	outDir := t.TempDir()
+	cfg := model.Config{
+		Build: model.BuildConfig{Parallelism: 1},
+		I18n:  model.I18nConfig{Locales: []string{"en", "ja"}, DefaultLocale: "en"},
+	}
+	now := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+	site := &model.Site{
+		Config: cfg,
+		Articles: []*model.ProcessedArticle{
+			{
+				Article: model.Article{FrontMatter: model.FrontMatter{
+					Slug: "post-en", Date: now,
+				}},
+				Locale: "en",
+			},
+			{
+				Article: model.Article{FrontMatter: model.FrontMatter{
+					Slug: "post-ja", Date: now,
+				}},
+				Locale: "ja",
+			},
+		},
+	}
+	eng := &captureEngine{}
+	g := NewHTMLGenerator(outDir, eng, cfg)
+	if err := g.Generate(site, nil); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	// Find archive jobs and check CurrentArchivePath
+	eng.mu.Lock()
+	defer eng.mu.Unlock()
+	var enMonthPath, jaMonthPath, enYearPath, jaYearPath string
+	for _, r := range eng.renders {
+		if r.tmpl != "archive.html" {
+			continue
+		}
+		path := r.data.CurrentArchivePath
+		locale := r.data.CurrentLocale
+		switch {
+		case locale == "en" && path == "/archives/2024/03/":
+			enMonthPath = path
+		case locale == "en" && path == "/archives/2024/":
+			enYearPath = path
+		case locale == "ja" && path == "/archives/2024/03/":
+			jaMonthPath = path
+		case locale == "ja" && path == "/archives/2024/":
+			jaYearPath = path
+		}	}
+	if enMonthPath == "" {
+		t.Error("EN month archive: CurrentArchivePath not set to /archives/2024/03/")
+	}
+	if enYearPath == "" {
+		t.Error("EN year archive: CurrentArchivePath not set to /archives/2024/")
+	}
+	if jaMonthPath == "" {
+		t.Error("JA month archive: CurrentArchivePath not set to /archives/2024/03/")
+	}
+	if jaYearPath == "" {
+		t.Error("JA year archive: CurrentArchivePath not set to /archives/2024/")
 	}
 }
 

--- a/internal/model/site.go
+++ b/internal/model/site.go
@@ -11,6 +11,7 @@ type Site struct {
 	CurrentLocale   string              // locale for the current page; empty when i18n is not configured
 	RelatedArticles []*ProcessedArticle // articles sharing at least one category with the current article (article pages only)
 	CurrentTaxonomy *Taxonomy           // set on tag and category listing pages; nil elsewhere
+	CurrentArchivePath string            // set on archive pages; locale-neutral path e.g. "/archives/2024/01/"
 }
 
 // Pagination holds computed paging metadata for listing pages.

--- a/internal/model/taxonomy.go
+++ b/internal/model/taxonomy.go
@@ -4,6 +4,7 @@ package model
 type Taxonomy struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
+	URL         string `yaml:"-"` // set at render time; locale-aware canonical URL
 }
 
 // TaxonomyRegistry holds the master lists loaded from taxonomy YAML files.


### PR DESCRIPTION
## Problem

On tag/category pages (`/ja/tags/{name}/`, `/ja/categories/{name}/`), clicking the EN language switcher in the navbar navigated to the home page (`/`) instead of the equivalent locale page (e.g. `/tags/{name}/`).

## Root Cause

`model.Taxonomy` only had `Name` and `Description` fields. Templates had no way to build the locale-alternate URL for the language switcher because `paginatedJobs` already computed `baseURLPath` (e.g. `/ja/tags/2phase-commit`) but never exposed it to templates.

## Fix

- Add `URL string` field to `model.Taxonomy` (tagged `yaml:"-"` so YAML loading is unaffected)  
- In `paginatedJobs`, copy the taxonomy and set `URL = baseURLPath + "/"` before assigning to template data  
- Templates can now use `slice .CurrentTaxonomy.URL 3` (strip `/ja`) or `prin- Templates can now use `slice .CurrentTaxonomy.URL 3` (strip `/ja`) or `prin- Templates can now use `slice .CurrentTaxonomy.URL 3` (strip `/ja`) or `prin- Templates can now use `slice .C {{- $altURL = slice .CurrentTaxonomy.URL 3}}
  {{- else}}
    {{- $altURL = printf "/ja%s" .CurrentTaxonomy.URL}}
  {{- end}}
{{- end}}
```