### PR TITLE
docs: update plugin-system with CategoryGroup, url: field, and SitePlugin JA section

### DIFF
--- a/docs/features/plugin-system.ja.md
+++ b/docs/features/plugin-system.ja.md
@@ -96,8 +96,117 @@ books:
 3. `internal/plugin/registry.go` の `DefaultRegistry()` に登録
 4. 本セクションにドキュメントを追記
 
+---
+
+## SitePlugin — サイト横断のページ生成
+
+`Plugin` が個別記事を対象とするのに対し、**`SitePlugin`** はサイト全体を対象として **VirtualPage**（Markdown ソースを持たないページ）を生成します。
+
+```
+cmd/gohan/build.go
+  └── plugin.DefaultRegistry().EnrichVirtual(site)  ← Enrich() の後に呼ばれる
+        └── 有効な各 SitePlugin に対して:
+              SitePlugin.VirtualPages(site, cfg) → site.VirtualPages に追加
+                                                   ↓
+                                    HTMLGenerator.buildJobs() がレンダリング
+```
+
+テンプレートでの参照パターン（ページ固有データは `.VirtualPageData` にあります）:
+```html
+{{range index .VirtualPageData "categories"}}
+  <h2>{{if .Name}}{{.Name}}{{else}}未分類{{end}}</h2>
+  {{range .Books}}
+    <a href="{{.LinkURL}}" target="_blank" rel="noopener">
+      {{if .ImageURL}}<img src="{{.ImageURL}}" alt="{{.Title}}">{{else}}{{.Title}}{{end}}
+    </a>
+  {{end}}
+{{end}}
+```
+
+### SitePlugin インターフェース
+
+`internal/plugin/plugin.go` で定義:
+
+```go
+type SitePlugin interface {
+    Name() string
+    Enabled(cfg map[string]interface{}) bool
+    VirtualPages(site *model.Site, cfg map[string]interface{}) ([]*model.VirtualPage, error)
+}
+```
+
+- **`Name()`** — `config.yaml` の `plugins.<name>` キーとなる一意識別子
+- **`Enabled()`** — プラグインの実行可否を制御
+- **`VirtualPages()`** — サイト全体を検査して 0 件以上の `VirtualPage` を返す
+
+### VirtualPage フィールド
+
+```
+VirtualPage.OutputPath  string   // 出力ディレクトリからの相対ファイルパス（例: "bookshelf/index.html"）
+VirtualPage.URL         string   // 正規 URL パス（例: "/bookshelf/"）
+VirtualPage.Template    string   // テーマのテンプレートファイル名（例: "bookshelf.html"）
+VirtualPage.Locale      string   // ロケールコード（例: "en" または "ja"）
+VirtualPage.Data        map[string]interface{}  // テンプレートで .VirtualPageData として参照
+```
+
+### ビルトイン SitePlugin
+
+#### bookshelf
+
+全記事の `books:` フロントマターを集約し、ロケールごとに本棚ページを 1 件生成します。
+
+**config.yaml:**
+```yaml
+plugins:
+  bookshelf:
+    enabled: true
+    tag: "your-associate-tag-22"   # Amazon アソシエイトトラッキングタグ
+```
+
+**記事フロントマター:**
+```yaml
+books:
+  - asin: "4873119464"          # Amazon ASIN — 書影 + Amazon リンクを生成
+    title: "入門 Go"
+  - url: "https://booth.pm/..."  # 非 Amazon: 直販 URL（書影なし）
+    title: "技術同人誌タイトル"
+```
+
+`url:` を `asin:` の代わりに指定した場合、`ImageURL` は空になり `LinkURL` はその URL になります。
+
+**生成 URL:**
+- デフォルトロケール (en): `/bookshelf/`
+- 非デフォルトロケール (ja): `/ja/bookshelf/`
+
+**テンプレートデータ構造** (`.VirtualPageData`):
+```
+.VirtualPageData["books"] → []BookEntry  # 日付降順（新しい順）
+  BookEntry.ASIN          string
+  BookEntry.Title         string
+  BookEntry.ImageURL      string   # images-na.ssl-images-amazon.com CDN。url: のみのエントリは空
+  BookEntry.LinkURL       string   # amazon.co.jp/dp/{ASIN}?tag={tag}、または直販 url: の値
+  BookEntry.ArticleSlug   string   # 書評記事のスラッグ
+  BookEntry.ArticleTitle  string   # 書評記事のタイトル
+  BookEntry.ArticleURL    string   # 書評記事の正規 URL
+  BookEntry.Categories    []string # 書評記事のカテゴリー
+  BookEntry.Date          time.Time
+
+.VirtualPageData["categories"] → []CategoryGroup  # カテゴリーでグループ化（アルファベット順）
+  CategoryGroup.Name      string       # カテゴリー名。空文字列 = 未分類（末尾に配置）
+  CategoryGroup.Books     []BookEntry
+```
+
+### 新しい SitePlugin の追加方法
+
+1. `internal/plugin/<name>/<name>.go` を作成し `plugin.SitePlugin` を実装
+2. コンパイル時インターフェースチェックを追加: `var _ plugin.SitePlugin = (*MyPlugin)(nil)`
+3. `internal/plugin/registry.go` の `DefaultRegistry()` の `sitePlugins` に登録
+4. `.VirtualPageData` を読み取るテーマテンプレートを作成
+5. 本セクションにドキュメントを追記
+
 ## スコープ
 
 - `plugin` パッケージによる動的ロードは意図的にスコープ外 — OS制約が多く、静的サイトジェネレーターには不要な複雑性をもたらすため
 - プラグインはHTMLを生成しない。データをテーマに提供するのみで、UIはテーマ側が完全制御する
 - プラグインから見た記事データは読み取り専用
