### PR TITLE
fix: include virtual pages in sitemap

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -217,7 +217,7 @@ func runBuild(args []string) error {
 	}
 
 	// Sitemap + feeds.
-	if err := generator.GenerateSitemap(outDir, cfg.Site.BaseURL, processed, *cfg); err != nil {
+	if err := generator.GenerateSitemap(outDir, cfg.Site.BaseURL, processed, site.VirtualPages, *cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: sitemap: %v\n", err)
 	}
 	if err := generator.GenerateFeeds(outDir, cfg.Site.BaseURL, cfg.Site.Title, processed, *cfg); err != nil {

--- a/internal/generator/sitemap.go
+++ b/internal/generator/sitemap.go
@@ -11,13 +11,14 @@ import (
 	"github.com/bmf-san/gohan/internal/model"
 )
 
-// GenerateSitemap writes sitemap.xml to outDir, listing all article URLs.
+// GenerateSitemap writes sitemap.xml to outDir, listing all article URLs and
+// any virtual pages produced by SitePlugins (e.g. /bookshelf/).
 // When articles have Translations populated (i18n), xhtml:link hreflang
 // alternates are included for SEO.
 // Articles are sorted newest-first. baseURL must not have a trailing slash.
 // When cfg has I18n.Locales configured, the locale index pages (/ and /ja/
 // etc.) are prepended to the sitemap as important entry points.
-func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle, cfg model.Config) error {
+func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle, virtualPages []*model.VirtualPage, cfg model.Config) error {
 	sorted := make([]*model.ProcessedArticle, len(articles))
 	copy(sorted, articles)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -54,6 +55,16 @@ func GenerateSitemap(outDir, baseURL string, articles []*model.ProcessedArticle,
 			buf.WriteString("    <loc>" + html.EscapeString(indexURL) + "</loc>\n")
 			buf.WriteString("  </url>\n")
 		}
+	}
+
+	// Emit virtual page URLs (e.g. /bookshelf/, /ja/bookshelf/).
+	for _, vp := range virtualPages {
+		if vp.URL == "" {
+			continue
+		}
+		buf.WriteString("  <url>\n")
+		buf.WriteString("    <loc>" + html.EscapeString(baseURL+vp.URL) + "</loc>\n")
+		buf.WriteString("  </url>\n")
 	}
 
 	for _, a := range sorted {

--- a/internal/generator/sitemap_feed_test.go
+++ b/internal/generator/sitemap_feed_test.go
@@ -22,7 +22,7 @@ func makeArticles() []*model.ProcessedArticle {
 
 func TestGenerateSitemap_Valid(t *testing.T) {
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", makeArticles(), model.Config{}); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", makeArticles(), nil, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -40,7 +40,7 @@ func TestGenerateSitemap_Valid(t *testing.T) {
 
 func TestGenerateSitemap_Empty(t *testing.T) {
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", nil, model.Config{}); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", nil, nil, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap empty: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -51,7 +51,7 @@ func TestGenerateSitemap_Empty(t *testing.T) {
 
 func TestGenerateSitemap_WellFormedXML(t *testing.T) {
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", makeArticles(), model.Config{}); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", makeArticles(), nil, model.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -120,6 +120,25 @@ func TestGenerateFeeds_SlugifiesTitle(t *testing.T) {
 	}
 }
 
+func TestGenerateSitemap_VirtualPages(t *testing.T) {
+	dir := t.TempDir()
+	vps := []*model.VirtualPage{
+		{URL: "/bookshelf/"},
+		{URL: "/ja/bookshelf/"},
+	}
+	if err := GenerateSitemap(dir, "https://example.com", nil, vps, model.Config{}); err != nil {
+		t.Fatalf("GenerateSitemap: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
+	s := string(data)
+	if !strings.Contains(s, "https://example.com/bookshelf/") {
+		t.Errorf("expected /bookshelf/ in sitemap:\n%s", s)
+	}
+	if !strings.Contains(s, "https://example.com/ja/bookshelf/") {
+		t.Errorf("expected /ja/bookshelf/ in sitemap:\n%s", s)
+	}
+}
+
 func TestGenerateSitemap_LastmodFromField(t *testing.T) {
 	date := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	lastmod := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
@@ -134,7 +153,7 @@ func TestGenerateSitemap_LastmodFromField(t *testing.T) {
 		},
 	}
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", articles, model.Config{}); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", articles, nil, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -156,7 +175,7 @@ func TestGenerateSitemap_LastmodFallsBackToDate(t *testing.T) {
 		},
 	}
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", articles, model.Config{}); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", articles, nil, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -182,7 +201,7 @@ func TestGenerateSitemap_HreflangAlternates(t *testing.T) {
 		},
 	}
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", articles, model.Config{}); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", articles, nil, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -203,7 +222,7 @@ func TestGenerateSitemap_I18nIndexPages(t *testing.T) {
 	cfg := model.Config{}
 	cfg.I18n.DefaultLocale = "en"
 	cfg.I18n.Locales = []string{"en", "ja"}
-	if err := GenerateSitemap(dir, "https://example.com", nil, cfg); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", nil, nil, cfg); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -224,7 +243,7 @@ func TestGenerateSitemap_UsesPrecomputedURL(t *testing.T) {
 			URL:     "/ja/posts/my-url/",
 		},
 	}
-	if err := GenerateSitemap(dir, "https://example.com", articles, model.Config{}); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", articles, nil, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -303,7 +322,7 @@ func TestGenerateSitemap_XDefault_DefaultLocale(t *testing.T) {
 		},
 	}
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", articles, cfg); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", articles, nil, cfg); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -328,7 +347,7 @@ func TestGenerateSitemap_XDefault_NonDefaultLocale(t *testing.T) {
 		},
 	}
 	dir := t.TempDir()
-	if err := GenerateSitemap(dir, "https://example.com", articles, cfg); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", articles, nil, cfg); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))
@@ -352,7 +371,7 @@ func TestGenerateSitemap_XDefault_NotEmittedWithoutConfig(t *testing.T) {
 	}
 	dir := t.TempDir()
 	// model.Config{} has an empty DefaultLocale
-	if err := GenerateSitemap(dir, "https://example.com", articles, model.Config{}); err != nil {
+	if err := GenerateSitemap(dir, "https://example.com", articles, nil, model.Config{}); err != nil {
 		t.Fatalf("GenerateSitemap: %v", err)
 	}
 	data, _ := os.ReadFile(filepath.Join(dir, "sitemap.xml"))


### PR DESCRIPTION
## Problem

`GenerateSitemap` only received `[]*model.ProcessedArticle`, so virtual pages produced by SitePlugins (e.g. `/bookshelf/`, `/ja/bookshelf/`) were never included in `sitemap.xml`. This is an SEO gap — plugin-generated pages should be indexed.

## Changes

### `internal/generator/sitemap.go`
- Add `virtualPages []*model.VirtualPage` parameter to `GenerateSitemap`
- Emit `<url><loc>…</loc></url>` for each virtual page with a non-empty URL, positioned after locale index pages and before article entries

### `cmd/gohan/build.go`
- Pass `site.VirtualPages` to `GenerateSitemap`

### `internal/generator/sitemap_feed_test.go`
- Update all 11 existing `GenerateSitemap` call sites to pass `nil` for the new parameter
- Add `TestGenerateSitemap_VirtualPages` verifying `/bookshelf/` and `/ja/bookshelf/` appear in the output

## Result

```xml
<url><loc>https://example.com/bookshelf/</loc></url>
<url><loc>https://example.com/ja/bookshelf/</loc></url>
```
These now appear in `sitemap.xml` between the locale index pages and article entries.