### PR TITLE
fix: skip Codecov upload for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           fi
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Problem

CI fails on Dependabot PRs because `CODECOV_TOKEN` is not available in Dependabot workflows (Dependabot uses its own isolated secrets). This causes the Codecov upload to fail with:

```
error - Upload failed: {"message":"Token required because branch is protected"}
```

Since `fail_ci_if_error: true`, this makes the entire CI check fail.

## Fix

Add `github.actor != 'dependabot[bot]'` to the `if` condition on the Codecov upload step so it is skipped for Dependabot PRs.

## Impact

- Dependabot PRs: Codecov upload is skipped (no CI failure)
- All other PRs: Codecov upload behaviour unchanged