### PR TITLE
feat: add category grouping to bookshelf plugin

### DIFF
--- a/internal/plugin/bookshelf/bookshelf.go
+++ b/internal/plugin/bookshelf/bookshelf.go
@@ -16,11 +16,14 @@
 //
 // # Template usage (bookshelf.html)
 //
-//	{{range index .VirtualPageData "books"}}
-//	  <a href="{{.LinkURL}}" target="_blank" rel="noopener">
-//	    <img src="{{.ImageURL}}" alt="{{.Title}}">
-//	  </a>
-//	  {{if .ArticleURL}}<a href="{{.ArticleURL}}">{{.ArticleTitle}}</a>{{end}}
+//	{{range index .VirtualPageData "categories"}}
+//	  <h2>{{if .Name}}{{.Name}}{{else}}Uncategorized{{end}}</h2>
+//	  {{range .Books}}
+//	    <a href="{{.LinkURL}}" target="_blank" rel="noopener">
+//	      <img src="{{.ImageURL}}" alt="{{.Title}}">
+//	    </a>
+//	    {{if .ArticleURL}}<a href="{{.ArticleURL}}">{{.ArticleTitle}}</a>{{end}}
+//	  {{end}}
 //	{{end}}
 package bookshelf
 
@@ -53,6 +56,14 @@ type BookEntry struct {
 	ArticleTitle string
 	ArticleURL   string
 	Date         time.Time
+	Categories   []string
+}
+
+// CategoryGroup groups BookEntries under a single category name.
+// When Name is empty the books have no category assigned.
+type CategoryGroup struct {
+	Name  string
+	Books []BookEntry
 }
 
 // Bookshelf implements SitePlugin.
@@ -83,6 +94,10 @@ func (b *Bookshelf) Enabled(cfg map[string]interface{}) bool {
 
 // VirtualPages collects all book entries from article front-matter and returns
 // one VirtualPage per locale containing the aggregated bookshelf data.
+// Each page's Data map contains:
+//
+//	"books"      []BookEntry       — all entries sorted by date descending
+//	"categories" []CategoryGroup   — entries grouped by article category, sorted alphabetically
 func (b *Bookshelf) VirtualPages(site *model.Site, cfg map[string]interface{}) ([]*model.VirtualPage, error) {
 	tag := strVal(cfg, "tag", defaultTag)
 
@@ -127,6 +142,7 @@ func (b *Bookshelf) VirtualPages(site *model.Site, cfg map[string]interface{}) (
 				ArticleTitle: article.FrontMatter.Title,
 				ArticleURL:   article.URL,
 				Date:         article.FrontMatter.Date,
+				Categories:   article.FrontMatter.Categories,
 			}
 			byLocale[locale].entries = append(byLocale[locale].entries, entry)
 		}
@@ -143,7 +159,7 @@ func (b *Bookshelf) VirtualPages(site *model.Site, cfg map[string]interface{}) (
 
 	var pages []*model.VirtualPage
 	for locale, le := range byLocale {
-		// Sort by date descending (newest first).
+		// Sort all entries by date descending (newest first).
 		sort.Slice(le.entries, func(i, j int) bool {
 			return le.entries[i].Date.After(le.entries[j].Date)
 		})
@@ -163,12 +179,52 @@ func (b *Bookshelf) VirtualPages(site *model.Site, cfg map[string]interface{}) (
 			Template:   "bookshelf.html",
 			Locale:     locale,
 			Data: map[string]interface{}{
-				"books": le.entries,
+				"books":      le.entries,
+				"categories": buildCategoryGroups(le.entries),
 			},
 		})
 	}
 
 	return pages, nil
+}
+
+// buildCategoryGroups groups entries by category and returns them sorted
+// alphabetically by category name. Entries with no categories are placed
+// in a group with an empty Name at the end.
+func buildCategoryGroups(entries []BookEntry) []CategoryGroup {
+	catMap := map[string][]BookEntry{}
+	for _, e := range entries {
+		if len(e.Categories) == 0 {
+			catMap[""] = append(catMap[""], e)
+		} else {
+			for _, cat := range e.Categories {
+				catMap[cat] = append(catMap[cat], e)
+			}
+		}
+	}
+
+	// Collect and sort names; empty (uncategorized) goes last.
+	names := make([]string, 0, len(catMap))
+	for name := range catMap {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		if names[i] == "" {
+			return false
+		}
+		if names[j] == "" {
+			return true
+		}
+		return names[i] < names[j]
+	})
+
+	groups := make([]CategoryGroup, 0, len(names))
+	for _, name := range names {
+		books := catMap[name]
+		// Books within each group are already date-sorted via le.entries order.
+		groups = append(groups, CategoryGroup{Name: name, Books: books})
+	}
+	return groups
 }
 
 // strVal extracts a string value from a map, returning def when missing or wrong type.

--- a/internal/plugin/bookshelf/bookshelf_test.go
+++ b/internal/plugin/bookshelf/bookshelf_test.go
@@ -284,3 +284,104 @@ func TestBookshelf_InvalidBooksField(t *testing.T) {
 		t.Error("expected error for invalid books field type, got nil")
 	}
 }
