### PR TITLE
feat: support non-Amazon books (url: field) in bookshelf plugin

### DIFF
--- a/internal/plugin/bookshelf/bookshelf.go
+++ b/internal/plugin/bookshelf/bookshelf.go
@@ -11,8 +11,10 @@
 // # Front-matter (article .md) — same key used by amazon_books plugin
 //
 //	books:
-//	  - asin: "4781920004"
+//	  - asin: "4781920004"           # Amazon ASIN — generates image + Amazon link
 //	    title: "組織を変える5つの対話"   # optional; used for alt text
+//	  - url: "https://booth.pm/..."  # non-Amazon: direct sales URL (no cover image)
+//	    title: "同人誌タイトル"
 //
 // # Template usage (bookshelf.html)
 //
@@ -129,15 +131,28 @@ func (b *Bookshelf) VirtualPages(site *model.Site, cfg map[string]interface{}) (
 				continue
 			}
 			asin := strVal(m, "asin", "")
-			if asin == "" {
+			directURL := strVal(m, "url", "")
+			if asin == "" && directURL == "" {
 				continue
 			}
-			title := strVal(m, "title", asin)
+			titleDef := asin
+			if titleDef == "" {
+				titleDef = directURL
+			}
+			title := strVal(m, "title", titleDef)
+			var imageURL, linkURL string
+			if asin != "" {
+				imageURL = fmt.Sprintf(imageURLTemplate, asin)
+				linkURL = fmt.Sprintf(linkURLTemplate, asin, url.QueryEscape(tag))
+			} else {
+				imageURL = ""
+				linkURL = directURL
+			}
 			entry := BookEntry{
 				ASIN:         asin,
 				Title:        title,
-				ImageURL:     fmt.Sprintf(imageURLTemplate, asin),
-				LinkURL:      fmt.Sprintf(linkURLTemplate, asin, url.QueryEscape(tag)),
+				ImageURL:     imageURL,
+				LinkURL:      linkURL,
 				ArticleSlug:  article.FrontMatter.Slug,
 				ArticleTitle: article.FrontMatter.Title,
 				ArticleURL:   article.URL,

--- a/internal/plugin/bookshelf/bookshelf_test.go
+++ b/internal/plugin/bookshelf/bookshelf_test.go
@@ -385,3 +385,57 @@ func TestBookshelf_CategoryGroups(t *testing.T) {
 		}
 	}
 }
+func TestBookshelf_NonAsinURL(t *testing.T) {
+	b := bookshelf.New()
+	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	site := &model.Site{
+		Config: model.Config{},
+		Articles: []*model.ProcessedArticle{
+			{
+				Article: model.Article{
+					FrontMatter: model.FrontMatter{
+						Title: "Booth Book",
+						Slug:  "booth-book",
+						Date:  date,
+						Extra: map[string]interface{}{
+							"books": []interface{}{
+								map[string]interface{}{
+									"title": "My Doujinshi",
+									"url":   "https://example.booth.pm/items/123",
+								},
+							},
+						},
+					},
+				},
+				URL: "/posts/booth-book/",
+			},
+		},
+	}
+	pages, err := b.VirtualPages(site, cfg(true, "tag"))
+	if err != nil {
+		t.Fatalf("VirtualPages: %v", err)
+	}
+	if len(pages) != 1 {
+		t.Fatalf("expected 1 page, got %d", len(pages))
+	}
+	books := pages[0].Data["books"].([]bookshelf.BookEntry)
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	bk := books[0]
+	if bk.Title != "My Doujinshi" {
+		t.Errorf("Title = %q, want My Doujinshi", bk.Title)
+	}
+	if bk.LinkURL != "https://example.booth.pm/items/123" {
+		t.Errorf("LinkURL = %q, want direct URL", bk.LinkURL)
+	}
+	if bk.ImageURL != "" {
+		t.Errorf("ImageURL should be empty for non-ASIN book, got %q", bk.ImageURL)
+	}
+	if bk.ASIN != "" {
+		t.Errorf("ASIN should be empty, got %q", bk.ASIN)
+	}
+	if !strings.Contains(bk.ArticleURL, "booth-book") {
+		t.Errorf("ArticleURL = %q, expected to contain article slug", bk.ArticleURL)
+	}
+}


### PR DESCRIPTION
## Problem

The bookshelf plugin required an `asin:` field and skipped any book entry without one. This prevented self-published books from booth.pm or techbookfest.org from appearing on the bookshelf page.

## Changes

### `internal/plugin/bookshelf/bookshelf.go`
- Accept `url:` as an alternative to `asin:` in the `books:` front-matter sequence
- When only `url:` is set: `LinkURL = url`, `ImageURL = ""`  (no Amazon cover)
- Skip an entry only when both `asin` and `url` are absent
- Updated package doc to document the `url:` field

### `internal/plugin/bookshelf/bookshelf_test.go`
- Add `TestBookshelf_NonAsinURL` verifying `LinkURL`, `ImageURL = ""`, `ASIN = ""`

## Front-matter usage

```yaml
books:
  - title: "OAuth・OIDCへの攻撃と対策を整理して理解できる本"
    url: "https://authya.booth.pm/items/1877818"
```

## Template note

The template should guard against empty `ImageURL` and show a fallback (handled in bmf-tech's `bookshelf.html`).