### PR TITLE
chore: remove stale BUG label comments from source files

### DIFF
--- a/cmd/gohan/new.go
+++ b/cmd/gohan/new.go
@@ -66,7 +66,7 @@ categories: []
 
 `, articleTitle, today)
 
-	// BUG-D: use O_CREATE|O_EXCL for an atomic create-or-fail, eliminating the
+	// Use O_CREATE|O_EXCL for an atomic create-or-fail, eliminating the
 	// TOCTOU race between the old os.Stat check and os.WriteFile.
 	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
 	if err != nil {

--- a/internal/generator/feed.go
+++ b/internal/generator/feed.go
@@ -130,7 +130,7 @@ func GenerateFeeds(outDir, baseURL, siteTitle string, articles []*model.Processe
 }
 
 func writeRSS(outDir, baseURL, title string, articles []*model.ProcessedArticle) error {
-	// BUG-C: channel URL must have a trailing slash (consistent with writeAtom).
+	// Channel URL must have a trailing slash (consistent with writeAtom).
 	return writeRSSWithChannelURL(outDir, baseURL, baseURL+"/", title, articles)
 }
 

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -642,7 +642,7 @@ func localeTaxonomyBase(base *model.Site, articles []*model.ProcessedArticle) *m
 	}
 	sort.Slice(tags, func(i, j int) bool { return tags[i].Name < tags[j].Name })
 	sort.Slice(cats, func(i, j int) bool { return cats[i].Name < cats[j].Name })
-	// BUG-B: preserve Taxonomy.Description from base.Tags / base.Categories.
+	// Preserve Taxonomy.Description from base.Tags / base.Categories.
 	// Without this, locale-filtered listing pages always show empty descriptions.
 	tagDesc := make(map[string]string, len(base.Tags))
 	for _, t := range base.Tags {
@@ -746,7 +746,7 @@ func articleOutputPath(a *model.ProcessedArticle, outDir string, cfg model.Confi
 		}
 	}
 	// Fallback: construct from slug and locale.
-	// BUG-7: sanitize slug to prevent path traversal outside the output directory.
+	// Sanitize slug to prevent path traversal outside the output directory.
 	slug := slugify(a.FrontMatter.Slug)
 	if slug == "untitled" {
 		slug = slugify(a.FrontMatter.Title)

--- a/internal/generator/ogp.go
+++ b/internal/generator/ogp.go
@@ -72,7 +72,7 @@ func (g *OGPGenerator) Generate(site *model.Site, changeSet *model.ChangeSet) er
 	changed := changedSet(changeSet)
 
 	for _, a := range site.Articles {
-		// BUG-7: sanitize slug to prevent path traversal (slugify strips dots, slashes, etc.).
+		// Sanitize slug to prevent path traversal (slugify strips dots, slashes, etc.).
 		slug := slugify(a.FrontMatter.Slug)
 		if slug == "untitled" {
 			slug = slugify(a.FrontMatter.Title)
@@ -80,7 +80,7 @@ func (g *OGPGenerator) Generate(site *model.Site, changeSet *model.ChangeSet) er
 		outPath := filepath.Join(ogpDir, slug+".png")
 
 		// Skip if already exists and article not in change set.
-		// BUG-1: changeSet entries are relative to contentDir, but a.FilePath is
+		// changeSet entries are relative to contentDir, but a.FilePath is
 		// absolute — compute the relative path for the lookup.
 		if _, statErr := os.Stat(outPath); statErr == nil && changeSet != nil {
 			lookupPath := a.FilePath

--- a/internal/generator/sitemap.go
+++ b/internal/generator/sitemap.go
@@ -75,7 +75,7 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle,
 		}
 		if len(a.Translations) > 0 {
 			// Self-referencing hreflang (recommended by Google).
-			// BUG-E: href values must be XML-escaped (consistent with <loc>).
+			// href values must be XML-escaped (consistent with <loc>).
 			locale := a.Locale
 			if locale == "" {
 				locale = "x-default"

--- a/internal/processor/site.go
+++ b/internal/processor/site.go
@@ -206,7 +206,7 @@ func computeOutputPath(a *model.Article, cfg model.Config) string {
 	dir := filepath.Dir(rel)
 	base := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
 	if a.FrontMatter.Slug != "" {
-		// BUG-A+F: sanitise slug against path traversal — take only the last path
+		// Sanitise slug against path traversal — take only the last path
 		// component so that "../../etc/passwd" reduces to "passwd".
 		// Also reject "." and ".." (degenerate), and the path separator itself
 		// (filepath.Base("///") returns "/" on Unix which would collapse the


### PR DESCRIPTION
## Summary

Remove stale `BUG-X` and `BUG-T` label markers from source code comments. These labels were used during an audit session to track known bugs. All referenced bugs have since been fixed, so the labels are no longer needed. The explanatory comments themselves are preserved where useful.

## Files changed

- `internal/processor/site.go`
- `internal/generator/feed.go`
- `internal/generator/ogp.go`
- `internal/generator/sitemap.go`
- `internal/generator/html.go`
- `cmd/gohan/new.go`