+
+func TestBookshelf_CategoryGroups(t *testing.T) {
+	b := bookshelf.New()
+	date := time.Date(2024, 5, 4, 0, 0, 0, 0, time.UTC)
+	site := &model.Site{
+		Config: model.Config{
+			Site: model.SiteConfig{Language: "en"},
+			I18n: model.I18nConfig{DefaultLocale: "en"},
+		},
+		Articles: []*model.ProcessedArticle{
+			{
+				Article: model.Article{FrontMatter: model.FrontMatter{
+					Title:      "Go Book",
+					Slug:       "go-book",
+					Date:       date,
+					Categories: []string{"Programming"},
+					Extra: map[string]interface{}{
+						"books": []interface{}{
+							map[string]interface{}{"asin": "GO1", "title": "Learning Go"},
+						},
+					},
+				}},
+				Locale: "en",
+				URL:    "/posts/go-book/",
+			},
+			{
+				Article: model.Article{FrontMatter: model.FrontMatter{
+					Title:      "Agile Book",
+					Slug:       "agile-book",
+					Date:       date,
+					Categories: []string{"Agile"},
+					Extra: map[string]interface{}{
+						"books": []interface{}{
+							map[string]interface{}{"asin": "AG1", "title": "Agile Samurai"},
+						},
+					},
+				}},
+				Locale: "en",
+				URL:    "/posts/agile-book/",
+			},
+			{
+				Article: model.Article{FrontMatter: model.FrontMatter{
+					Title: "No Category Book",
+					Slug:  "no-cat",
+					Date:  date,
+					Extra: map[string]interface{}{
+						"books": []interface{}{
+							map[string]interface{}{"asin": "NC1", "title": "Unknown Category"},
+						},
+					},
+				}},
+				Locale: "en",
+				URL:    "/posts/no-cat/",
+			},
+		},
+	}
+
+	pages, err := b.VirtualPages(site, cfg(true, ""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pages) != 1 {
+		t.Fatalf("expected 1 page, got %d", len(pages))
+	}
+
+	cats, ok := pages[0].Data["categories"].([]bookshelf.CategoryGroup)
+	if !ok {
+		t.Fatalf("Data[\"categories\"] type = %T, want []bookshelf.CategoryGroup", pages[0].Data["categories"])
+	}
+
+	// Expect: Agile, Programming (alphabetical), then "" (uncategorized) last.
+	if len(cats) != 3 {
+		t.Fatalf("expected 3 category groups, got %d", len(cats))
+	}
+	if cats[0].Name != "Agile" {
+		t.Errorf("cats[0].Name = %q, want Agile", cats[0].Name)
+	}
+	if cats[1].Name != "Programming" {
+		t.Errorf("cats[1].Name = %q, want Programming", cats[1].Name)
+	}
+	if cats[2].Name != "" {
+		t.Errorf("cats[2].Name = %q, want empty (uncategorized)", cats[2].Name)
+	}
+	if len(cats[0].Books) != 1 || cats[0].Books[0].ASIN != "AG1" {
+		t.Errorf("Agile group books mismatch")
+	}
+	if len(cats[1].Books) != 1 || cats[1].Books[0].ASIN != "GO1" {
+		t.Errorf("Programming group books mismatch")
+	}
+	if len(cats[2].Books) != 1 || cats[2].Books[0].ASIN != "NC1" {
+		t.Errorf("uncategorized group books mismatch")
+	}
+
+	// Categories field on BookEntry should be populated.
+	books := pages[0].Data["books"].([]bookshelf.BookEntry)
+	for _, bk := range books {
+		if bk.ASIN == "GO1" && len(bk.Categories) == 0 {
+			t.Error("BookEntry.Categories should be populated for GO1")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds category grouping support to the bookshelf built-in plugin.

## Changes

### `internal/plugin/bookshelf/bookshelf.go`
- Add `Categories []string` field to `BookEntry` — populated from each book's `categories:` key in front-matter
- Add `CategoryGroup` struct `{ Name string; Books []BookEntry }`
- Add `buildCategoryGroups(entries []BookEntry) []CategoryGroup` — groups entries by category, sorts group names alphabetically, uncategorized entries (no categories) go last
- Expose `"categories"` key in `VirtualPage.Data` (alongside the existing `"books"` key)

### `internal/plugin/bookshelf/bookshelf_test.go`
- Add `TestBookshelf_CategoryGroups` — verifies correct grouping, alphabetical ordering of groups, uncategorized last, and `BookEntry.Categories` population

## Front-matter usage

```yaml
books:
  - asin: "4873119464"
    title: "The Pragmatic Programmer"
    categories:
      - Programming
```

## Template usage

```html
{{- range $group := index .VirtualPageData "categories" }}
<h2>{{ if $group.Name }}{{ $group.Name }}{{ else }}Uncategorized{{ end }}</h2>
{{- range $book := $group.Books }}
  <!-- book card -->
{{- end }}
{{- end }}
```