### PR TITLE
feat(template): add contains template function

### DIFF
--- a/internal/template/template_engine.go
+++ b/internal/template/template_engine.go
@@ -139,6 +139,10 @@ func builtinFuncs(defaultLocale string) template.FuncMap {
 			}
 			return fmt.Sprintf("%s/page/%d/", baseURL, p)
 		},
+		// contains reports whether substr is within s. Mirrors strings.Contains;
+		// useful for conditional logic in templates where the standard
+		// html/template builtins lack string-inspection helpers.
+		"contains": strings.Contains,
 	}
 }
 


### PR DESCRIPTION
## Summary

Expose `strings.Contains` as a `contains` template function. `html/template` lacks string-inspection helpers out of the box, and taxonomy-aware templates benefit from cheap substring checks (e.g. detecting percent-encoded paths to decide whether a cross-locale taxonomy URL would exist).

## Usage

```
{{if contains .CurrentTaxonomy.URL "%"}}locale-specific{{else}}shared{{end}}
```

## Test

Existing `internal/template` tests pass.
