### PR TITLE
fix: locale-aware language switcher, 12-bug audit fixes, and Atom feed RFC 4287 compliance

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/bmf-san/gohan/internal/config"
@@ -142,11 +143,13 @@ func runBuild(args []string) error {
 	proc.BuildTranslationMap(processed)
 
 	// Validate that no two articles resolve to the same output path.
-	// Duplicate output paths cause silent page overwrites during HTML generation.
+	// Duplicate output paths would cause non-deterministic page overwrites.
 	if errs := processor.ValidateOutputPaths(processed); len(errs) > 0 {
+		var msgs []string
 		for _, e := range errs {
-			fmt.Fprintf(os.Stderr, "warn: output path: %v\n", e)
+			msgs = append(msgs, e.Error())
 		}
+		return fmt.Errorf("duplicate output paths: %s", strings.Join(msgs, "; "))
 	}
 
 	// Build taxonomy registry.
@@ -201,7 +204,7 @@ func runBuild(args []string) error {
 	templateDir := filepath.Join(rootDir, cfg.Theme.Dir, "templates")
 	tmpl := gohantemplate.NewEngine()
 	if loadErr := tmpl.Load(templateDir, nil, cfg.I18n.DefaultLocale); loadErr != nil {
-		fmt.Fprintf(os.Stderr, "warn: load templates: %v\n", loadErr)
+		return fmt.Errorf("load templates: %w", loadErr)
 	}
 	gen := generator.NewHTMLGenerator(outDir, tmpl, *cfg)
 	if err := gen.Generate(site, changeSet); err != nil {
@@ -220,7 +223,10 @@ func runBuild(args []string) error {
 	newManifest := diff.NewManifest(configHash)
 	hashEngine := diff.NewGitDiffEngine(contentDir)
 	for _, a := range articles {
-		rel, _ := filepath.Rel(contentDir, a.FilePath)
+		rel, relErr := filepath.Rel(contentDir, a.FilePath)
+		if relErr != nil {
+			continue
+		}
 		if h, herr := hashEngine.Hash(a.FilePath); herr == nil {
 			newManifest.FileHashes[rel] = h
 		}

--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -212,7 +212,7 @@ func runBuild(args []string) error {
 	if err := generator.GenerateSitemap(outDir, cfg.Site.BaseURL, processed, *cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: sitemap: %v\n", err)
 	}
-	if err := generator.GenerateFeeds(outDir, cfg.Site.BaseURL, cfg.Site.Title, processed); err != nil {
+	if err := generator.GenerateFeeds(outDir, cfg.Site.BaseURL, cfg.Site.Title, processed, *cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: feeds: %v\n", err)
 	}
 

--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -200,7 +200,7 @@ func runBuild(args []string) error {
 	outDir := cfg.Build.OutputDir
 	templateDir := filepath.Join(rootDir, cfg.Theme.Dir, "templates")
 	tmpl := gohantemplate.NewEngine()
-	if loadErr := tmpl.Load(templateDir, nil); loadErr != nil {
+	if loadErr := tmpl.Load(templateDir, nil, cfg.I18n.DefaultLocale); loadErr != nil {
 		fmt.Fprintf(os.Stderr, "warn: load templates: %v\n", loadErr)
 	}
 	gen := generator.NewHTMLGenerator(outDir, tmpl, *cfg)

--- a/cmd/gohan/new.go
+++ b/cmd/gohan/new.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,11 +49,6 @@ func runNew(args []string) error {
 
 	filePath := filepath.Join(dir, slug+".md")
 
-	// Error if file already exists
-	if _, err := os.Stat(filePath); err == nil {
-		return fmt.Errorf("file already exists: %s", filePath)
-	}
-
 	// Create directory if needed
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
@@ -70,7 +66,18 @@ categories: []
 
 `, articleTitle, today)
 
-	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+	// BUG-D: use O_CREATE|O_EXCL for an atomic create-or-fail, eliminating the
+	// TOCTOU race between the old os.Stat check and os.WriteFile.
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("file already exists: %s", filePath)
+		}
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := io.WriteString(f, content); err != nil {
+		_ = os.Remove(filePath)
 		return fmt.Errorf("failed to write file: %w", err)
 	}
 

--- a/docs/features/i18n.ja.md
+++ b/docs/features/i18n.ja.md
@@ -145,7 +145,7 @@ I18n I18nConfig `yaml:"i18n"`
 {{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
 {{- if .CurrentArchivePath}}
   {{- if eq .CurrentLocale "ja"}}
-    {{- $altURL = .CurrentArchivePath}}
+    {{- $altURL = slice .CurrentArchivePath 3}}
   {{- else}}
     {{- $altURL = printf "/ja%s" .CurrentArchivePath}}
   {{- end}}

--- a/docs/features/i18n.md
+++ b/docs/features/i18n.md
@@ -146,7 +146,7 @@ Archive listing pages use `.CurrentArchivePath` in the same way:
 {{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
 {{- if .CurrentArchivePath}}
   {{- if eq .CurrentLocale "ja"}}
-    {{- $altURL = .CurrentArchivePath}}
+    {{- $altURL = slice .CurrentArchivePath 3}}
   {{- else}}
     {{- $altURL = printf "/ja%s" .CurrentArchivePath}}
   {{- end}}

--- a/docs/guide/templates.ja.md
+++ b/docs/guide/templates.ja.md
@@ -41,7 +41,8 @@ type Site struct {
     CurrentLocale   string              // 現在ページのロケールコード（例: "en", "ja"）。i18n 未設定時は空
     RelatedArticles    []*ProcessedArticle // 現在記事と同一カテゴリーを持つ関連記事（記事ページのみ。他ページは nil）
     CurrentTaxonomy    *Taxonomy           // 一覧表示中のタグまたはカテゴリー。他ページは nil
-    CurrentArchivePath string              // アーカイブページでのロケール非依存パス（例: "/archives/2024/01/"）。他ページは空文字
+    CurrentArchivePath   string              // アーカイブページでのロケール対応パス（例: EN "/archives/2024/01/"、JA "/ja/archives/2024/01/"）。他ページは空文字
+    CurrentArchiveIsMonth bool                // 月別アーカイブページで true（例: /archives/2024/01/）、年別アーカイブページで false（例: /archives/2024/）
 }
 ```
 

--- a/docs/guide/templates.ja.md
+++ b/docs/guide/templates.ja.md
@@ -131,8 +131,8 @@ type Taxonomy struct {
 | 関数 | 使用例 | 説明 |
 |---|---|---|
 | `formatDate` | `{{formatDate "2006-01-02" .FrontMatter.Date}}` | 日付フォーマット |
-| `tagURL` | `{{tagURL "go"}}` → `/tags/go/` | タグページの URL |
-| `categoryURL` | `{{categoryURL "tech"}}` → `/categories/tech/` | カテゴリーページの URL |
+| `tagURL` | `{{tagURL .CurrentLocale "go"}}` → `/tags/go/`（EN）または `/ja/tags/go/`（JA） | ロケール対応のタグページ URL |
+| `categoryURL` | `{{categoryURL .CurrentLocale "tech"}}` → `/categories/tech/`（EN） | ロケール対応のカテゴリーページ URL |
 | `markdownify` | `{{markdownify "**bold**"}}` | Markdown を HTML に変換 |
 
 `formatDate` のレイアウト文字列は [Go の time フォーマット](https://pkg.go.dev/time#Layout) に従います:

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -41,7 +41,8 @@ type Site struct {
     CurrentLocale   string              // Locale for the current page (e.g. "en", "ja"); empty when i18n is not configured
     RelatedArticles    []*ProcessedArticle // Articles sharing at least one category with the current article (article pages only; nil on all other pages)
     CurrentTaxonomy    *Taxonomy           // The tag or category being listed; nil on all other pages
-    CurrentArchivePath string              // Set on archive pages; locale-neutral path, e.g. "/archives/2024/01/"; empty on all other pages
+    CurrentArchivePath   string              // Set on archive pages; locale-aware path, e.g. "/archives/2024/01/" (EN) or "/ja/archives/2024/01/" (JA); empty on all other pages
+    CurrentArchiveIsMonth bool                // true on month archive pages (e.g. /archives/2024/01/); false on year archive pages (e.g. /archives/2024/)
 }
 ```
 

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -154,8 +154,8 @@ type Taxonomy struct {
 | Function | Example | Description |
 |---|---|---|
 | `formatDate` | `{{formatDate "2006-01-02" .FrontMatter.Date}}` | Format a `time.Time` value |
-| `tagURL` | `{{tagURL "go"}}` → `/tags/go/` | Generate a tag page URL |
-| `categoryURL` | `{{categoryURL "tech"}}` → `/categories/tech/` | Generate a category page URL |
+| `tagURL` | `{{tagURL .CurrentLocale "go"}}` → `/tags/go/` (EN) or `/ja/tags/go/` (JA) | Generate a locale-aware tag page URL |
+| `categoryURL` | `{{categoryURL .CurrentLocale "tech"}}` → `/categories/tech/` (EN) | Generate a locale-aware category page URL |
 | `markdownify` | `{{markdownify "**bold**"}}` | Convert a Markdown string to HTML |
 
 `formatDate` uses Go's [reference time](https://pkg.go.dev/time#Layout) layout:
@@ -192,7 +192,7 @@ type Taxonomy struct {
         <a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>
         {{if .FrontMatter.Tags}}
         <span>
-          {{range .FrontMatter.Tags}}<a href="{{tagURL .}}">#{{.}}</a> {{end}}
+          {{range .FrontMatter.Tags}}<a href="{{tagURL $.CurrentLocale .}}">#{{.}}</a> {{end}}
         </span>
         {{end}}
       </li>
@@ -232,7 +232,7 @@ type Taxonomy struct {
       {{if .FrontMatter.Author}}<span> · {{.FrontMatter.Author}}</span>{{end}}
       {{if .FrontMatter.Tags}}
       <ul class="tags">
-        {{range .FrontMatter.Tags}}<li><a href="{{tagURL .}}">{{.}}</a></li>{{end}}
+        {{range .FrontMatter.Tags}}<li><a href="{{tagURL $.CurrentLocale .}}">{{.}}</a></li>{{end}}
       </ul>
       {{end}}
       <div class="content">{{.HTMLContent}}</div>

--- a/internal/diff/cache.go
+++ b/internal/diff/cache.go
@@ -31,7 +31,9 @@ func ReadManifest(cacheDir string) (*model.BuildManifest, error) {
 	}
 	var m model.BuildManifest
 	if err := json.Unmarshal(data, &m); err != nil {
-		return nil, fmt.Errorf("unmarshal manifest: %w", err)
+		// Treat a corrupt or truncated manifest as absent so the next build
+		// performs a full rebuild rather than aborting with an error.
+		return nil, nil
 	}
 	return &m, nil
 }
@@ -47,7 +49,7 @@ func WriteManifest(cacheDir string, m *model.BuildManifest) error {
 		return fmt.Errorf("marshal manifest: %w", err)
 	}
 	path := filepath.Join(cacheDir, cacheManifestFile)
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := writeAtomicFile(path, data, 0644); err != nil {
 		return fmt.Errorf("write manifest: %w", err)
 	}
 	return nil
@@ -74,8 +76,38 @@ func WriteCachedHTML(cacheDir, slug, html string) error {
 		return fmt.Errorf("mkdir html cache: %w", err)
 	}
 	path := filepath.Join(dir, slug+".html")
-	if err := os.WriteFile(path, []byte(html), 0644); err != nil {
+	if err := writeAtomicFile(path, []byte(html), 0644); err != nil {
 		return fmt.Errorf("write cached html: %w", err)
+	}
+	return nil
+}
+
+// writeAtomicFile writes data to path atomically using a temp-file-then-rename
+// pattern so that a crash or kill mid-write never leaves a truncated file.
+func writeAtomicFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".gohan-cache-tmp-")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	_, werr := tmp.Write(data)
+	cerr := tmp.Close()
+	if werr != nil {
+		_ = os.Remove(tmpName)
+		return werr
+	}
+	if cerr != nil {
+		_ = os.Remove(tmpName)
+		return cerr
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return err
 	}
 	return nil
 }

--- a/internal/diff/cache.go
+++ b/internal/diff/cache.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	cacheManifestFile = "manifest.json"
-	cacheHTMLDir      = "html"
 	configHashKey     = "__config__"
 	manifestVersion   = "1"
 )
@@ -51,33 +50,6 @@ func WriteManifest(cacheDir string, m *model.BuildManifest) error {
 	path := filepath.Join(cacheDir, cacheManifestFile)
 	if err := writeAtomicFile(path, data, 0644); err != nil {
 		return fmt.Errorf("write manifest: %w", err)
-	}
-	return nil
-}
-
-// ReadCachedHTML returns the cached HTML for slug from cacheDir/html/<slug>.html.
-// Returns ("", nil) when not present.
-func ReadCachedHTML(cacheDir, slug string) (string, error) {
-	path := filepath.Join(cacheDir, cacheHTMLDir, slug+".html")
-	data, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("read cached html: %w", err)
-	}
-	return string(data), nil
-}
-
-// WriteCachedHTML stores html under cacheDir/html/<slug>.html.
-func WriteCachedHTML(cacheDir, slug, html string) error {
-	dir := filepath.Join(cacheDir, cacheHTMLDir)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("mkdir html cache: %w", err)
-	}
-	path := filepath.Join(dir, slug+".html")
-	if err := writeAtomicFile(path, []byte(html), 0644); err != nil {
-		return fmt.Errorf("write cached html: %w", err)
 	}
 	return nil
 }

--- a/internal/diff/cache_test.go
+++ b/internal/diff/cache_test.go
@@ -30,22 +30,6 @@ func TestReadManifest_NotExist(t *testing.T) {
 	if m != nil { t.Error("expected nil") }
 }
 
-func TestWriteReadCachedHTML(t *testing.T) {
-	dir := t.TempDir()
-	html := "<h1>hello</h1>"
-	if err := WriteCachedHTML(dir, "my-post", html); err != nil { t.Fatalf("write: %v", err) }
-	got, err := ReadCachedHTML(dir, "my-post")
-	if err != nil { t.Fatalf("read: %v", err) }
-	if got != html { t.Errorf("got %q, want %q", got, html) }
-}
-
-func TestReadCachedHTML_NotExist(t *testing.T) {
-	dir := t.TempDir()
-	got, err := ReadCachedHTML(dir, "nope")
-	if err != nil { t.Fatalf("unexpected error: %v", err) }
-	if got != "" { t.Error("expected empty string") }
-}
-
 func TestClearCache(t *testing.T) {
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "cache")

--- a/internal/diff/cache_test.go
+++ b/internal/diff/cache_test.go
@@ -12,49 +12,79 @@ import (
 func TestWriteReadManifest(t *testing.T) {
 	dir := t.TempDir()
 	m := &model.BuildManifest{
-		Version:   "1",
-		BuildTime: time.Now().UTC().Truncate(time.Second),
+		Version:    "1",
+		BuildTime:  time.Now().UTC().Truncate(time.Second),
 		FileHashes: map[string]string{"a.md": "abc"},
 	}
-	if err := WriteManifest(dir, m); err != nil { t.Fatalf("WriteManifest: %v", err) }
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
 	got, err := ReadManifest(dir)
-	if err != nil { t.Fatalf("ReadManifest: %v", err) }
-	if got.Version != m.Version { t.Errorf("version mismatch") }
-	if got.FileHashes["a.md"] != "abc" { t.Error("hash mismatch") }
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if got.Version != m.Version {
+		t.Errorf("version mismatch")
+	}
+	if got.FileHashes["a.md"] != "abc" {
+		t.Error("hash mismatch")
+	}
 }
 
 func TestReadManifest_NotExist(t *testing.T) {
 	dir := t.TempDir()
 	m, err := ReadManifest(dir)
-	if err != nil { t.Fatalf("unexpected error: %v", err) }
-	if m != nil { t.Error("expected nil") }
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m != nil {
+		t.Error("expected nil")
+	}
 }
 
 func TestClearCache(t *testing.T) {
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "cache")
-	if err := os.MkdirAll(sub, 0755); err != nil { t.Fatal(err) }
-	if err := os.WriteFile(filepath.Join(sub, "x.json"), []byte("{}"), 0644); err != nil { t.Fatal(err) }
-	if err := ClearCache(sub); err != nil { t.Fatalf("ClearCache: %v", err) }
-	if _, err := os.Stat(sub); !os.IsNotExist(err) { t.Error("expected removed") }
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "x.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ClearCache(sub); err != nil {
+		t.Fatalf("ClearCache: %v", err)
+	}
+	if _, err := os.Stat(sub); !os.IsNotExist(err) {
+		t.Error("expected removed")
+	}
 }
 
 func TestCheckConfigChange_NilManifest(t *testing.T) {
-	if !CheckConfigChange(nil, "hash") { t.Error("expected true for nil") }
+	if !CheckConfigChange(nil, "hash") {
+		t.Error("expected true for nil")
+	}
 }
 
 func TestCheckConfigChange_Same(t *testing.T) {
 	m := &model.BuildManifest{FileHashes: map[string]string{"__config__": "h1"}}
-	if CheckConfigChange(m, "h1") { t.Error("expected false") }
+	if CheckConfigChange(m, "h1") {
+		t.Error("expected false")
+	}
 }
 
 func TestCheckConfigChange_Different(t *testing.T) {
 	m := &model.BuildManifest{FileHashes: map[string]string{"__config__": "old"}}
-	if !CheckConfigChange(m, "new") { t.Error("expected true") }
+	if !CheckConfigChange(m, "new") {
+		t.Error("expected true")
+	}
 }
 
 func TestNewManifest(t *testing.T) {
 	m := NewManifest("myhash")
-	if m.Version != "1" { t.Errorf("version: %s", m.Version) }
-	if m.FileHashes["__config__"] != "myhash" { t.Errorf("config hash: %v", m.FileHashes) }
+	if m.Version != "1" {
+		t.Errorf("version: %s", m.Version)
+	}
+	if m.FileHashes["__config__"] != "myhash" {
+		t.Errorf("config hash: %v", m.FileHashes)
+	}
 }

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -51,6 +51,9 @@ func (g *GitDiffEngine) Detect(manifest *model.BuildManifest) (*model.ChangeSet,
 		}
 	}
 	for path := range manifest.FileHashes {
+		if path == configHashKey {
+			continue // sentinel key — not a real content file
+		}
 		if _, ok := current[path]; !ok {
 			cs.DeletedFiles = append(cs.DeletedFiles, path)
 		}

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -109,6 +109,13 @@ func parseNameStatus(output string) *model.ChangeSet {
 			cs.ModifiedFiles = append(cs.ModifiedFiles, path)
 		case strings.HasPrefix(status, "D"):
 			cs.DeletedFiles = append(cs.DeletedFiles, path)
+		case strings.HasPrefix(status, "R"):
+			// Rename: treat old path as deleted, new path as added.
+			// Format: R<score>\told_path\tnew_path
+			cs.DeletedFiles = append(cs.DeletedFiles, path)
+			if len(parts) >= 3 {
+				cs.AddedFiles = append(cs.AddedFiles, parts[2])
+			}
 		}
 	}
 	return cs

--- a/internal/diff/git.go
+++ b/internal/diff/git.go
@@ -6,9 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/bmf-san/gohan/internal/model"
 )
@@ -64,64 +62,6 @@ func (g *GitDiffEngine) Detect(manifest *model.BuildManifest) (*model.ChangeSet,
 // Hash returns the SHA-256 hex digest of the file at filePath.
 func (g *GitDiffEngine) Hash(filePath string) (string, error) {
 	return hashFile(filePath)
-}
-
-// IsGitRepo reports whether dir is inside a Git working tree.
-func IsGitRepo(dir string) bool {
-	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(string(out)) == "true"
-}
-
-// DetectChanges runs git diff --name-status between fromCommit and toCommit
-// in rootDir and returns a ChangeSet. Falls back to an empty ChangeSet with
-// an error when rootDir is not a Git repo.
-func DetectChanges(rootDir, fromCommit, toCommit string) (*model.ChangeSet, error) {
-	if !IsGitRepo(rootDir) {
-		// Not a git repo: caller should treat this as a full build.
-		return &model.ChangeSet{}, nil
-	}
-	out, err := exec.Command("git", "-C", rootDir,
-		"diff", "--name-status", fromCommit, toCommit).Output()
-	if err != nil {
-		return nil, err
-	}
-	return parseNameStatus(string(out)), nil
-}
-
-// parseNameStatus parses the output of `git diff --name-status`.
-func parseNameStatus(output string) *model.ChangeSet {
-	cs := &model.ChangeSet{}
-	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
-		if line == "" {
-			continue
-		}
-		parts := strings.Fields(line)
-		if len(parts) < 2 {
-			continue
-		}
-		status, path := parts[0], parts[1]
-		switch {
-		case strings.HasPrefix(status, "A"):
-			cs.AddedFiles = append(cs.AddedFiles, path)
-		case strings.HasPrefix(status, "M"):
-			cs.ModifiedFiles = append(cs.ModifiedFiles, path)
-		case strings.HasPrefix(status, "D"):
-			cs.DeletedFiles = append(cs.DeletedFiles, path)
-		case strings.HasPrefix(status, "R"):
-			// Rename: treat old path as deleted, new path as added.
-			// Format: R<score>\told_path\tnew_path
-			cs.DeletedFiles = append(cs.DeletedFiles, path)
-			if len(parts) >= 3 {
-				cs.AddedFiles = append(cs.AddedFiles, parts[2])
-			}
-		}
-	}
-	return cs
 }
 
 // hashAllFiles walks rootDir and returns a map of relative-path → SHA-256 hex.

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -148,6 +148,21 @@ func TestParseNameStatus(t *testing.T) {
 	}
 }
 
+func TestParseNameStatus_Rename(t *testing.T) {
+	// git diff --name-status emits "R<score>\told\tnew" for renames.
+	output := "R100\tinternal/old.go\tinternal/new.go\n"
+	cs := parseNameStatus(output)
+	if len(cs.DeletedFiles) != 1 || cs.DeletedFiles[0] != "internal/old.go" {
+		t.Errorf("expected old path in DeletedFiles, got %v", cs.DeletedFiles)
+	}
+	if len(cs.AddedFiles) != 1 || cs.AddedFiles[0] != "internal/new.go" {
+		t.Errorf("expected new path in AddedFiles, got %v", cs.AddedFiles)
+	}
+	if len(cs.ModifiedFiles) != 0 {
+		t.Errorf("expected no ModifiedFiles, got %v", cs.ModifiedFiles)
+	}
+}
+
 func TestGitDiffEngine_Hash(t *testing.T) {
 	content := "gohan hash test"
 	path := writeTemp(t, content)

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -32,23 +32,6 @@ func writeTemp(t *testing.T, content string) string {
 	return f.Name()
 }
 
-func TestIsGitRepo_NonGit(t *testing.T) {
-	dir := t.TempDir()
-	if IsGitRepo(dir) {
-		t.Error("expected false for plain temp dir")
-	}
-}
-
-func TestIsGitRepo_GitDir(t *testing.T) {
-	root, err := filepath.Abs("../..")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !IsGitRepo(root) {
-		t.Errorf("expected true for project root %s", root)
-	}
-}
-
 func TestHash_ValidFile(t *testing.T) {
 	content := "hello gohan"
 	path := writeTemp(t, content)
@@ -134,35 +117,6 @@ func TestDetect_DeletedFile(t *testing.T) {
 	}
 }
 
-func TestParseNameStatus(t *testing.T) {
-	output := "M\tinternal/foo.go\nA\tinternal/bar.go\nD\tinternal/old.go\n"
-	cs := parseNameStatus(output)
-	if len(cs.ModifiedFiles) != 1 {
-		t.Errorf("modified: %v", cs.ModifiedFiles)
-	}
-	if len(cs.AddedFiles) != 1 {
-		t.Errorf("added: %v", cs.AddedFiles)
-	}
-	if len(cs.DeletedFiles) != 1 {
-		t.Errorf("deleted: %v", cs.DeletedFiles)
-	}
-}
-
-func TestParseNameStatus_Rename(t *testing.T) {
-	// git diff --name-status emits "R<score>\told\tnew" for renames.
-	output := "R100\tinternal/old.go\tinternal/new.go\n"
-	cs := parseNameStatus(output)
-	if len(cs.DeletedFiles) != 1 || cs.DeletedFiles[0] != "internal/old.go" {
-		t.Errorf("expected old path in DeletedFiles, got %v", cs.DeletedFiles)
-	}
-	if len(cs.AddedFiles) != 1 || cs.AddedFiles[0] != "internal/new.go" {
-		t.Errorf("expected new path in AddedFiles, got %v", cs.AddedFiles)
-	}
-	if len(cs.ModifiedFiles) != 0 {
-		t.Errorf("expected no ModifiedFiles, got %v", cs.ModifiedFiles)
-	}
-}
-
 func TestGitDiffEngine_Hash(t *testing.T) {
 	content := "gohan hash test"
 	path := writeTemp(t, content)
@@ -188,13 +142,4 @@ func TestGitDiffEngine_Hash_Missing(t *testing.T) {
 	}
 }
 
-func TestDetectChanges_NonGitDir(t *testing.T) {
-	dir := t.TempDir()
-	cs, err := DetectChanges(dir, "HEAD~1", "HEAD")
-	if err != nil {
-		t.Fatalf("DetectChanges on non-git dir: %v", err)
-	}
-	if len(cs.AddedFiles)+len(cs.ModifiedFiles)+len(cs.DeletedFiles) != 0 {
-		t.Errorf("expected empty ChangeSet for non-git dir, got %+v", cs)
-	}
-}
+

--- a/internal/diff/git_test.go
+++ b/internal/diff/git_test.go
@@ -141,5 +141,3 @@ func TestGitDiffEngine_Hash_Missing(t *testing.T) {
 		t.Error("expected error for missing file")
 	}
 }
-
-

--- a/internal/generator/atomic.go
+++ b/internal/generator/atomic.go
@@ -35,5 +35,9 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 		_ = os.Remove(tmpName)
 		return err
 	}
-	return os.Rename(tmpName, path)
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
 }

--- a/internal/generator/feed.go
+++ b/internal/generator/feed.go
@@ -59,7 +59,13 @@ type atomEntry struct {
 
 // GenerateFeeds writes feed.xml (RSS 2.0) and atom.xml (Atom 1.0) to outDir.
 // Articles are sorted newest-first. baseURL must not have a trailing slash.
-func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.ProcessedArticle) error {
+// When cfg has I18n.Locales configured, per-locale feeds are also written:
+//
+//	{locale}/feed.xml and {locale}/atom.xml for each non-default locale.
+//
+// The root feed.xml / atom.xml contain only articles from the default locale
+// (or all articles when i18n is not configured).
+func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.ProcessedArticle, cfg model.Config) error {
 	sorted := make([]*model.ProcessedArticle, len(articles))
 	copy(sorted, articles)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -69,6 +75,45 @@ func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.Processe
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return err
 	}
+
+	// When i18n is active, filter root feeds to the default locale only and
+	// write per-locale feeds under their locale subdirectory.
+	if len(cfg.I18n.Locales) > 0 {
+		rootArticles := filterFeedArticles(sorted, cfg.I18n.DefaultLocale)
+		if err := writeRSS(outDir, baseURL, siteTitle, rootArticles); err != nil {
+			return err
+		}
+		if err := writeAtom(outDir, baseURL, siteTitle, rootArticles); err != nil {
+			return err
+		}
+		for _, loc := range cfg.I18n.Locales {
+			if loc == cfg.I18n.DefaultLocale {
+				continue // already written at root
+			}
+			locDir := filepath.Join(outDir, loc)
+			if err := os.MkdirAll(locDir, 0o755); err != nil {
+				return err
+			}
+			locArticles := filterFeedArticles(sorted, loc)
+			// channelURL is the locale index (used for <channel><link>).
+			// Article item links use the site root baseURL because a.URL already
+			// includes the locale prefix (e.g. /ja/posts/hello/).
+			var channelURL string
+			if baseURL != "" {
+				channelURL = baseURL + "/" + loc
+			} else {
+				channelURL = "/" + loc
+			}
+			if err := writeRSSWithChannelURL(locDir, baseURL, channelURL, siteTitle, locArticles); err != nil {
+				return err
+			}
+			if err := writeAtomWithChannelURL(locDir, baseURL, channelURL, siteTitle, locArticles); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	if err := writeRSS(outDir, baseURL, siteTitle, sorted); err != nil {
 		return err
 	}
@@ -76,15 +121,19 @@ func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.Processe
 }
 
 func writeRSS(outDir, baseURL, title string, articles []*model.ProcessedArticle) error {
+	return writeRSSWithChannelURL(outDir, baseURL, baseURL, title, articles)
+}
+
+func writeRSSWithChannelURL(outDir, itemBaseURL, channelURL, title string, articles []*model.ProcessedArticle) error {
 	now := time.Now().UTC().Format(time.RFC1123Z)
 	ch := rssChannel{
 		Title:       title,
-		Link:        baseURL,
+		Link:        channelURL,
 		Description: title,
 		PubDate:     now,
 	}
 	for _, a := range articles {
-		link := articleLink(baseURL, a)
+		link := articleLink(itemBaseURL, a)
 		ch.Items = append(ch.Items, rssItem{
 			Title:       a.FrontMatter.Title,
 			Link:        link,
@@ -98,6 +147,10 @@ func writeRSS(outDir, baseURL, title string, articles []*model.ProcessedArticle)
 }
 
 func writeAtom(outDir, baseURL, title string, articles []*model.ProcessedArticle) error {
+	return writeAtomWithChannelURL(outDir, baseURL, baseURL, title, articles)
+}
+
+func writeAtomWithChannelURL(outDir, itemBaseURL, channelURL, title string, articles []*model.ProcessedArticle) error {
 	updated := time.Now().UTC().Format(time.RFC3339)
 	if len(articles) > 0 {
 		updated = articles[0].FrontMatter.Date.UTC().Format(time.RFC3339)
@@ -105,13 +158,13 @@ func writeAtom(outDir, baseURL, title string, articles []*model.ProcessedArticle
 	feed := atomFeed{
 		Xmlns:   "http://www.w3.org/2005/Atom",
 		Title:   title,
-		Link:    atomLink{Href: baseURL},
+		Link:    atomLink{Href: channelURL},
 		Updated: updated,
 	}
 	for _, a := range articles {
 		feed.Entries = append(feed.Entries, atomEntry{
 			Title:   a.FrontMatter.Title,
-			Link:    atomLink{Href: articleLink(baseURL, a)},
+			Link:    atomLink{Href: articleLink(itemBaseURL, a)},
 			Updated: a.FrontMatter.Date.UTC().Format(time.RFC3339),
 			Summary: a.Summary,
 		})
@@ -147,4 +200,15 @@ func writeXML(path string, v interface{}) error {
 		return err
 	}
 	return writeFileAtomic(path, buf.Bytes(), 0o644)
+}
+
+// filterFeedArticles returns only articles whose Locale matches locale.
+func filterFeedArticles(articles []*model.ProcessedArticle, locale string) []*model.ProcessedArticle {
+	var out []*model.ProcessedArticle
+	for _, a := range articles {
+		if a.Locale == locale {
+			out = append(out, a)
+		}
+	}
+	return out
 }

--- a/internal/generator/feed.go
+++ b/internal/generator/feed.go
@@ -100,9 +100,9 @@ func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.Processe
 			// includes the locale prefix (e.g. /ja/posts/hello/).
 			var channelURL string
 			if baseURL != "" {
-				channelURL = baseURL + "/" + loc
+				channelURL = baseURL + "/" + loc + "/"
 			} else {
-				channelURL = "/" + loc
+				channelURL = "/" + loc + "/"
 			}
 			if err := writeRSSWithChannelURL(locDir, baseURL, channelURL, siteTitle, locArticles); err != nil {
 				return err
@@ -133,6 +133,9 @@ func writeRSSWithChannelURL(outDir, itemBaseURL, channelURL, title string, artic
 		PubDate:     now,
 	}
 	for _, a := range articles {
+		if a.FrontMatter.Date.IsZero() {
+			continue // skip articles with no publication date
+		}
 		link := articleLink(itemBaseURL, a)
 		ch.Items = append(ch.Items, rssItem{
 			Title:       a.FrontMatter.Title,
@@ -152,8 +155,11 @@ func writeAtom(outDir, baseURL, title string, articles []*model.ProcessedArticle
 
 func writeAtomWithChannelURL(outDir, itemBaseURL, channelURL, title string, articles []*model.ProcessedArticle) error {
 	updated := time.Now().UTC().Format(time.RFC3339)
-	if len(articles) > 0 {
-		updated = articles[0].FrontMatter.Date.UTC().Format(time.RFC3339)
+	for _, a := range articles {
+		if !a.FrontMatter.Date.IsZero() {
+			updated = a.FrontMatter.Date.UTC().Format(time.RFC3339)
+			break
+		}
 	}
 	feed := atomFeed{
 		Xmlns:   "http://www.w3.org/2005/Atom",
@@ -162,6 +168,9 @@ func writeAtomWithChannelURL(outDir, itemBaseURL, channelURL, title string, arti
 		Updated: updated,
 	}
 	for _, a := range articles {
+		if a.FrontMatter.Date.IsZero() {
+			continue // skip articles with no publication date
+		}
 		feed.Entries = append(feed.Entries, atomEntry{
 			Title:   a.FrontMatter.Title,
 			Link:    atomLink{Href: articleLink(itemBaseURL, a)},

--- a/internal/generator/feed.go
+++ b/internal/generator/feed.go
@@ -59,11 +59,11 @@ type atomAuthor struct {
 }
 
 type atomEntry struct {
-	ID      string     `xml:"id"`
-	Title   string     `xml:"title"`
-	Link    atomLink   `xml:"link"`
-	Updated string     `xml:"updated"`
-	Summary string     `xml:"summary"`
+	ID      string   `xml:"id"`
+	Title   string   `xml:"title"`
+	Link    atomLink `xml:"link"`
+	Updated string   `xml:"updated"`
+	Summary string   `xml:"summary"`
 }
 
 // GenerateFeeds writes feed.xml (RSS 2.0) and atom.xml (Atom 1.0) to outDir.
@@ -174,9 +174,9 @@ func writeAtomWithChannelURL(outDir, itemBaseURL, channelURL, title string, arti
 	author := cfg.Theme.Params["author"]
 	baseAtomURL := channelURL + "atom.xml"
 	feed := atomFeed{
-		Xmlns:   "http://www.w3.org/2005/Atom",
-		ID:      baseAtomURL,
-		Title:   title,
+		Xmlns: "http://www.w3.org/2005/Atom",
+		ID:    baseAtomURL,
+		Title: title,
 		Links: []atomLink{
 			{Rel: "alternate", Type: "text/html", Href: channelURL},
 			{Rel: "self", Type: "application/atom+xml", Href: baseAtomURL},

--- a/internal/generator/feed.go
+++ b/internal/generator/feed.go
@@ -40,21 +40,30 @@ type rssItem struct {
 type atomFeed struct {
 	XMLName xml.Name    `xml:"feed"`
 	Xmlns   string      `xml:"xmlns,attr"`
+	ID      string      `xml:"id"`
 	Title   string      `xml:"title"`
-	Link    atomLink    `xml:"link"`
+	Links   []atomLink  `xml:"link"`
+	Author  atomAuthor  `xml:"author"`
 	Updated string      `xml:"updated"`
 	Entries []atomEntry `xml:"entry"`
 }
 
 type atomLink struct {
+	Rel  string `xml:"rel,attr,omitempty"`
+	Type string `xml:"type,attr,omitempty"`
 	Href string `xml:"href,attr"`
 }
 
+type atomAuthor struct {
+	Name string `xml:"name"`
+}
+
 type atomEntry struct {
-	Title   string   `xml:"title"`
-	Link    atomLink `xml:"link"`
-	Updated string   `xml:"updated"`
-	Summary string   `xml:"summary"`
+	ID      string     `xml:"id"`
+	Title   string     `xml:"title"`
+	Link    atomLink   `xml:"link"`
+	Updated string     `xml:"updated"`
+	Summary string     `xml:"summary"`
 }
 
 // GenerateFeeds writes feed.xml (RSS 2.0) and atom.xml (Atom 1.0) to outDir.
@@ -83,7 +92,7 @@ func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.Processe
 		if err := writeRSS(outDir, baseURL, siteTitle, rootArticles); err != nil {
 			return err
 		}
-		if err := writeAtom(outDir, baseURL, siteTitle, rootArticles); err != nil {
+		if err := writeAtom(outDir, baseURL, siteTitle, rootArticles, cfg); err != nil {
 			return err
 		}
 		for _, loc := range cfg.I18n.Locales {
@@ -107,7 +116,7 @@ func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.Processe
 			if err := writeRSSWithChannelURL(locDir, baseURL, channelURL, siteTitle, locArticles); err != nil {
 				return err
 			}
-			if err := writeAtomWithChannelURL(locDir, baseURL, channelURL, siteTitle, locArticles); err != nil {
+			if err := writeAtomWithChannelURL(locDir, baseURL, channelURL, siteTitle, locArticles, cfg); err != nil {
 				return err
 			}
 		}
@@ -117,7 +126,7 @@ func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.Processe
 	if err := writeRSS(outDir, baseURL, siteTitle, sorted); err != nil {
 		return err
 	}
-	return writeAtom(outDir, baseURL, siteTitle, sorted)
+	return writeAtom(outDir, baseURL, siteTitle, sorted, cfg)
 }
 
 func writeRSS(outDir, baseURL, title string, articles []*model.ProcessedArticle) error {
@@ -149,11 +158,11 @@ func writeRSSWithChannelURL(outDir, itemBaseURL, channelURL, title string, artic
 	return writeXML(filepath.Join(outDir, "feed.xml"), root)
 }
 
-func writeAtom(outDir, baseURL, title string, articles []*model.ProcessedArticle) error {
-	return writeAtomWithChannelURL(outDir, baseURL, baseURL, title, articles)
+func writeAtom(outDir, baseURL, title string, articles []*model.ProcessedArticle, cfg model.Config) error {
+	return writeAtomWithChannelURL(outDir, baseURL, baseURL+"/", title, articles, cfg)
 }
 
-func writeAtomWithChannelURL(outDir, itemBaseURL, channelURL, title string, articles []*model.ProcessedArticle) error {
+func writeAtomWithChannelURL(outDir, itemBaseURL, channelURL, title string, articles []*model.ProcessedArticle, cfg model.Config) error {
 	updated := time.Now().UTC().Format(time.RFC3339)
 	for _, a := range articles {
 		if !a.FrontMatter.Date.IsZero() {
@@ -161,19 +170,28 @@ func writeAtomWithChannelURL(outDir, itemBaseURL, channelURL, title string, arti
 			break
 		}
 	}
+	author := cfg.Theme.Params["author"]
+	baseAtomURL := channelURL + "atom.xml"
 	feed := atomFeed{
 		Xmlns:   "http://www.w3.org/2005/Atom",
+		ID:      baseAtomURL,
 		Title:   title,
-		Link:    atomLink{Href: channelURL},
+		Links: []atomLink{
+			{Rel: "alternate", Type: "text/html", Href: channelURL},
+			{Rel: "self", Type: "application/atom+xml", Href: baseAtomURL},
+		},
+		Author:  atomAuthor{Name: author},
 		Updated: updated,
 	}
 	for _, a := range articles {
 		if a.FrontMatter.Date.IsZero() {
 			continue // skip articles with no publication date
 		}
+		link := articleLink(itemBaseURL, a)
 		feed.Entries = append(feed.Entries, atomEntry{
+			ID:      link,
 			Title:   a.FrontMatter.Title,
-			Link:    atomLink{Href: articleLink(itemBaseURL, a)},
+			Link:    atomLink{Rel: "alternate", Type: "text/html", Href: link},
 			Updated: a.FrontMatter.Date.UTC().Format(time.RFC3339),
 			Summary: a.Summary,
 		})

--- a/internal/generator/feed.go
+++ b/internal/generator/feed.go
@@ -130,7 +130,8 @@ func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.Processe
 }
 
 func writeRSS(outDir, baseURL, title string, articles []*model.ProcessedArticle) error {
-	return writeRSSWithChannelURL(outDir, baseURL, baseURL, title, articles)
+	// BUG-C: channel URL must have a trailing slash (consistent with writeAtom).
+	return writeRSSWithChannelURL(outDir, baseURL, baseURL+"/", title, articles)
 }
 
 func writeRSSWithChannelURL(outDir, itemBaseURL, channelURL, title string, articles []*model.ProcessedArticle) error {

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -642,9 +642,25 @@ func localeTaxonomyBase(base *model.Site, articles []*model.ProcessedArticle) *m
 	}
 	sort.Slice(tags, func(i, j int) bool { return tags[i].Name < tags[j].Name })
 	sort.Slice(cats, func(i, j int) bool { return cats[i].Name < cats[j].Name })
-	// No fallback to base.Tags / base.Categories: an empty slice is the correct
-	// value when the locale has no tagged/categorised articles.  Falling back to
-	// all-locale data would expose cross-locale taxonomy entries in the sidebar.
+	// BUG-B: preserve Taxonomy.Description from base.Tags / base.Categories.
+	// Without this, locale-filtered listing pages always show empty descriptions.
+	tagDesc := make(map[string]string, len(base.Tags))
+	for _, t := range base.Tags {
+		tagDesc[t.Name] = t.Description
+	}
+	catDesc := make(map[string]string, len(base.Categories))
+	for _, c := range base.Categories {
+		catDesc[c.Name] = c.Description
+	}
+	for i := range tags {
+		tags[i].Description = tagDesc[tags[i].Name]
+	}
+	for i := range cats {
+		cats[i].Description = catDesc[cats[i].Name]
+	}
+	// No fallback to base.Tags / base.Categories tags themselves: an empty slice
+	// is the correct value when the locale has no tagged/categorised articles.
+	// Falling back to all-locale data would expose cross-locale entries in the sidebar.
 	return &model.Site{
 		Config:       base.Config,
 		Articles:     base.Articles,

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -694,9 +694,15 @@ func siteWithPagination(base *model.Site, articles []*model.ProcessedArticle, pg
 }
 
 // sortByDateDesc sorts a slice of processed articles newest-first in place.
+// When two articles share the same date, FilePath is used as a tiebreaker so
+// that builds with same-dated articles are deterministic across runs.
 func sortByDateDesc(articles []*model.ProcessedArticle) {
 	sort.Slice(articles, func(i, j int) bool {
-		return articles[i].FrontMatter.Date.After(articles[j].FrontMatter.Date)
+		di, dj := articles[i].FrontMatter.Date, articles[j].FrontMatter.Date
+		if !di.Equal(dj) {
+			return di.After(dj)
+		}
+		return articles[i].FilePath < articles[j].FilePath
 	})
 }
 

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -663,7 +663,7 @@ func localeTaxonomyBase(base *model.Site, articles []*model.ProcessedArticle) *m
 	// Falling back to all-locale data would expose cross-locale entries in the sidebar.
 	return &model.Site{
 		Config:       base.Config,
-		Articles:     base.Articles,
+		Articles:     articles,
 		Tags:         tags,
 		Categories:   cats,
 		ArchiveYears: archiveYears(articles),
@@ -751,13 +751,4 @@ func articleOutputPath(a *model.ProcessedArticle, outDir string, cfg model.Confi
 	return filepath.Join(outDir, "posts", slug, "index.html")
 }
 
-// filteredSite creates a site copy with articles matching pred.
-func filteredSite(base *model.Site, pred func(*model.ProcessedArticle) bool) *model.Site {
-	var filtered []*model.ProcessedArticle
-	for _, a := range base.Articles {
-		if pred(a) {
-			filtered = append(filtered, a)
-		}
-	}
-	return siteFor(base, filtered)
-}
+

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -284,17 +284,16 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 				copy(as, articles)
 				sortByDateDesc(as)
 				k := key
-				d := siteFor(site, as)
-				d.CurrentLocale = locale
-				d.CurrentArchivePath = fmt.Sprintf("/archives/%04d/%02d/", k.year, int(k.month))
-				jobs = append(jobs, writeJob{
-					path: filepath.Join(g.outDir, archivePrefix, "archives",
-						fmt.Sprintf("%04d", k.year),
-						fmt.Sprintf("%02d", int(k.month)),
-						"index.html"),
-					tmpl: "archive.html",
-					data: d,
-				})
+				basePath := filepath.Join(archivePrefix, "archives", fmt.Sprintf("%04d", k.year), fmt.Sprintf("%02d", int(k.month)))
+				var baseURLPath, archivePath string
+				if archivePrefix == "" {
+					baseURLPath = fmt.Sprintf("/archives/%04d/%02d", k.year, int(k.month))
+					archivePath = fmt.Sprintf("/archives/%04d/%02d/", k.year, int(k.month))
+				} else {
+					baseURLPath = fmt.Sprintf("/%s/archives/%04d/%02d", archivePrefix, k.year, int(k.month))
+					archivePath = fmt.Sprintf("/%s/archives/%04d/%02d/", archivePrefix, k.year, int(k.month))
+				}
+				jobs = append(jobs, paginatedArchiveJobs(site, as, g.outDir, basePath, baseURLPath, perPage, locale, archivePath, true)...)
 			}
 
 			for year, articles := range yearArchives {
@@ -302,16 +301,16 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 				copy(as, articles)
 				sortByDateDesc(as)
 				y := year
-				d := siteFor(site, as)
-				d.CurrentLocale = locale
-				d.CurrentArchivePath = fmt.Sprintf("/archives/%04d/", y)
-				jobs = append(jobs, writeJob{
-					path: filepath.Join(g.outDir, archivePrefix, "archives",
-						fmt.Sprintf("%04d", y),
-						"index.html"),
-					tmpl: "archive.html",
-					data: d,
-				})
+				basePath := filepath.Join(archivePrefix, "archives", fmt.Sprintf("%04d", y))
+				var baseURLPath, archivePath string
+				if archivePrefix == "" {
+					baseURLPath = fmt.Sprintf("/archives/%04d", y)
+					archivePath = fmt.Sprintf("/archives/%04d/", y)
+				} else {
+					baseURLPath = fmt.Sprintf("/%s/archives/%04d", archivePrefix, y)
+					archivePath = fmt.Sprintf("/%s/archives/%04d/", archivePrefix, y)
+				}
+				jobs = append(jobs, paginatedArchiveJobs(site, as, g.outDir, basePath, baseURLPath, perPage, locale, archivePath, false)...)
 			}
 		}
 	} else {
@@ -329,14 +328,10 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 			copy(as, articles)
 			sortByDateDesc(as)
 			k := key
-			jobs = append(jobs, writeJob{
-				path: filepath.Join(g.outDir, "archives",
-					fmt.Sprintf("%04d", k.year),
-					fmt.Sprintf("%02d", int(k.month)),
-					"index.html"),
-				tmpl: "archive.html",
-				data: siteFor(site, as),
-			})
+			basePath := filepath.Join("archives", fmt.Sprintf("%04d", k.year), fmt.Sprintf("%02d", int(k.month)))
+			baseURLPath := fmt.Sprintf("/archives/%04d/%02d", k.year, int(k.month))
+			archivePath := fmt.Sprintf("/archives/%04d/%02d/", k.year, int(k.month))
+			jobs = append(jobs, paginatedArchiveJobs(site, as, g.outDir, basePath, baseURLPath, perPage, "", archivePath, true)...)
 		}
 
 		yearArchives := map[int][]*model.ProcessedArticle{}
@@ -351,13 +346,10 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 			copy(as, articles)
 			sortByDateDesc(as)
 			y := year
-			jobs = append(jobs, writeJob{
-				path: filepath.Join(g.outDir, "archives",
-					fmt.Sprintf("%04d", y),
-					"index.html"),
-				tmpl: "archive.html",
-				data: siteFor(site, as),
-			})
+			basePath := filepath.Join("archives", fmt.Sprintf("%04d", y))
+			baseURLPath := fmt.Sprintf("/archives/%04d", y)
+			archivePath := fmt.Sprintf("/archives/%04d/", y)
+			jobs = append(jobs, paginatedArchiveJobs(site, as, g.outDir, basePath, baseURLPath, perPage, "", archivePath, false)...)
 		}
 	}
 
@@ -463,6 +455,27 @@ func paginatedJobs(
 			tmpl: tmpl,
 			data: d,
 		})
+	}
+	return jobs
+}
+
+// paginatedArchiveJobs is like paginatedJobs but also sets CurrentArchivePath
+// and CurrentArchiveIsMonth on every job so archive templates can render
+// locale-aware language-switcher links and display the correct date granularity.
+// archivePath is the locale-aware path, e.g. "/archives/2024/03/" or "/ja/archives/2024/03/".
+// isMonth is true for month-granularity archives, false for year-granularity.
+func paginatedArchiveJobs(
+	site *model.Site,
+	articles []*model.ProcessedArticle,
+	outDir, basePath, baseURLPath string,
+	perPage int,
+	currentLocale, archivePath string,
+	isMonth bool,
+) []writeJob {
+	jobs := paginatedJobs(site, articles, outDir, "archive.html", basePath, baseURLPath, perPage, currentLocale, nil)
+	for i := range jobs {
+		jobs[i].data.CurrentArchivePath = archivePath
+		jobs[i].data.CurrentArchiveIsMonth = isMonth
 	}
 	return jobs
 }

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -756,5 +756,3 @@ func articleOutputPath(a *model.ProcessedArticle, outDir string, cfg model.Confi
 	}
 	return filepath.Join(outDir, "posts", slug, "index.html")
 }
-
-

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -37,7 +37,9 @@ type writeJob struct {
 }
 
 // Generate writes all HTML pages and copies static assets.
-// When changeSet is nil every page is written; otherwise only affected pages.
+// Generate writes all HTML pages for site into g.outDir.
+// changeSet is forwarded to the OGP image generator only; HTML pages are always
+// fully regenerated regardless of changeSet.
 func (g *HTMLGenerator) Generate(site *model.Site, changeSet *model.ChangeSet) error {
 	parallelism := g.cfg.Build.Parallelism
 	if parallelism <= 0 {
@@ -90,7 +92,7 @@ func (g *HTMLGenerator) Generate(site *model.Site, changeSet *model.ChangeSet) e
 	}
 
 	if g.cfg.OGP.Enabled {
-		ogpGen := NewOGPGenerator(g.outDir, g.cfg.OGP)
+		ogpGen := NewOGPGenerator(g.outDir, g.cfg.Build.ContentDir, g.cfg.OGP)
 		if err := ogpGen.Generate(site, changeSet); err != nil {
 			return fmt.Errorf("ogp generation: %w", err)
 		}
@@ -128,6 +130,22 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 		jobs = append(jobs, paginatedJobs(site, allArticles, g.outDir, "index.html", "", "", perPage, "", nil)...)
 	}
 
+	// Pre-compute per-locale taxonomy bases so that article pages receive
+	// locale-filtered Tags, Categories, and ArchiveYears — matching the
+	// behaviour of listing pages (tag, category, archive, index).
+	articleLocaleBases := map[string]*model.Site{}
+	if len(g.cfg.I18n.Locales) > 0 {
+		for _, loc := range g.cfg.I18n.Locales {
+			locale := loc
+			locArticles := filterArticles(site.Articles, func(a *model.ProcessedArticle) bool {
+				return a.Locale == locale
+			})
+			articleLocaleBases[locale] = localeTaxonomyBase(site, locArticles)
+		}
+	} else {
+		articleLocaleBases[""] = localeTaxonomyBase(site, site.Articles)
+	}
+
 	// Article pages: use pre-computed output path and respect FrontMatter.Template.
 	for _, a := range site.Articles {
 		a := a
@@ -136,7 +154,11 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 		if a.FrontMatter.Template != "" {
 			tmplName = a.FrontMatter.Template
 		}
-		d := siteFor(site, []*model.ProcessedArticle{a})
+		base := articleLocaleBases[a.Locale]
+		if base == nil {
+			base = localeTaxonomyBase(site, site.Articles)
+		}
+		d := siteFor(base, []*model.ProcessedArticle{a})
 		d.CurrentLocale = a.Locale
 		d.RelatedArticles = relatedArticles(site.Articles, a, 5)
 		jobs = append(jobs, writeJob{
@@ -515,7 +537,10 @@ func CopyDir(srcDir, dstDir string) error {
 		if err != nil {
 			return err
 		}
-		rel, _ := filepath.Rel(srcDir, path)
+		rel, relErr := filepath.Rel(srcDir, path)
+		if relErr != nil {
+			return fmt.Errorf("copydir: rel path: %w", relErr)
+		}
 		dst := filepath.Join(dstDir, rel)
 		if d.IsDir() {
 			return os.MkdirAll(dst, 0o755)
@@ -617,12 +642,9 @@ func localeTaxonomyBase(base *model.Site, articles []*model.ProcessedArticle) *m
 	}
 	sort.Slice(tags, func(i, j int) bool { return tags[i].Name < tags[j].Name })
 	sort.Slice(cats, func(i, j int) bool { return cats[i].Name < cats[j].Name })
-	if len(tags) == 0 {
-		tags = base.Tags
-	}
-	if len(cats) == 0 {
-		cats = base.Categories
-	}
+	// No fallback to base.Tags / base.Categories: an empty slice is the correct
+	// value when the locale has no tagged/categorised articles.  Falling back to
+	// all-locale data would expose cross-locale taxonomy entries in the sidebar.
 	return &model.Site{
 		Config:       base.Config,
 		Articles:     base.Articles,
@@ -702,8 +724,9 @@ func articleOutputPath(a *model.ProcessedArticle, outDir string, cfg model.Confi
 		}
 	}
 	// Fallback: construct from slug and locale.
-	slug := a.FrontMatter.Slug
-	if slug == "" {
+	// BUG-7: sanitize slug to prevent path traversal outside the output directory.
+	slug := slugify(a.FrontMatter.Slug)
+	if slug == "untitled" {
 		slug = slugify(a.FrontMatter.Title)
 	}
 	if a.Locale != "" && a.Locale != cfg.I18n.DefaultLocale {

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -18,7 +18,7 @@ type mockEngine struct {
 	calls []string
 }
 
-func (m *mockEngine) Load(_ string, _ htmltemplate.FuncMap) error { return nil }
+func (m *mockEngine) Load(_ string, _ htmltemplate.FuncMap, _ string) error { return nil }
 func (m *mockEngine) Render(w io.Writer, name string, _ *model.Site) error {
 	m.mu.Lock()
 	m.calls = append(m.calls, name)
@@ -38,7 +38,7 @@ type captureEngine struct {
 	renders []captureRender
 }
 
-func (c *captureEngine) Load(_ string, _ htmltemplate.FuncMap) error { return nil }
+func (c *captureEngine) Load(_ string, _ htmltemplate.FuncMap, _ string) error { return nil }
 func (c *captureEngine) Render(w io.Writer, name string, data *model.Site) error {
 	// Copy the site value so mutations after Render don't affect captured state.
 	dataCopy := *data
@@ -989,5 +989,50 @@ func TestArchive_PaginationJobs_I18n(t *testing.T) {
 	}
 	if jaMonthJobs != 2 {
 		t.Errorf("expected 2 JA month-archive pages, got %d", jaMonthJobs)
+	}
+}
+// TestLocaleTaxonomyBase_NoFallback verifies that localeTaxonomyBase does NOT
+// fall back to cross-locale tags/categories when a locale's articles have none.
+// Previously the function returned base.Tags for locales with untagged articles,
+// which caused JA tags to appear in the EN sidebar and vice-versa.
+func TestLocaleTaxonomyBase_NoFallback(t *testing.T) {
+	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	enArticle := &model.ProcessedArticle{
+		Article: model.Article{
+			FrontMatter: model.FrontMatter{
+				Title: "EN Post",
+				Slug:  "en-post",
+				Date:  date,
+				// No tags — should NOT fall back to JA tags
+			},
+		},
+		Locale: "en",
+	}
+	jaArticle := &model.ProcessedArticle{
+		Article: model.Article{
+			FrontMatter: model.FrontMatter{
+				Title: "JA Post",
+				Slug:  "ja-post",
+				Date:  date,
+				Tags:  []string{"golang", "書評"},
+			},
+		},
+		Locale: "ja",
+	}
+	base := &model.Site{
+		Articles: []*model.ProcessedArticle{enArticle, jaArticle},
+		Tags: []model.Taxonomy{{Name: "golang"}, {Name: "書評"}},
+	}
+
+	// EN locale has no tags — must return empty, not JA tags.
+	enBase := localeTaxonomyBase(base, []*model.ProcessedArticle{enArticle})
+	if len(enBase.Tags) != 0 {
+		t.Errorf("EN localeTaxonomyBase: expected 0 tags, got %d: %v", len(enBase.Tags), enBase.Tags)
+	}
+
+	// JA locale has tags — must return only JA tags.
+	jaBase := localeTaxonomyBase(base, []*model.ProcessedArticle{jaArticle})
+	if len(jaBase.Tags) != 2 {
+		t.Errorf("JA localeTaxonomyBase: expected 2 tags, got %d: %v", len(jaBase.Tags), jaBase.Tags)
 	}
 }

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -418,7 +418,8 @@ func TestGenerate_ArchiveCurrentArchivePath(t *testing.T) {
 			jaMonthPath = path
 		case locale == "ja" && path == "/archives/2024/":
 			jaYearPath = path
-		}	}
+		}
+	}
 	if enMonthPath == "" {
 		t.Error("EN month archive: CurrentArchivePath not set to /archives/2024/03/")
 	}

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -544,12 +544,25 @@ func TestSortByDateDesc(t *testing.T) {
 	older := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 	newer := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 	articles := []*model.ProcessedArticle{
-		{Article: model.Article{FrontMatter: model.FrontMatter{Title: "Old", Date: older}}},
-		{Article: model.Article{FrontMatter: model.FrontMatter{Title: "New", Date: newer}}},
+		{Article: model.Article{FilePath: "/content/old.md", FrontMatter: model.FrontMatter{Title: "Old", Date: older}}},
+		{Article: model.Article{FilePath: "/content/new.md", FrontMatter: model.FrontMatter{Title: "New", Date: newer}}},
 	}
 	sortByDateDesc(articles)
 	if articles[0].FrontMatter.Title != "New" {
 		t.Errorf("expected 'New' first after sortByDateDesc, got %q", articles[0].FrontMatter.Title)
+	}
+
+	// Same-date articles must be ordered deterministically by FilePath.
+	sameDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	tied := []*model.ProcessedArticle{
+		{Article: model.Article{FilePath: "/content/z-last.md", FrontMatter: model.FrontMatter{Title: "Z", Date: sameDate}}},
+		{Article: model.Article{FilePath: "/content/a-first.md", FrontMatter: model.FrontMatter{Title: "A", Date: sameDate}}},
+		{Article: model.Article{FilePath: "/content/m-middle.md", FrontMatter: model.FrontMatter{Title: "M", Date: sameDate}}},
+	}
+	sortByDateDesc(tied)
+	if tied[0].FrontMatter.Title != "A" || tied[1].FrontMatter.Title != "M" || tied[2].FrontMatter.Title != "Z" {
+		t.Errorf("same-date articles should be sorted by FilePath ascending; got %q, %q, %q",
+			tied[0].FrontMatter.Title, tied[1].FrontMatter.Title, tied[2].FrontMatter.Title)
 	}
 }
 

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -412,12 +412,24 @@ func TestGenerate_ArchiveCurrentArchivePath(t *testing.T) {
 		switch {
 		case locale == "en" && path == "/archives/2024/03/":
 			enMonthPath = path
+			if !r.data.CurrentArchiveIsMonth {
+				t.Error("EN month archive: CurrentArchiveIsMonth should be true")
+			}
 		case locale == "en" && path == "/archives/2024/":
 			enYearPath = path
-		case locale == "ja" && path == "/archives/2024/03/":
+			if r.data.CurrentArchiveIsMonth {
+				t.Error("EN year archive: CurrentArchiveIsMonth should be false")
+			}
+		case locale == "ja" && path == "/ja/archives/2024/03/":
 			jaMonthPath = path
-		case locale == "ja" && path == "/archives/2024/":
+			if !r.data.CurrentArchiveIsMonth {
+				t.Error("JA month archive: CurrentArchiveIsMonth should be true")
+			}
+		case locale == "ja" && path == "/ja/archives/2024/":
 			jaYearPath = path
+			if r.data.CurrentArchiveIsMonth {
+				t.Error("JA year archive: CurrentArchiveIsMonth should be false")
+			}
 		}
 	}
 	if enMonthPath == "" {
@@ -427,10 +439,10 @@ func TestGenerate_ArchiveCurrentArchivePath(t *testing.T) {
 		t.Error("EN year archive: CurrentArchivePath not set to /archives/2024/")
 	}
 	if jaMonthPath == "" {
-		t.Error("JA month archive: CurrentArchivePath not set to /archives/2024/03/")
+		t.Error("JA month archive: CurrentArchivePath not set to /ja/archives/2024/03/")
 	}
 	if jaYearPath == "" {
-		t.Error("JA year archive: CurrentArchivePath not set to /archives/2024/")
+		t.Error("JA year archive: CurrentArchivePath not set to /ja/archives/2024/")
 	}
 }
 
@@ -877,5 +889,105 @@ func TestArticleOutputPath_FallbackWhenEmpty(t *testing.T) {
 	want := filepath.Join(outDir, "posts", "hello", "index.html")
 	if got != want {
 		t.Errorf("articleOutputPath fallback: got %q, want %q", got, want)
+	}
+}
+
+// TestArchive_PaginationJobs verifies that archive pages are paginated when the
+// article count exceeds perPage, and that CurrentArchivePath is set on all pages.
+func TestArchive_PaginationJobs(t *testing.T) {
+	date := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	var articles []*model.ProcessedArticle
+	for i := 0; i < 25; i++ {
+		articles = append(articles, &model.ProcessedArticle{
+			Article: model.Article{FrontMatter: model.FrontMatter{
+				Title: fmt.Sprintf("Article %d", i),
+				Slug:  fmt.Sprintf("article-%d", i),
+				Date:  date,
+			}},
+		})
+	}
+	site := &model.Site{
+		Config: model.Config{
+			Build: model.BuildConfig{Parallelism: 1, PerPage: 10},
+		},
+		Articles: articles,
+	}
+	g := NewHTMLGenerator(t.TempDir(), &mockEngine{}, site.Config)
+	jobs := g.buildJobs(site)
+
+	var archiveJobs []writeJob
+	for _, j := range jobs {
+		if j.tmpl == "archive.html" {
+			archiveJobs = append(archiveJobs, j)
+		}
+	}
+
+	// 25 articles / 10 per page = 3 pages for month + year archives (month same count)
+	monthJobs := 0
+	yearJobs := 0
+	for _, j := range archiveJobs {
+		if j.data.CurrentArchivePath == "/archives/2024/03/" {
+			monthJobs++
+			if j.data.CurrentArchivePath == "" {
+				t.Error("CurrentArchivePath must be set on paginated archive pages")
+			}
+		} else if j.data.CurrentArchivePath == "/archives/2024/" {
+			yearJobs++
+		}
+	}
+	if monthJobs != 3 {
+		t.Errorf("expected 3 paginated month-archive jobs for 25 articles with perPage=10, got %d", monthJobs)
+	}
+	if yearJobs != 3 {
+		t.Errorf("expected 3 paginated year-archive jobs for 25 articles with perPage=10, got %d", yearJobs)
+	}
+}
+
+// TestArchive_PaginationJobs_I18n verifies locale-aware archive pagination.
+func TestArchive_PaginationJobs_I18n(t *testing.T) {
+	date := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	var articles []*model.ProcessedArticle
+	for i := 0; i < 15; i++ {
+		articles = append(articles, &model.ProcessedArticle{
+			Article: model.Article{FrontMatter: model.FrontMatter{
+				Title: fmt.Sprintf("EN %d", i), Slug: fmt.Sprintf("en-%d", i), Date: date,
+			}},
+			Locale: "en",
+		})
+		articles = append(articles, &model.ProcessedArticle{
+			Article: model.Article{FrontMatter: model.FrontMatter{
+				Title: fmt.Sprintf("JA %d", i), Slug: fmt.Sprintf("ja-%d", i), Date: date,
+			}},
+			Locale: "ja",
+		})
+	}
+	site := &model.Site{
+		Config: model.Config{
+			Build: model.BuildConfig{Parallelism: 1, PerPage: 10},
+			I18n:  model.I18nConfig{Locales: []string{"en", "ja"}, DefaultLocale: "en"},
+		},
+		Articles: articles,
+	}
+	g := NewHTMLGenerator(t.TempDir(), &mockEngine{}, site.Config)
+	jobs := g.buildJobs(site)
+
+	enMonthJobs, jaMonthJobs := 0, 0
+	for _, j := range jobs {
+		if j.tmpl != "archive.html" {
+			continue
+		}
+		switch {
+		case j.data.CurrentLocale == "en" && j.data.CurrentArchivePath == "/archives/2024/03/":
+			enMonthJobs++
+		case j.data.CurrentLocale == "ja" && j.data.CurrentArchivePath == "/ja/archives/2024/03/":
+			jaMonthJobs++
+		}
+	}
+	// 15 articles each locale, perPage=10 → 2 pages each
+	if enMonthJobs != 2 {
+		t.Errorf("expected 2 EN month-archive pages, got %d", enMonthJobs)
+	}
+	if jaMonthJobs != 2 {
+		t.Errorf("expected 2 JA month-archive pages, got %d", jaMonthJobs)
 	}
 }

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -926,12 +926,10 @@ func TestArchive_PaginationJobs(t *testing.T) {
 	monthJobs := 0
 	yearJobs := 0
 	for _, j := range archiveJobs {
-		if j.data.CurrentArchivePath == "/archives/2024/03/" {
+		switch j.data.CurrentArchivePath {
+		case "/archives/2024/03/":
 			monthJobs++
-			if j.data.CurrentArchivePath == "" {
-				t.Error("CurrentArchivePath must be set on paginated archive pages")
-			}
-		} else if j.data.CurrentArchivePath == "/archives/2024/" {
+		case "/archives/2024/":
 			yearJobs++
 		}
 	}

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -991,6 +991,7 @@ func TestArchive_PaginationJobs_I18n(t *testing.T) {
 		t.Errorf("expected 2 JA month-archive pages, got %d", jaMonthJobs)
 	}
 }
+
 // TestLocaleTaxonomyBase_NoFallback verifies that localeTaxonomyBase does NOT
 // fall back to cross-locale tags/categories when a locale's articles have none.
 // Previously the function returned base.Tags for locales with untagged articles,
@@ -1021,7 +1022,7 @@ func TestLocaleTaxonomyBase_NoFallback(t *testing.T) {
 	}
 	base := &model.Site{
 		Articles: []*model.ProcessedArticle{enArticle, jaArticle},
-		Tags: []model.Taxonomy{{Name: "golang"}, {Name: "書評"}},
+		Tags:     []model.Taxonomy{{Name: "golang"}, {Name: "書評"}},
 	}
 
 	// EN locale has no tags — must return empty, not JA tags.

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -177,18 +177,6 @@ func TestTagNorm(t *testing.T) {
 	}
 }
 
-func TestFilteredSite(t *testing.T) {
-	site := makeSite()
-	got := filteredSite(site, func(a *model.ProcessedArticle) bool { return true })
-	if len(got.Articles) != 1 {
-		t.Errorf("expected 1, got %d", len(got.Articles))
-	}
-	empty := filteredSite(site, func(a *model.ProcessedArticle) bool { return false })
-	if len(empty.Articles) != 0 {
-		t.Errorf("expected 0, got %d", len(empty.Articles))
-	}
-}
-
 // ---- Pagination tests ----
 
 func makePaginatedArticles(n int) []*model.ProcessedArticle {

--- a/internal/generator/ogp.go
+++ b/internal/generator/ogp.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"bytes"
 	"fmt"
 	"hash/fnv"
 	"image"
@@ -25,13 +26,17 @@ const (
 
 // OGPGenerator generates OGP thumbnail images for articles at build time.
 type OGPGenerator struct {
-	outDir string
-	cfg    model.OGPConfig
+	outDir     string
+	contentDir string // used to convert absolute FilePath to relative for changeSet lookup
+	cfg        model.OGPConfig
 }
 
 // NewOGPGenerator returns an OGPGenerator configured from cfg.
-func NewOGPGenerator(outDir string, cfg model.OGPConfig) *OGPGenerator {
-	return &OGPGenerator{outDir: outDir, cfg: cfg}
+// contentDir should be the absolute path to the content directory so that
+// article FilePaths (absolute) can be matched against changeSet entries
+// (relative to contentDir). Pass "" to disable that conversion.
+func NewOGPGenerator(outDir, contentDir string, cfg model.OGPConfig) *OGPGenerator {
+	return &OGPGenerator{outDir: outDir, contentDir: contentDir, cfg: cfg}
 }
 
 // Generate creates one PNG per article in public/ogp/{slug}.png.
@@ -68,15 +73,24 @@ func (g *OGPGenerator) Generate(site *model.Site, changeSet *model.ChangeSet) er
 	changed := changedSet(changeSet)
 
 	for _, a := range site.Articles {
-		slug := a.FrontMatter.Slug
-		if slug == "" {
+		// BUG-7: sanitize slug to prevent path traversal (slugify strips dots, slashes, etc.).
+		slug := slugify(a.FrontMatter.Slug)
+		if slug == "untitled" {
 			slug = slugify(a.FrontMatter.Title)
 		}
 		outPath := filepath.Join(ogpDir, slug+".png")
 
-		// Skip if already exists and article not in change set
+		// Skip if already exists and article not in change set.
+		// BUG-1: changeSet entries are relative to contentDir, but a.FilePath is
+		// absolute — compute the relative path for the lookup.
 		if _, statErr := os.Stat(outPath); statErr == nil && changeSet != nil {
-			if !changed[a.FilePath] {
+			lookupPath := a.FilePath
+			if g.contentDir != "" {
+				if rel, relErr := filepath.Rel(g.contentDir, a.FilePath); relErr == nil {
+					lookupPath = rel
+				}
+			}
+			if !changed[lookupPath] {
 				continue
 			}
 		}
@@ -107,12 +121,11 @@ func (g *OGPGenerator) renderImage(outPath, slug string, w, h int, logo image.Im
 		xdraw.BiLinear.Scale(img, dstRect, logo, bounds, draw.Over, nil)
 	}
 
-	f, err := os.Create(outPath)
-	if err != nil {
-		return err
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return fmt.Errorf("ogp: encode %q: %w", slug, err)
 	}
-	defer func() { _ = f.Close() }()
-	return png.Encode(f, img)
+	return writeFileAtomic(outPath, buf.Bytes(), 0o644)
 }
 
 // drawGradientBackground fills img with a diagonal two-colour gradient whose

--- a/internal/generator/ogp.go
+++ b/internal/generator/ogp.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"strings"
 
 	xdraw "golang.org/x/image/draw"
 
@@ -276,19 +275,6 @@ func loadImage(path string) (image.Image, error) {
 	defer func() { _ = f.Close() }()
 	img, _, err := image.Decode(f)
 	return img, err
-}
-
-// parseHexColor parses a "#rrggbb" string into color.RGBA.
-func parseHexColor(s string) (color.RGBA, error) {
-	s = strings.TrimPrefix(s, "#")
-	if len(s) != 6 {
-		return color.RGBA{}, fmt.Errorf("invalid hex color: %q", s)
-	}
-	var r, g, b uint8
-	if _, err := fmt.Sscanf(s, "%02x%02x%02x", &r, &g, &b); err != nil {
-		return color.RGBA{}, err
-	}
-	return color.RGBA{R: r, G: g, B: b, A: 255}, nil
 }
 
 // changedSet converts a ChangeSet slice into a map for O(1) lookup.

--- a/internal/generator/ogp_test.go
+++ b/internal/generator/ogp_test.go
@@ -52,7 +52,7 @@ func TestParseHexColor_Invalid(t *testing.T) {
 func TestOGPGenerator_Disabled(t *testing.T) {
 	outDir := t.TempDir()
 	cfg := model.OGPConfig{Enabled: false}
-	gen := NewOGPGenerator(outDir, cfg)
+	gen := NewOGPGenerator(outDir, "", cfg)
 	site := ogpSite()
 	if err := gen.Generate(site, nil); err != nil {
 		t.Fatalf("unexpected error when disabled: %v", err)
@@ -75,7 +75,7 @@ func TestOGPGenerator_NoFontFile_ProducesImage(t *testing.T) {
 		TextColor:       "#cdd6f4",
 		FontFile:        "", // no font
 	}
-	gen := NewOGPGenerator(outDir, cfg)
+	gen := NewOGPGenerator(outDir, "", cfg)
 	article := &model.ProcessedArticle{
 		Article: model.Article{
 			FrontMatter: model.FrontMatter{
@@ -117,7 +117,7 @@ func TestOGPGenerator_SkipsUnchanged(t *testing.T) {
 		Height:          63,
 		BackgroundColor: "#000000",
 	}
-	gen := NewOGPGenerator(outDir, cfg)
+	gen := NewOGPGenerator(outDir, "", cfg)
 
 	article := &model.ProcessedArticle{
 		Article: model.Article{
@@ -165,7 +165,7 @@ func TestOGPGenerator_NilChangeSet_GeneratesAll(t *testing.T) {
 		Height:          63,
 		BackgroundColor: "#0f0f0f",
 	}
-	gen := NewOGPGenerator(outDir, cfg)
+	gen := NewOGPGenerator(outDir, "", cfg)
 
 	articles := []*model.ProcessedArticle{
 		{Article: model.Article{FrontMatter: model.FrontMatter{Title: "First", Slug: "first"}}},
@@ -189,7 +189,7 @@ func TestOGPGenerator_DefaultDimensions(t *testing.T) {
 		Enabled:         true,
 		BackgroundColor: "#ffffff",
 	}
-	gen := NewOGPGenerator(outDir, cfg)
+	gen := NewOGPGenerator(outDir, "", cfg)
 	article := &model.ProcessedArticle{
 		Article: model.Article{FrontMatter: model.FrontMatter{Title: "Def", Slug: "def"}},
 	}

--- a/internal/generator/ogp_test.go
+++ b/internal/generator/ogp_test.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"image/color"
 	"image/png"
 	"os"
 	"path/filepath"
@@ -17,36 +16,6 @@ func ogpSite(articles ...*model.ProcessedArticle) *model.Site {
 		s.Articles = articles
 	}
 	return s
-}
-
-func TestParseHexColor_Valid(t *testing.T) {
-	cases := []struct {
-		in   string
-		want color.RGBA
-	}{
-		{"#ffffff", color.RGBA{255, 255, 255, 255}},
-		{"#000000", color.RGBA{0, 0, 0, 255}},
-		{"#1a2b3c", color.RGBA{0x1a, 0x2b, 0x3c, 255}},
-		{"#AABBCC", color.RGBA{0xaa, 0xbb, 0xcc, 255}},
-	}
-	for _, c := range cases {
-		got, err := parseHexColor(c.in)
-		if err != nil {
-			t.Errorf("parseHexColor(%q) unexpected error: %v", c.in, err)
-			continue
-		}
-		if got != c.want {
-			t.Errorf("parseHexColor(%q) = %v, want %v", c.in, got, c.want)
-		}
-	}
-}
-
-func TestParseHexColor_Invalid(t *testing.T) {
-	for _, s := range []string{"", "fff", "gggggg", "#12345", "#1234567"} {
-		if _, err := parseHexColor(s); err == nil {
-			t.Errorf("parseHexColor(%q) expected error, got nil", s)
-		}
-	}
 }
 
 func TestOGPGenerator_Disabled(t *testing.T) {
@@ -68,12 +37,9 @@ func TestOGPGenerator_NoFontFile_ProducesImage(t *testing.T) {
 	// Even without a font, a background image should be generated (text skipped gracefully)
 	outDir := t.TempDir()
 	cfg := model.OGPConfig{
-		Enabled:         true,
-		Width:           120,
-		Height:          63,
-		BackgroundColor: "#1e1e2e",
-		TextColor:       "#cdd6f4",
-		FontFile:        "", // no font
+		Enabled: true,
+		Width:   120,
+		Height:  63,
 	}
 	gen := NewOGPGenerator(outDir, "", cfg)
 	article := &model.ProcessedArticle{
@@ -112,10 +78,9 @@ func TestOGPGenerator_NoFontFile_ProducesImage(t *testing.T) {
 func TestOGPGenerator_SkipsUnchanged(t *testing.T) {
 	outDir := t.TempDir()
 	cfg := model.OGPConfig{
-		Enabled:         true,
-		Width:           120,
-		Height:          63,
-		BackgroundColor: "#000000",
+		Enabled: true,
+		Width:   120,
+		Height:  63,
 	}
 	gen := NewOGPGenerator(outDir, "", cfg)
 
@@ -160,10 +125,9 @@ func TestOGPGenerator_SkipsUnchanged(t *testing.T) {
 func TestOGPGenerator_NilChangeSet_GeneratesAll(t *testing.T) {
 	outDir := t.TempDir()
 	cfg := model.OGPConfig{
-		Enabled:         true,
-		Width:           120,
-		Height:          63,
-		BackgroundColor: "#0f0f0f",
+		Enabled: true,
+		Width:   120,
+		Height:  63,
 	}
 	gen := NewOGPGenerator(outDir, "", cfg)
 
@@ -186,8 +150,7 @@ func TestOGPGenerator_DefaultDimensions(t *testing.T) {
 	outDir := t.TempDir()
 	// Width/Height = 0 should use defaults (1200x630)
 	cfg := model.OGPConfig{
-		Enabled:         true,
-		BackgroundColor: "#ffffff",
+		Enabled: true,
 	}
 	gen := NewOGPGenerator(outDir, "", cfg)
 	article := &model.ProcessedArticle{

--- a/internal/generator/sitemap.go
+++ b/internal/generator/sitemap.go
@@ -82,6 +82,20 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle,
 			for _, tr := range a.Translations {
 				fmt.Fprintf(&buf, "    <xhtml:link rel=\"alternate\" hreflang=\"%s\" href=\"%s\"/>\n", tr.Locale, baseURL+tr.URL)
 			}
+			// x-default points to the default-locale variant so search engines
+			// have a clear fallback when no locale matches the visitor's language.
+			if cfg.I18n.DefaultLocale != "" {
+				xdefault := loc // self is default unless we find a translation that is
+				if a.Locale != cfg.I18n.DefaultLocale {
+					for _, tr := range a.Translations {
+						if tr.Locale == cfg.I18n.DefaultLocale {
+							xdefault = baseURL + tr.URL
+							break
+						}
+					}
+				}
+				fmt.Fprintf(&buf, "    <xhtml:link rel=\"alternate\" hreflang=\"x-default\" href=\"%s\"/>\n", xdefault)
+			}
 		}
 		buf.WriteString("  </url>\n")
 	}

--- a/internal/generator/sitemap.go
+++ b/internal/generator/sitemap.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"fmt"
+	"html"
 	"os"
 	"path/filepath"
 	"sort"
@@ -50,7 +51,7 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle,
 				indexURL = baseURL + "/" + loc + "/"
 			}
 			buf.WriteString("  <url>\n")
-			buf.WriteString("    <loc>" + indexURL + "</loc>\n")
+			buf.WriteString("    <loc>" + html.EscapeString(indexURL) + "</loc>\n")
 			buf.WriteString("  </url>\n")
 		}
 	}
@@ -68,7 +69,7 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle,
 		loc := baseURL + articleURL
 
 		buf.WriteString("  <url>\n")
-		buf.WriteString("    <loc>" + loc + "</loc>\n")
+		buf.WriteString("    <loc>" + html.EscapeString(loc) + "</loc>\n")
 		if !a.FrontMatter.Date.IsZero() {
 			buf.WriteString("    <lastmod>" + a.FrontMatter.Date.UTC().Format("2006-01-02") + "</lastmod>\n")
 		}

--- a/internal/generator/sitemap.go
+++ b/internal/generator/sitemap.go
@@ -75,13 +75,14 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle,
 		}
 		if len(a.Translations) > 0 {
 			// Self-referencing hreflang (recommended by Google).
+			// BUG-E: href values must be XML-escaped (consistent with <loc>).
 			locale := a.Locale
 			if locale == "" {
 				locale = "x-default"
 			}
-			fmt.Fprintf(&buf, "    <xhtml:link rel=\"alternate\" hreflang=\"%s\" href=\"%s\"/>\n", locale, loc)
+			fmt.Fprintf(&buf, "    <xhtml:link rel=\"alternate\" hreflang=\"%s\" href=\"%s\"/>\n", locale, html.EscapeString(loc))
 			for _, tr := range a.Translations {
-				fmt.Fprintf(&buf, "    <xhtml:link rel=\"alternate\" hreflang=\"%s\" href=\"%s\"/>\n", tr.Locale, baseURL+tr.URL)
+				fmt.Fprintf(&buf, "    <xhtml:link rel=\"alternate\" hreflang=\"%s\" href=\"%s\"/>\n", tr.Locale, html.EscapeString(baseURL+tr.URL))
 			}
 			// x-default points to the default-locale variant so search engines
 			// have a clear fallback when no locale matches the visitor's language.
@@ -95,7 +96,7 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle,
 						}
 					}
 				}
-				fmt.Fprintf(&buf, "    <xhtml:link rel=\"alternate\" hreflang=\"x-default\" href=\"%s\"/>\n", xdefault)
+				fmt.Fprintf(&buf, "    <xhtml:link rel=\"alternate\" hreflang=\"x-default\" href=\"%s\"/>\n", html.EscapeString(xdefault))
 			}
 		}
 		buf.WriteString("  </url>\n")

--- a/internal/generator/sitemap_feed_test.go
+++ b/internal/generator/sitemap_feed_test.go
@@ -63,7 +63,7 @@ func TestGenerateSitemap_WellFormedXML(t *testing.T) {
 
 func TestGenerateFeeds_Valid(t *testing.T) {
 	dir := t.TempDir()
-	if err := GenerateFeeds(dir, "https://example.com", "My Blog", makeArticles()); err != nil {
+	if err := GenerateFeeds(dir, "https://example.com", "My Blog", makeArticles(), model.Config{}); err != nil {
 		t.Fatalf("GenerateFeeds: %v", err)
 	}
 	for _, name := range []string{"feed.xml", "atom.xml"} {
@@ -80,7 +80,7 @@ func TestGenerateFeeds_Valid(t *testing.T) {
 
 func TestGenerateFeeds_NewestFirst(t *testing.T) {
 	dir := t.TempDir()
-	if err := GenerateFeeds(dir, "https://example.com", "Blog", makeArticles()); err != nil {
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", makeArticles(), model.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	for _, name := range []string{"feed.xml", "atom.xml"} {
@@ -94,7 +94,7 @@ func TestGenerateFeeds_NewestFirst(t *testing.T) {
 
 func TestGenerateFeeds_WellFormedXML(t *testing.T) {
 	dir := t.TempDir()
-	if err := GenerateFeeds(dir, "https://example.com", "Blog", makeArticles()); err != nil {
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", makeArticles(), model.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	for _, name := range []string{"feed.xml", "atom.xml"} {
@@ -111,7 +111,7 @@ func TestGenerateFeeds_SlugifiesTitle(t *testing.T) {
 	articles := []*model.ProcessedArticle{
 		{Article: model.Article{FrontMatter: model.FrontMatter{Title: "Hello World", Date: time.Now()}}},
 	}
-	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles); err != nil {
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles, model.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "feed.xml"))
@@ -206,7 +206,7 @@ func TestGenerateFeeds_I18nUsesPrecomputedURL(t *testing.T) {
 			Locale: "ja",
 		},
 	}
-	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles); err != nil {
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles, model.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	for _, name := range []string{"feed.xml", "atom.xml"} {
@@ -233,7 +233,7 @@ func TestGenerateFeeds_NoURLFallsBackToSlug(t *testing.T) {
 			// URL is empty (no i18n)
 		},
 	}
-	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles); err != nil {
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles, model.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	for _, name := range []string{"feed.xml", "atom.xml"} {
@@ -313,5 +313,96 @@ func TestGenerateSitemap_XDefault_NotEmittedWithoutConfig(t *testing.T) {
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
 	if strings.Contains(string(data), "x-default") {
 		t.Errorf("x-default should NOT be emitted when DefaultLocale is not configured:\n%s", data)
+	}
+}
+
+// TestGenerateFeeds_I18n_LocaleFilter verifies that when i18n is configured:
+//   - root feed.xml / atom.xml contain only default-locale articles
+//   - locale subdirectory feeds contain only that locale's articles
+func TestGenerateFeeds_I18n_LocaleFilter(t *testing.T) {
+	date := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	cfg := model.Config{}
+	cfg.I18n.DefaultLocale = "en"
+	cfg.I18n.Locales = []string{"en", "ja"}
+
+	articles := []*model.ProcessedArticle{
+		{
+			Article: model.Article{FrontMatter: model.FrontMatter{Title: "EN Post", Slug: "en-post", Date: date}},
+			URL:     "/posts/en-post/",
+			Locale:  "en",
+		},
+		{
+			Article: model.Article{FrontMatter: model.FrontMatter{Title: "JA Post", Slug: "ja-post", Date: date}},
+			URL:     "/ja/posts/ja-post/",
+			Locale:  "ja",
+		},
+	}
+	dir := t.TempDir()
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles, cfg); err != nil {
+		t.Fatalf("GenerateFeeds: %v", err)
+	}
+
+	// Root feeds (EN only)
+	for _, name := range []string{"feed.xml", "atom.xml"} {
+		data, _ := os.ReadFile(filepath.Join(dir, name))
+		s := string(data)
+		if !strings.Contains(s, "EN Post") {
+			t.Errorf("root %s: expected EN Post", name)
+		}
+		if strings.Contains(s, "JA Post") {
+			t.Errorf("root %s: must NOT contain JA Post", name)
+		}
+	}
+
+	// JA locale feeds
+	for _, name := range []string{"feed.xml", "atom.xml"} {
+		data, _ := os.ReadFile(filepath.Join(dir, "ja", name))
+		s := string(data)
+		if !strings.Contains(s, "JA Post") {
+			t.Errorf("ja/%s: expected JA Post", name)
+		}
+		if strings.Contains(s, "EN Post") {
+			t.Errorf("ja/%s: must NOT contain EN Post", name)
+		}
+		// Article link must not double the locale prefix
+		if strings.Contains(s, "/ja/ja/") {
+			t.Errorf("ja/%s: double locale prefix /ja/ja/ detected:\n%s", name, s)
+		}
+		// Channel link should point to locale root
+		if !strings.Contains(s, "https://example.com/ja") {
+			t.Errorf("ja/%s: channel link should be https://example.com/ja", name)
+		}
+	}
+}
+
+// TestGenerateFeeds_I18n_NoDefaultLocale verifies backward compatibility:
+// when no locales are configured, a single combined feed is written.
+func TestGenerateFeeds_I18n_NoDefaultLocale(t *testing.T) {
+	date := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	articles := []*model.ProcessedArticle{
+		{
+			Article: model.Article{FrontMatter: model.FrontMatter{Title: "EN Post", Slug: "en-post", Date: date}},
+			Locale:  "en",
+		},
+		{
+			Article: model.Article{FrontMatter: model.FrontMatter{Title: "JA Post", Slug: "ja-post", Date: date}},
+			Locale:  "ja",
+		},
+	}
+	dir := t.TempDir()
+	if err := GenerateFeeds(dir, "https://example.com", "Blog", articles, model.Config{}); err != nil {
+		t.Fatalf("GenerateFeeds: %v", err)
+	}
+	// Both articles must appear in root feed
+	for _, name := range []string{"feed.xml", "atom.xml"} {
+		data, _ := os.ReadFile(filepath.Join(dir, name))
+		s := string(data)
+		if !strings.Contains(s, "EN Post") || !strings.Contains(s, "JA Post") {
+			t.Errorf("%s: expected both EN and JA posts in non-i18n feed:\n%s", name, s)
+		}
+	}
+	// No locale subdirectory should exist
+	if _, err := os.Stat(filepath.Join(dir, "ja")); err == nil {
+		t.Error("ja/ subdirectory should NOT be created when i18n is not configured")
 	}
 }

--- a/internal/generator/sitemap_feed_test.go
+++ b/internal/generator/sitemap_feed_test.go
@@ -243,3 +243,75 @@ func TestGenerateFeeds_NoURLFallsBackToSlug(t *testing.T) {
 		}
 	}
 }
+
+// TestGenerateSitemap_XDefault_DefaultLocale verifies that x-default points to
+// the self URL when the article's locale is the site's default locale.
+func TestGenerateSitemap_XDefault_DefaultLocale(t *testing.T) {
+	cfg := model.Config{}
+	cfg.I18n.DefaultLocale = "en"
+	articles := []*model.ProcessedArticle{
+		{
+			Article:      model.Article{FrontMatter: model.FrontMatter{Slug: "hello", Date: time.Now()}},
+			Locale:       "en",
+			URL:          "/posts/hello/",
+			Translations: []model.LocaleRef{{Locale: "ja", URL: "/ja/posts/hello/"}},
+		},
+	}
+	dir := t.TempDir()
+	if err := GenerateSitemap(dir, "https://example.com", articles, cfg); err != nil {
+		t.Fatalf("GenerateSitemap: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
+	s := string(data)
+	want := `hreflang="x-default" href="https://example.com/posts/hello/"`
+	if !strings.Contains(s, want) {
+		t.Errorf("expected x-default pointing to EN (self) URL\nwant substring: %s\ngot:\n%s", want, s)
+	}
+}
+
+// TestGenerateSitemap_XDefault_NonDefaultLocale verifies that x-default points
+// to the default-locale translation URL when the article itself is non-default.
+func TestGenerateSitemap_XDefault_NonDefaultLocale(t *testing.T) {
+	cfg := model.Config{}
+	cfg.I18n.DefaultLocale = "en"
+	articles := []*model.ProcessedArticle{
+		{
+			Article:      model.Article{FrontMatter: model.FrontMatter{Slug: "hello", Date: time.Now()}},
+			Locale:       "ja",
+			URL:          "/ja/posts/hello/",
+			Translations: []model.LocaleRef{{Locale: "en", URL: "/posts/hello/"}},
+		},
+	}
+	dir := t.TempDir()
+	if err := GenerateSitemap(dir, "https://example.com", articles, cfg); err != nil {
+		t.Fatalf("GenerateSitemap: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
+	s := string(data)
+	want := `hreflang="x-default" href="https://example.com/posts/hello/"`
+	if !strings.Contains(s, want) {
+		t.Errorf("expected x-default pointing to EN translation URL\nwant substring: %s\ngot:\n%s", want, s)
+	}
+}
+
+// TestGenerateSitemap_XDefault_NotEmittedWithoutConfig verifies that no
+// x-default link is emitted when DefaultLocale is not configured.
+func TestGenerateSitemap_XDefault_NotEmittedWithoutConfig(t *testing.T) {
+	articles := []*model.ProcessedArticle{
+		{
+			Article:      model.Article{FrontMatter: model.FrontMatter{Slug: "hello", Date: time.Now()}},
+			Locale:       "en",
+			URL:          "/posts/hello/",
+			Translations: []model.LocaleRef{{Locale: "ja", URL: "/ja/posts/hello/"}},
+		},
+	}
+	dir := t.TempDir()
+	// model.Config{} has an empty DefaultLocale
+	if err := GenerateSitemap(dir, "https://example.com", articles, model.Config{}); err != nil {
+		t.Fatalf("GenerateSitemap: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
+	if strings.Contains(string(data), "x-default") {
+		t.Errorf("x-default should NOT be emitted when DefaultLocale is not configured:\n%s", data)
+	}
+}

--- a/internal/generator/sitemap_feed_test.go
+++ b/internal/generator/sitemap_feed_test.go
@@ -368,9 +368,9 @@ func TestGenerateFeeds_I18n_LocaleFilter(t *testing.T) {
 		if strings.Contains(s, "/ja/ja/") {
 			t.Errorf("ja/%s: double locale prefix /ja/ja/ detected:\n%s", name, s)
 		}
-		// Channel link should point to locale root
-		if !strings.Contains(s, "https://example.com/ja") {
-			t.Errorf("ja/%s: channel link should be https://example.com/ja", name)
+		// Channel link should point to locale root (with trailing slash)
+		if !strings.Contains(s, "https://example.com/ja/") {
+			t.Errorf("ja/%s: channel link should be https://example.com/ja/", name)
 		}
 	}
 }

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -53,13 +53,10 @@ type SyntaxHighlightConfig struct {
 
 // OGPConfig holds settings for build-time OGP image generation.
 type OGPConfig struct {
-	Enabled         bool   `yaml:"enabled"`
-	BackgroundColor string `yaml:"background_color"`
-	TextColor       string `yaml:"text_color"`
-	FontFile        string `yaml:"font_file"`
-	LogoFile        string `yaml:"logo_file"` // empty means no logo
-	Width           int    `yaml:"width"`
-	Height          int    `yaml:"height"`
+	Enabled  bool   `yaml:"enabled"`
+	LogoFile string `yaml:"logo_file"` // empty means no logo
+	Width    int    `yaml:"width"`
+	Height   int    `yaml:"height"`
 }
 
 // I18nConfig holds multi-language content configuration.

--- a/internal/model/site.go
+++ b/internal/model/site.go
@@ -2,17 +2,17 @@ package model
 
 // Site holds the full rendering context passed to templates.
 type Site struct {
-	Config             Config
-	Articles           []*ProcessedArticle
-	Tags               []Taxonomy
-	Categories         []Taxonomy
-	ArchiveYears       []int               // unique years that have articles, sorted newest-first
-	Pagination         *Pagination         // nil when pagination is disabled or not a listing page
-	CurrentLocale      string              // locale for the current page; empty when i18n is not configured
-	RelatedArticles    []*ProcessedArticle // articles sharing at least one category with the current article (article pages only)
-	CurrentTaxonomy      *Taxonomy           // set on tag and category listing pages; nil elsewhere
-	CurrentArchivePath   string              // set on archive pages; locale-aware path e.g. "/archives/2024/01/" or "/ja/archives/2024/01/"
-	CurrentArchiveIsMonth bool               // true for month archives (/archives/2024/01/), false for year archives (/archives/2024/)
+	Config                Config
+	Articles              []*ProcessedArticle
+	Tags                  []Taxonomy
+	Categories            []Taxonomy
+	ArchiveYears          []int               // unique years that have articles, sorted newest-first
+	Pagination            *Pagination         // nil when pagination is disabled or not a listing page
+	CurrentLocale         string              // locale for the current page; empty when i18n is not configured
+	RelatedArticles       []*ProcessedArticle // articles sharing at least one category with the current article (article pages only)
+	CurrentTaxonomy       *Taxonomy           // set on tag and category listing pages; nil elsewhere
+	CurrentArchivePath    string              // set on archive pages; locale-aware path e.g. "/archives/2024/01/" or "/ja/archives/2024/01/"
+	CurrentArchiveIsMonth bool                // true for month archives (/archives/2024/01/), false for year archives (/archives/2024/)
 }
 
 // Pagination holds computed paging metadata for listing pages.

--- a/internal/model/site.go
+++ b/internal/model/site.go
@@ -2,16 +2,16 @@ package model
 
 // Site holds the full rendering context passed to templates.
 type Site struct {
-	Config          Config
-	Articles        []*ProcessedArticle
-	Tags            []Taxonomy
-	Categories      []Taxonomy
-	ArchiveYears    []int               // unique years that have articles, sorted newest-first
-	Pagination      *Pagination         // nil when pagination is disabled or not a listing page
-	CurrentLocale   string              // locale for the current page; empty when i18n is not configured
-	RelatedArticles []*ProcessedArticle // articles sharing at least one category with the current article (article pages only)
-	CurrentTaxonomy *Taxonomy           // set on tag and category listing pages; nil elsewhere
-	CurrentArchivePath string            // set on archive pages; locale-neutral path e.g. "/archives/2024/01/"
+	Config             Config
+	Articles           []*ProcessedArticle
+	Tags               []Taxonomy
+	Categories         []Taxonomy
+	ArchiveYears       []int               // unique years that have articles, sorted newest-first
+	Pagination         *Pagination         // nil when pagination is disabled or not a listing page
+	CurrentLocale      string              // locale for the current page; empty when i18n is not configured
+	RelatedArticles    []*ProcessedArticle // articles sharing at least one category with the current article (article pages only)
+	CurrentTaxonomy    *Taxonomy           // set on tag and category listing pages; nil elsewhere
+	CurrentArchivePath string              // set on archive pages; locale-neutral path e.g. "/archives/2024/01/"
 }
 
 // Pagination holds computed paging metadata for listing pages.

--- a/internal/model/site.go
+++ b/internal/model/site.go
@@ -10,8 +10,9 @@ type Site struct {
 	Pagination         *Pagination         // nil when pagination is disabled or not a listing page
 	CurrentLocale      string              // locale for the current page; empty when i18n is not configured
 	RelatedArticles    []*ProcessedArticle // articles sharing at least one category with the current article (article pages only)
-	CurrentTaxonomy    *Taxonomy           // set on tag and category listing pages; nil elsewhere
-	CurrentArchivePath string              // set on archive pages; locale-neutral path e.g. "/archives/2024/01/"
+	CurrentTaxonomy      *Taxonomy           // set on tag and category listing pages; nil elsewhere
+	CurrentArchivePath   string              // set on archive pages; locale-aware path e.g. "/archives/2024/01/" or "/ja/archives/2024/01/"
+	CurrentArchiveIsMonth bool               // true for month archives (/archives/2024/01/), false for year archives (/archives/2024/)
 }
 
 // Pagination holds computed paging metadata for listing pages.

--- a/internal/processor/graph.go
+++ b/internal/processor/graph.go
@@ -63,7 +63,12 @@ func CalculateDiff(oldGraph, newGraph *model.DependencyGraph) (*model.ChangeSet,
 		if _, exists := oldGraph.Nodes[path]; !exists {
 			cs.AddedFiles = append(cs.AddedFiles, path)
 		} else {
-			cs.ModifiedFiles = append(cs.ModifiedFiles, path)
+			// Only report as modified when the modification time actually changed.
+			oldNode := oldGraph.Nodes[path]
+			newNode := newGraph.Nodes[path]
+			if oldNode == nil || newNode == nil || !oldNode.LastModified.Equal(newNode.LastModified) {
+				cs.ModifiedFiles = append(cs.ModifiedFiles, path)
+			}
 		}
 	}
 	for path := range oldGraph.Nodes {

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -151,17 +151,21 @@ func TestCalculateImpact(t *testing.T) {
 }
 
 func TestCalculateDiff(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
 	old := &model.DependencyGraph{
 		Nodes: map[string]*model.Node{
-			"a.md": {Path: "a.md"},
-			"b.md": {Path: "b.md"},
+			"a.md": {Path: "a.md", LastModified: t0}, // will be modified (t0 → t1)
+			"b.md": {Path: "b.md", LastModified: t0}, // will be deleted
+			"d.md": {Path: "d.md", LastModified: t0}, // unchanged (same time)
 		},
 		Edges: map[string][]string{},
 	}
 	newG := &model.DependencyGraph{
 		Nodes: map[string]*model.Node{
-			"a.md": {Path: "a.md"},
-			"c.md": {Path: "c.md"},
+			"a.md": {Path: "a.md", LastModified: t1}, // modified
+			"c.md": {Path: "c.md", LastModified: t1}, // added
+			"d.md": {Path: "d.md", LastModified: t0}, // unchanged — same timestamp
 		},
 		Edges: map[string][]string{},
 	}

--- a/internal/processor/site.go
+++ b/internal/processor/site.go
@@ -206,7 +206,14 @@ func computeOutputPath(a *model.Article, cfg model.Config) string {
 	dir := filepath.Dir(rel)
 	base := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
 	if a.FrontMatter.Slug != "" {
-		base = a.FrontMatter.Slug
+		// BUG-A: sanitise slug against path traversal — take only the last path
+		// component so that "../../etc/passwd" reduces to "passwd".
+		s := filepath.Base(filepath.FromSlash(a.FrontMatter.Slug))
+		if s == "." || s == ".." {
+			// degenerate input — keep the filename-derived base
+		} else {
+			base = s
+		}
 	}
 	// i18n: strip the locale segment from dir, re-add only for non-default locales.
 	if locale := detectLocale(a, cfg); locale != "" {

--- a/internal/processor/site.go
+++ b/internal/processor/site.go
@@ -206,12 +206,13 @@ func computeOutputPath(a *model.Article, cfg model.Config) string {
 	dir := filepath.Dir(rel)
 	base := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
 	if a.FrontMatter.Slug != "" {
-		// BUG-A: sanitise slug against path traversal — take only the last path
+		// BUG-A+F: sanitise slug against path traversal — take only the last path
 		// component so that "../../etc/passwd" reduces to "passwd".
+		// Also reject "." and ".." (degenerate), and the path separator itself
+		// (filepath.Base("///") returns "/" on Unix which would collapse the
+		// directory join in filepath.Join).
 		s := filepath.Base(filepath.FromSlash(a.FrontMatter.Slug))
-		if s == "." || s == ".." {
-			// degenerate input — keep the filename-derived base
-		} else {
+		if s != "." && s != ".." && s != string(filepath.Separator) && s != "" {
 			base = s
 		}
 	}

--- a/internal/processor/site.go
+++ b/internal/processor/site.go
@@ -181,6 +181,11 @@ func (p *SiteProcessor) BuildTranslationMap(articles []*model.ProcessedArticle) 
 			if sibling == a {
 				continue
 			}
+			// Skip siblings with no locale or URL (non-i18n sites where
+			// translation_key is used without an i18n configuration).
+			if sibling.Locale == "" || sibling.URL == "" {
+				continue
+			}
 			a.Translations = append(a.Translations, model.LocaleRef{
 				Locale: sibling.Locale,
 				URL:    sibling.URL,
@@ -218,16 +223,20 @@ func computeOutputPath(a *model.Article, cfg model.Config) string {
 	return filepath.Join(cfg.Build.OutputDir, dir, base, "index.html")
 }
 
-// extractSummary returns the first paragraph of content, truncated to maxChars.
+// extractSummary returns the first paragraph of content, truncated to maxChars runes.
 func extractSummary(content string, maxChars int) string {
 	content = strings.TrimSpace(content)
-	if idx := strings.Index(content, "\n\n"); idx > 0 && idx <= maxChars {
-		return strings.TrimSpace(content[:idx])
+	runes := []rune(content)
+	if idx := strings.Index(content, "\n\n"); idx > 0 {
+		paragraph := strings.TrimSpace(content[:idx])
+		if len([]rune(paragraph)) <= maxChars {
+			return paragraph
+		}
 	}
-	if len(content) <= maxChars {
+	if len(runes) <= maxChars {
 		return content
 	}
-	return content[:maxChars] + "..."
+	return string(runes[:maxChars]) + "..."
 }
 
 // Ensure SiteProcessor implements the Processor interface at compile time.

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -12,7 +12,10 @@ import (
 // the standard library html/template package.
 type TemplateEngine interface {
 	// Load parses all template files rooted at templateDir (e.g. theme/templates).
-	Load(templateDir string, funcs template.FuncMap) error
+	// defaultLocale is the site's primary locale (e.g. "en"); pass "" for
+	// non-i18n sites. tagURL and categoryURL use it to decide when to omit the
+	// locale prefix.
+	Load(templateDir string, funcs template.FuncMap, defaultLocale string) error
 
 	// Render executes the named template with the given data, writing the result
 	// to w.  templateName corresponds to a file base name such as "article.html".

--- a/internal/template/template_engine.go
+++ b/internal/template/template_engine.go
@@ -109,7 +109,7 @@ func builtinFuncs(defaultLocale string) template.FuncMap {
 		// suitable for rendering a pagination control. For example, for
 		// current=5 total=10 it returns [1 -1 4 5 6 -1 10].
 		"paginationPages": func(current, total int) []int {
-			if total <= 1 {
+			if total <= 1 || current < 1 {
 				return nil
 			}
 			pages := []int{}
@@ -146,6 +146,7 @@ func builtinFuncs(defaultLocale string) template.FuncMap {
 // letters and replacing spaces with hyphens. Non-ASCII characters (e.g.
 // Japanese, accented Latin) are kept intact, matching the behaviour of
 // tagNorm in the generator so template links are consistent with page paths.
+// Returns "untitled" when the input produces an empty result.
 func toSlug(s string) string {
 	var b strings.Builder
 	for _, r := range s {
@@ -157,6 +158,9 @@ func toSlug(s string) string {
 		default:
 			b.WriteRune(r)
 		}
+	}
+	if b.Len() == 0 {
+		return "untitled"
 	}
 	return b.String()
 }

--- a/internal/template/template_engine.go
+++ b/internal/template/template_engine.go
@@ -129,12 +129,23 @@ func builtinFuncs() template.FuncMap {
 	}
 }
 
-// toSlug converts a display name to a URL-friendly slug by lowercasing and
-// replacing spaces with hyphens.
+// toSlug converts a display name to a URL-friendly slug by lowercasing ASCII
+// letters and replacing spaces with hyphens. Non-ASCII characters (e.g.
+// Japanese, accented Latin) are kept intact, matching the behaviour of
+// tagNorm in the generator so template links are consistent with page paths.
 func toSlug(s string) string {
-	s = strings.ToLower(s)
-	s = strings.ReplaceAll(s, " ", "-")
-	return s
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + 32)
+		case r == ' ':
+			b.WriteRune('-')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // Ensure Engine implements TemplateEngine at compile time.

--- a/internal/template/template_engine.go
+++ b/internal/template/template_engine.go
@@ -28,8 +28,10 @@ func NewEngine() *Engine {
 // Load parses all .html files found (recursively) under templateDir.
 // Built-in helper functions (formatDate, tagURL, categoryURL, markdownify) are
 // registered automatically; callers may supply additional functions via funcs.
-func (e *Engine) Load(templateDir string, funcs template.FuncMap) error {
-	allFuncs := builtinFuncs()
+// defaultLocale is the site's primary locale (e.g. "en"); pass "" for non-i18n
+// sites. tagURL and categoryURL use it to decide when to omit the locale prefix.
+func (e *Engine) Load(templateDir string, funcs template.FuncMap, defaultLocale string) error {
+	allFuncs := builtinFuncs(defaultLocale)
 	for k, v := range funcs {
 		allFuncs[k] = v
 	}
@@ -73,20 +75,31 @@ func (e *Engine) Render(w io.Writer, templateName string, data *model.Site) erro
 }
 
 // builtinFuncs returns the default template function map.
-func builtinFuncs() template.FuncMap {
+// defaultLocale is the site's primary locale; tagURL and categoryURL use it to
+// omit the locale prefix for the default locale (and for non-i18n sites when
+// "" is passed).
+func builtinFuncs(defaultLocale string) template.FuncMap {
 	conv := parser.NewConverter(parser.WithGFM())
 	return template.FuncMap{
 		// formatDate formats t using layout (e.g. "2006-01-02").
 		"formatDate": func(layout string, t time.Time) string {
 			return t.Format(layout)
 		},
-		// tagURL returns the canonical URL for a tag.
-		"tagURL": func(tag string) string {
-			return "/tags/" + toSlug(tag) + "/"
+		// tagURL returns the locale-aware canonical URL for a tag.
+		// locale="" or locale==defaultLocale → /tags/{slug}/
+		// otherwise → /{locale}/tags/{slug}/
+		"tagURL": func(locale, tag string) string {
+			if locale == "" || locale == defaultLocale {
+				return "/tags/" + toSlug(tag) + "/"
+			}
+			return "/" + locale + "/tags/" + toSlug(tag) + "/"
 		},
-		// categoryURL returns the canonical URL for a category.
-		"categoryURL": func(cat string) string {
-			return "/categories/" + toSlug(cat) + "/"
+		// categoryURL returns the locale-aware canonical URL for a category.
+		"categoryURL": func(locale, cat string) string {
+			if locale == "" || locale == defaultLocale {
+				return "/categories/" + toSlug(cat) + "/"
+			}
+			return "/" + locale + "/categories/" + toSlug(cat) + "/"
 		},
 		// markdownify converts a Markdown string to safe HTML.
 		"markdownify": func(s string) (template.HTML, error) {

--- a/internal/template/template_engine_test.go
+++ b/internal/template/template_engine_test.go
@@ -332,3 +332,23 @@ func TestEngine_Builtin_PageURL(t *testing.T) {
 		}
 	}
 }
+
+func TestToSlug_Empty(t *testing.T) {
+	// Empty input must return "untitled" not an empty string,
+	// so tagURL("", "") never produces "/tags//".
+	if got := toSlug(""); got != "untitled" {
+		t.Errorf("toSlug(%q) = %q, want %q", "", got, "untitled")
+	}
+}
+
+func TestPaginationPages_InvalidCurrent(t *testing.T) {
+	// current < 1 must return nil (invalid input guard, BUG-09).
+	fns := builtinFuncs("")
+	fn := fns["paginationPages"].(func(int, int) []int)
+	if got := fn(0, 10); got != nil {
+		t.Errorf("paginationPages(0,10): expected nil, got %v", got)
+	}
+	if got := fn(-1, 10); got != nil {
+		t.Errorf("paginationPages(-1,10): expected nil, got %v", got)
+	}
+}

--- a/internal/template/template_engine_test.go
+++ b/internal/template/template_engine_test.go
@@ -41,7 +41,7 @@ func TestEngine_Load_Valid(t *testing.T) {
 	dir := t.TempDir()
 	writeTmpl(t, dir, "index.html", `{{define "index.html"}}hello{{end}}`)
 	e := NewEngine()
-	if err := e.Load(dir, nil); err != nil {
+	if err := e.Load(dir, nil, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -50,14 +50,14 @@ func TestEngine_Load_NoHTML(t *testing.T) {
 	dir := t.TempDir()
 	writeTmpl(t, dir, "readme.txt", "nothing here")
 	e := NewEngine()
-	if err := e.Load(dir, nil); err == nil {
+	if err := e.Load(dir, nil, ""); err == nil {
 		t.Error("expected error when no .html files, got nil")
 	}
 }
 
 func TestEngine_Load_DirNotFound(t *testing.T) {
 	e := NewEngine()
-	if err := e.Load("/nonexistent/themes/default", nil); err == nil {
+	if err := e.Load("/nonexistent/themes/default", nil, ""); err == nil {
 		t.Error("expected error for missing directory, got nil")
 	}
 }
@@ -74,7 +74,7 @@ func TestEngine_Render_MissingTemplate(t *testing.T) {
 	dir := t.TempDir()
 	writeTmpl(t, dir, "index.html", `{{define "index.html"}}hi{{end}}`)
 	e := NewEngine()
-	if err := e.Load(dir, nil); err != nil {
+	if err := e.Load(dir, nil, ""); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	var buf bytes.Buffer
@@ -87,7 +87,7 @@ func TestEngine_Render_VariableExpansion(t *testing.T) {
 	dir := t.TempDir()
 	writeTmpl(t, dir, "index.html", `{{define "index.html"}}{{.Config.Site.Title}}{{end}}`)
 	e := NewEngine()
-	if err := e.Load(dir, nil); err != nil {
+	if err := e.Load(dir, nil, ""); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	got := renderStr(t, e, "index.html", minSite("My Blog"))
@@ -101,7 +101,7 @@ func TestEngine_Render_MultipleTemplates(t *testing.T) {
 	writeTmpl(t, dir, "index.html", `{{define "index.html"}}index{{end}}`)
 	writeTmpl(t, dir, "article.html", `{{define "article.html"}}article{{end}}`)
 	e := NewEngine()
-	if err := e.Load(dir, nil); err != nil {
+	if err := e.Load(dir, nil, ""); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	if got := renderStr(t, e, "index.html", minSite("")); got != "index" {
@@ -113,7 +113,7 @@ func TestEngine_Render_MultipleTemplates(t *testing.T) {
 }
 
 func TestEngine_Builtin_FormatDate(t *testing.T) {
-	fns := builtinFuncs()
+	fns := builtinFuncs("")
 	fn, ok := fns["formatDate"].(func(string, time.Time) string)
 	if !ok {
 		t.Fatal("formatDate not found in builtinFuncs")
@@ -126,31 +126,55 @@ func TestEngine_Builtin_FormatDate(t *testing.T) {
 }
 
 func TestEngine_Builtin_TagURL(t *testing.T) {
-	fns := builtinFuncs()
-	fn, ok := fns["tagURL"].(func(string) string)
+	// no-locale (non-i18n): root path
+	fns := builtinFuncs("")
+	fn, ok := fns["tagURL"].(func(string, string) string)
 	if !ok {
-		t.Fatal("tagURL not found")
+		t.Fatal("tagURL not found or wrong type")
 	}
-	got := fn("Go Programming")
-	if got != "/tags/go-programming/" {
-		t.Errorf("tagURL: got %q, want %q", got, "/tags/go-programming/")
+	if got := fn("", "Go Programming"); got != "/tags/go-programming/" {
+		t.Errorf("tagURL no-locale: got %q, want %q", got, "/tags/go-programming/")
+	}
+
+	// default locale ("en"): same root path — no prefix
+	fnsEN := builtinFuncs("en")
+	fnEN := fnsEN["tagURL"].(func(string, string) string)
+	if got := fnEN("en", "Go Programming"); got != "/tags/go-programming/" {
+		t.Errorf("tagURL en (default): got %q, want %q", got, "/tags/go-programming/")
+	}
+
+	// non-default locale ("ja"): locale-prefixed path
+	if got := fnEN("ja", "Go Programming"); got != "/ja/tags/go-programming/" {
+		t.Errorf("tagURL ja: got %q, want %q", got, "/ja/tags/go-programming/")
 	}
 }
 
 func TestEngine_Builtin_CategoryURL(t *testing.T) {
-	fns := builtinFuncs()
-	fn, ok := fns["categoryURL"].(func(string) string)
+	// no-locale (non-i18n): root path
+	fns := builtinFuncs("")
+	fn, ok := fns["categoryURL"].(func(string, string) string)
 	if !ok {
-		t.Fatal("categoryURL not found")
+		t.Fatal("categoryURL not found or wrong type")
 	}
-	got := fn("Web Development")
-	if got != "/categories/web-development/" {
-		t.Errorf("categoryURL: got %q, want %q", got, "/categories/web-development/")
+	if got := fn("", "Web Development"); got != "/categories/web-development/" {
+		t.Errorf("categoryURL no-locale: got %q, want %q", got, "/categories/web-development/")
+	}
+
+	// default locale ("en"): root path — no prefix
+	fnsEN := builtinFuncs("en")
+	fnEN := fnsEN["categoryURL"].(func(string, string) string)
+	if got := fnEN("en", "Web Development"); got != "/categories/web-development/" {
+		t.Errorf("categoryURL en (default): got %q, want %q", got, "/categories/web-development/")
+	}
+
+	// non-default locale ("ja"): locale-prefixed path
+	if got := fnEN("ja", "Web Development"); got != "/ja/categories/web-development/" {
+		t.Errorf("categoryURL ja: got %q, want %q", got, "/ja/categories/web-development/")
 	}
 }
 
 func TestEngine_Builtin_Markdownify(t *testing.T) {
-	fns := builtinFuncs()
+	fns := builtinFuncs("")
 	fn, ok := fns["markdownify"].(func(string) (template.HTML, error))
 	if !ok {
 		t.Fatal("markdownify not found")
@@ -171,7 +195,7 @@ func TestEngine_CustomFunc(t *testing.T) {
 	customFuncs := template.FuncMap{
 		"shout": func(s string) string { return strings.ToUpper(s) + "!" },
 	}
-	if err := e.Load(dir, customFuncs); err != nil {
+	if err := e.Load(dir, customFuncs, ""); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	got := renderStr(t, e, "custom.html", minSite("hello"))
@@ -189,7 +213,7 @@ func TestEngine_Load_SubDir(t *testing.T) {
 	writeTmpl(t, dir, "index.html", `{{define "index.html"}}main{{end}}`)
 	writeTmpl(t, sub, "partial.html", `{{define "partial.html"}}part{{end}}`)
 	e := NewEngine()
-	if err := e.Load(dir, nil); err != nil {
+	if err := e.Load(dir, nil, ""); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	if got := renderStr(t, e, "index.html", minSite("")); got != "main" {
@@ -216,7 +240,7 @@ func TestToSlug(t *testing.T) {
 }
 
 func TestEngine_Builtin_PaginationPages(t *testing.T) {
-	fns := builtinFuncs()
+	fns := builtinFuncs("")
 	fn, ok := fns["paginationPages"].(func(int, int) []int)
 	if !ok {
 		t.Fatal("paginationPages not found in builtinFuncs")
@@ -283,7 +307,7 @@ func TestEngine_Builtin_PaginationPages(t *testing.T) {
 }
 
 func TestEngine_Builtin_PageURL(t *testing.T) {
-	fns := builtinFuncs()
+	fns := builtinFuncs("")
 	fn, ok := fns["pageURL"].(func(string, int) string)
 	if !ok {
 		t.Fatal("pageURL not found in builtinFuncs")


### PR DESCRIPTION
## Summary

This PR bundles all fixes from multiple code audit rounds, plus locale-aware language switcher support and Atom feed RFC 4287 compliance.

---

## Language Switcher (i18n)

- **`Taxonomy.URL`** field added — locale-aware URL for tag/category pages, enabling correct language switcher links
- **`CurrentArchivePath`** field added — locale-aware archive URL for archive page language switcher
- **`CurrentArchiveIsMonth`** added — distinguishes yearly vs monthly archive pages
- `tagURL` / `categoryURL` template functions made locale-aware (2-arg API)
- Per-locale feeds generated for i18n sites
- Archive listing pages paginated
- `toSlug` aligned with `tagNorm` (ASCII-only lowercase)
- `git rename (R)` status handled in `parseNameStatus`
- `x-default` hreflang added to sitemap for i18n sites

---

## Atom Feed RFC 4287 Compliance

- Feed `<id>` element added (required by RFC 4287)
- Feed `<link rel="self">` added
- Feed `<author>…</author>` added (read from `config.theme.params.author`)
- Entry `<id>` added per entry
- Entry `<link>` now has `rel="alternate" type="text/html"`

---

## 12-Bug Audit (round 1)

| # | Location | Bug | Fix |
|---|----------|-----|-----|
| BUG-1 | `generator/ogp.go` | OGP changeset path mismatch (relative vs absolute) | `filepath.Rel(contentDir, a.FilePath)` |
| BUG-2 | `cmd/gohan/build.go` | Template load failure treated as warning, build continues | Return error immediately |
| BUG-3 | `diff/cache.go` | Corrupt manifest aborts build | Return `nil, nil` → trigger full rebuild |
| BUG-4 | `diff/cache.go` | Non-atomic manifest and HTML writes (data corruption on crash) | `writeAtomicFile()` using temp+rename |
| BUG-5 | `diff/git.go` | `__config__` sentinel leaked into deleted-files detection | Skip sentinel key in loop |
| BUG-6 | `processor/graph.go` | `CalculateDiff` marks all shared nodes as modified | Only mark Modified when `LastModified` timestamps differ |
| BUG-7 | `generator/ogp.go`, `generator/html.go` | `FrontMatter.Slug` path traversal (raw value used in file path) | `slugify(a.FrontMatter.Slug)` |
| BUG-8 | `processor/site.go` | `extractSummary` byte-level truncation corrupts multi-byte UTF-8 | `[]rune` truncation |
| BUG-9 | `cmd/gohan/build.go` | `filepath.Rel` error silently discarded | Return error, skip article |
| BUG-10 | `generator/html.go` | `filepath.Rel` error silently discarded in `CopyDir` | Return error |
| BUG-11 | `generator/sitemap.go` | Sitemap `<loc>` values not XML-escaped (bare `&` in URLs) | `html.EscapeString()` on all `<loc>` values |
| BUG-12 | `generator/html.go` | `site.ArchiveYears` nil fallback uses wrong locale base | `localeTaxonomyBase(site, site.Articles)` |

---

## 6-Bug Audit (round 2) — commits `64090f9`, `900959b`

| # | Location | Bug | Fix |
|---|----------|-----|-----|
| BUG-A | `processor/site.go` `computeOutputPath` | `FrontMatter.Slug` used as-is as output path base — path traversal possible (e.g. `../../etc/passwd`) | `filepath.Base(filepath.FromSlash(slug))` strips all directory components |
| BUG-B | `processor/site.go` `localeTaxonomyBase` | Locale-filtered `Taxonomy.Description` always empty — tag/category page templates showed no descriptions | Build lookup from base taxonomy items and populate |
| BUG-C | `generator/feed.go` | RSS `<channel><link>` lacked trailing slash (baseURL without `/`), inconsistent with Atom | Pass `baseURL+"/"` uniformly |
| BUG-D | `cmd/gohan/new.go` | TOCTOU race in file creation: `os.Stat` → `os.Create` sequence allowed interleaved overwrites | Use `os.OpenFile` with `O_EXCL` flag for atomic exclusive creation |
| BUG-E | `generator/sitemap.go` | `<xhtml:link href>` values not XML-escaped (unlike `<loc>` which was already fixed) | Apply `html.EscapeString` to all three `href` emits (self, translation, x-default) |
| BUG-F | `processor/site.go` | Slug separator guard incomplete: `filepath.Base("///")` returns `"/"` on Unix, which passed the old `"." / ".."` check and was used as path base, collapsing the directory join | Also reject `s == string(filepath.Separator)` and `s == ""` |

---

## Tests

All 13 packages pass:

```
ok  	github.com/bmf-san/gohan/...   (13 packages)
```