+- VirtualPage は Atom フィードおよびインデックスの記事一覧には含まれない

--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -161,6 +161,17 @@ plugins:
     tag: "your-associate-tag-22"   # Amazon Associates tracking tag
 ```
 
+**Article front-matter:**
+```yaml
+books:
+  - asin: "4873119464"          # Amazon ASIN — generates cover image + Amazon link
+    title: "入門 Go"
+  - url: "https://booth.pm/..."  # non-Amazon: direct sales URL (no cover image)
+    title: "My Zine"
+```
+
+When `url:` is provided instead of `asin:`, `ImageURL` is empty and `LinkURL` is the direct URL.
+
 **Generated URLs:**
 - Default locale (en): `/bookshelf/`
 - Non-default locale (ja): `/ja/bookshelf/`
@@ -170,15 +181,32 @@ plugins:
 .VirtualPageData["books"] → []BookEntry
   BookEntry.ASIN          string
   BookEntry.Title         string
-  BookEntry.ImageURL      string   # images-na.ssl-images-amazon.com CDN
-  BookEntry.LinkURL       string   # amazon.co.jp/dp/{ASIN}?tag={tag}
+  BookEntry.ImageURL      string   # images-na.ssl-images-amazon.com CDN; empty for url:-only entries
+  BookEntry.LinkURL       string   # amazon.co.jp/dp/{ASIN}?tag={tag}, or the direct url: value
   BookEntry.ArticleSlug   string   # slug of the source article (book review)
   BookEntry.ArticleTitle  string   # title of the source article
   BookEntry.ArticleURL    string   # canonical URL of the source article
+  BookEntry.Categories    []string # categories of the source article
   BookEntry.Date          time.Time
+
+.VirtualPageData["categories"] → []CategoryGroup  # entries grouped by category
+  CategoryGroup.Name      string       # category name; empty string = uncategorised
+  CategoryGroup.Books     []BookEntry
 ```
 
-Entries are sorted by date descending (newest first).
+`books` is sorted by date descending (newest first). `categories` is sorted alphabetically by category name; uncategorised entries appear last.
+
+**Template example (category grouping):**
+```html
+{{range index .VirtualPageData "categories"}}
+  <h2>{{if .Name}}{{.Name}}{{else}}Uncategorised{{end}}</h2>
+  {{range .Books}}
+    <a href="{{.LinkURL}}" target="_blank" rel="noopener">
+      {{if .ImageURL}}<img src="{{.ImageURL}}" alt="{{.Title}}">{{else}}{{.Title}}{{end}}
+    </a>
+  {{end}}
+{{end}}
+```
 
 ### Adding a New SitePlugin
 


### PR DESCRIPTION
## Summary

Update `docs/features/plugin-system.md` (EN) and add the missing SitePlugin section to `docs/features/plugin-system.ja.md` (JA).

## Changes

### plugin-system.md (EN)

- Add `url:` front-matter field for non-Amazon books (booth.pm, techbookfest, etc.)
- Add `BookEntry.Categories []string` field (source article categories)
- Add `.VirtualPageData["categories"] → []CategoryGroup` to template data shape
- Add `CategoryGroup` struct (`Name string`, `Books []BookEntry`)
- Add template example for category-grouped rendering
- Clarify `ImageURL` is empty and `LinkURL` is the direct URL when `url:` is used

### plugin-system.ja.md (JA)

- Add the entire SitePlugin section (was completely missing)
- Includes: architecture diagram, SitePlugin interface, VirtualPage fields, bookshelf plugin (with `url:` field, `CategoryGroup`, updated template data shape), and "Adding a New SitePlugin" guide
- Scope section updated to mention VirtualPages are excluded from feeds and index listing

## Related versions

- `url:` field support: gohan v1.0.16
- Category grouping (`CategoryGroup`): gohan v1.0.14