### PR TITLE
chore: add .golangci.yml and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS for gohan
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/customizing-your-repository/about-code-owners
+
+* @bmf-san

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+  modules-download-mode: readonly
+
+linters:
+  enable:
+    - errcheck
+    - staticcheck
+    - govet
+    - ineffassign
+    - misspell
+    - gocritic
+    - unused
+  settings:
+    misspell:
+      locale: US
+    gocritic:
+      enabled-checks:
+        - nilValReturn
+  exclusions:
+    paths:
+      - ".*_mock\\.go"
+      - ".*\\.pb\\.go"
+      - "testdata/.*"
+    rules:
+      - path: "_test\\.go"
+        linters: [gocritic, errcheck]
+      - path: "_test\\.go"
+        linters: [staticcheck]
+        text: "^QF"
+      - text: 'Error return value of.*[.]Close.*is not checked'
+        linters: [errcheck]
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -133,7 +133,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 
 	// Pre-compute per-locale taxonomy bases so that article pages receive
 	// locale-filtered Tags, Categories, and ArchiveYears — matching the
-	// behaviour of listing pages (tag, category, archive, index).
+	// behavior of listing pages (tag, category, archive, index).
 	articleLocaleBases := map[string]*model.Site{}
 	if len(g.cfg.I18n.Locales) > 0 {
 		for _, loc := range g.cfg.I18n.Locales {
@@ -800,7 +800,7 @@ func localeTaxonomyBase(base *model.Site, articles []*model.ProcessedArticle) *m
 		cats[i].Description = catDesc[cats[i].Name]
 	}
 	// No fallback to base.Tags / base.Categories tags themselves: an empty slice
-	// is the correct value when the locale has no tagged/categorised articles.
+	// is the correct value when the locale has no tagged/categorized articles.
 	// Falling back to all-locale data would expose cross-locale entries in the sidebar.
 	return &model.Site{
 		Config:       base.Config,

--- a/internal/generator/ogp.go
+++ b/internal/generator/ogp.go
@@ -127,7 +127,7 @@ func (g *OGPGenerator) renderImage(outPath, slug string, w, h int, logo image.Im
 	return writeFileAtomic(outPath, buf.Bytes(), 0o644)
 }
 
-// drawGradientBackground fills img with a diagonal two-colour gradient whose
+// drawGradientBackground fills img with a diagonal two-color gradient whose
 // hues are derived deterministically from the article slug hash.
 func drawGradientBackground(img *image.RGBA, seed uint64, w, h int) {
 	h1 := float64(seed % 360)

--- a/internal/processor/site.go
+++ b/internal/processor/site.go
@@ -206,7 +206,7 @@ func computeOutputPath(a *model.Article, cfg model.Config) string {
 	dir := filepath.Dir(rel)
 	base := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
 	if a.FrontMatter.Slug != "" {
-		// Sanitise slug against path traversal — take only the last path
+		// Sanitize slug against path traversal — take only the last path
 		// component so that "../../etc/passwd" reduces to "passwd".
 		// Also reject "." and ".." (degenerate), and the path separator itself
 		// (filepath.Base("///") returns "/" on Unix which would collapse the

--- a/internal/template/template_engine.go
+++ b/internal/template/template_engine.go
@@ -144,7 +144,7 @@ func builtinFuncs(defaultLocale string) template.FuncMap {
 
 // toSlug converts a display name to a URL-friendly slug by lowercasing ASCII
 // letters and replacing spaces with hyphens. Non-ASCII characters (e.g.
-// Japanese, accented Latin) are kept intact, matching the behaviour of
+// Japanese, accented Latin) are kept intact, matching the behavior of
 // tagNorm in the generator so template links are consistent with page paths.
 // Returns "untitled" when the input produces an empty result.
 func toSlug(s string) string {


### PR DESCRIPTION
## Summary

Add explicit linter configuration and code ownership mapping.

## Changes

- **`.golangci.yml`**: v2 config enabling `errcheck`, `staticcheck`, `govet`, `ineffassign`, `misspell` (US locale), `gocritic` (`nilValReturn`), and `unused`. Mirrors gogocoin's style but omits `hugeParam` / `rangeValCopy` from gocritic (would require signature changes across many generators; can be revisited later).
- **`.github/CODEOWNERS`**: maps all paths to `@bmf-san` for automatic review requests.
- **Misspell fixes in existing comments**: `behaviour` → `behavior` (2), `categorised` → `categorized`, `colour` → `color`, `Sanitise` → `Sanitize`. Comment-only, no behavioral change.

## Verification

- `golangci-lint run ./...` → clean (0 issues)
- `go test ./...` → all packages pass

## Related

Part of the quality-improvement sprint proposed for gohan.