### PR TITLE
fix(ci): bump go directive from 1.26.1 to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bmf-san/gohan
 
-go 1.26.1
+go 1.26.2
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
## Why

`govulncheck` on main is failing ([run 24619571651](https://github.com/bmf-san/gohan/actions/runs/24619571651)) because Go 1.26.1's standard library is affected by five advisories — all fixed in **1.26.2**:

| ID | Package | Issue |
|---|---|---|
| [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4947) | `crypto/x509` | Unexpected work during chain building (DoS) |
| [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946) | `crypto/x509` | Inefficient policy validation |
| [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870) | `crypto/tls` | TLS 1.3 KeyUpdate persistent retention / DoS |
| [GO-2026-4866](https://pkg.go.dev/vuln/GO-2026-4866) | `crypto/x509` | Case-sensitive `excludedSubtrees` auth bypass |
| [GO-2026-4865](https://pkg.go.dev/vuln/GO-2026-4865) | `html/template` | JsBraceDepth context-tracking XSS |

## Change

```diff
-go 1.26.1
+go 1.26.2
```

All CI jobs use `actions/setup-go@v6` with `go-version-file: go.mod`, so the new toolchain will be picked up automatically.

## Verification

Locally with `GOTOOLCHAIN=auto` (downloaded 1.26.2):

- `go mod tidy` → no diff beyond the `go` line
- `go build ./...` → OK
- `go test ./...` → all packages pass

`govulncheck` should report no stdlib findings on the next CI run.