### PR TITLE
ci: centralize coverage threshold into Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,7 @@ jobs:
 
       - name: Check coverage threshold
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
-          echo "Total coverage: ${COVERAGE}%"
-          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
-            echo "Coverage ${COVERAGE}% is below the required 80%"
-            exit 1
-          fi
+        run: make coverage-check
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ BIN      = gohan
 CMD      = ./cmd/gohan
 COVERAGE = coverage.out
 
-.PHONY: all build test lint serve clean install coverage tidy vuln tools help
+# ─── Coverage threshold ──────────────────────────────────────────────────────
+# Keep COVERAGE_THRESHOLD in sync with codecov.yml (coverage.status.project.default.target).
+COVERAGE_THRESHOLD ?= 80
+
+.PHONY: all build test lint serve clean install coverage coverage-check tidy vuln tools help
 
 ## all: build the binary (default target)
 all: build
@@ -35,6 +39,12 @@ test:
 ## coverage: print coverage summary (run 'make test' first)
 coverage:
 	@go tool cover -func=$(COVERAGE) | grep total
+
+## coverage-check: fail if total coverage is below COVERAGE_THRESHOLD (default 80)
+coverage-check:
+	@COV=$$(go tool cover -func=$(COVERAGE) | grep total | awk '{print $$3}' | tr -d '%'); \
+	echo "Total coverage: $${COV}%"; \
+	awk -v cov="$${COV}" -v th="$(COVERAGE_THRESHOLD)" 'BEGIN { if (cov+0 < th+0) { printf "Coverage %s%% is below the required %s%%\n", cov, th; exit 1 } }'
 
 ## tools: install development tools (golangci-lint, govulncheck)
 tools:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+# Keep `target` values in sync with Makefile COVERAGE_THRESHOLD.
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary

Centralize the coverage threshold so it is no longer duplicated between the CI workflow and `codecov.yml`.

## Changes

- `Makefile`: introduce `COVERAGE_THRESHOLD ?= 80` and a new `coverage-check` target that uses `awk` for the comparison (drops the `bc` dependency previously required in the workflow).
- `.github/workflows/ci.yml`: replace the inline bash block with `make coverage-check`.
- `codecov.yml`: add a comment noting that `target` values must be kept in sync with the Makefile variable.

## Verification

- `make test && make coverage-check` locally prints `Total coverage: 86.0%` and exits 0.
- Passing `COVERAGE_THRESHOLD=99 make coverage-check` correctly fails.

## Related

Part of the quality-improvement sprint.