### PR TITLE
ci: add auto-assign, labeler, and semantic PR title workflows

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,6 @@
+# Configuration for kentaro-m/auto-assign-action
+# Automatically assigns the PR author as the assignee.
+addAssignees: author
+
+# Reviewers are not auto-assigned for this repository.
+addReviewers: false

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,56 @@
+# Configuration for actions/labeler
+# Automatically applies labels to pull requests based on changed file paths.
+# Note: `dependencies` is intentionally omitted here because Dependabot attaches it directly.
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - "**/*.md"
+          - README*
+          - LICENSE
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+
+test:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*_test.go"
+          - internal/**/testdata/**
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/config/**
+          - codecov.yml
+          - Makefile
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - cmd/**
+
+parser:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/parser/**
+          - internal/processor/**
+
+generator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/generator/**
+          - internal/template/**
+
+server:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/server/**
+
+plugin:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/plugin/**

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,20 @@
+name: Auto Assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-assign:
+    name: Auto-assign PR author
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-assign author
+        uses: kentaro-m/auto-assign-action@v2.0.2
+        with:
+          configuration-path: .github/auto_assign.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,21 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Auto-label PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels based on changed files
+        uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,40 @@
+name: Semantic Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            must start with a lowercase character.


### PR DESCRIPTION
## Why

Port the three PR-hygiene workflows that have been working well in [bmf-san/gogocoin](https://github.com/bmf-san/gogocoin/tree/main/.github/workflows) so PRs in this repo get the same consistent treatment:

- PR author auto-assigned (no manual `assignees` step)
- Path-based labels applied automatically
- PR titles validated against Conventional Commits

## Changes

| File | Purpose |
|---|---|
| `.github/workflows/auto-assign.yml` + `.github/auto_assign.yml` | Auto-assign the PR author as assignee via `kentaro-m/auto-assign-action@v2.0.2`. No reviewer auto-pick. |
| `.github/workflows/labeler.yml` + `.github/labeler.yml` | Path-based labels via `actions/labeler@v6` with `sync-labels: true`. |
| `.github/workflows/semantic-pr.yml` | PR title must be Conventional Commits, subject lowercase (`amannn/action-semantic-pull-request@v6`). |

### Label set (tailored to gohan's layout)

| Label | Glob |
|---|---|
| `documentation` | `docs/**`, `**/*.md`, `README*`, `LICENSE` |
| `github_actions` | `.github/**` |
| `test` | `**/*_test.go`, `internal/**/testdata/**` |
| `config` | `internal/config/**`, `codecov.yml`, `Makefile` |
| `cli` | `cmd/**` |
| `parser` | `internal/parser/**`, `internal/processor/**` |
| `generator` | `internal/generator/**`, `internal/template/**` |
| `server` | `internal/server/**` |
| `plugin` | `internal/plugin/**` |

`dependencies` is intentionally **omitted** — Dependabot attaches it directly.

### Conventional Commits accepted types

`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. Scope optional.

## Security

All three workflows run on `pull_request_target` with the minimum required permissions (`contents: read` + targeted write where needed). No checkout of PR code is performed.

## After merge

Existing labels (if any) matching the names above will be re-used; new label names are created lazily on first application by `actions/labeler`.