### PR TITLE
feat(taxonomy): cross-locale translation via translation_key

### DIFF
--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -106,6 +106,15 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 	var jobs []writeJob
 	perPage := g.cfg.Build.PerPage
 
+	// Build cross-locale taxonomy translation URL maps keyed by TranslationKey.
+	// translations[translationKey][locale] = locale-aware URL with trailing slash.
+	// Tags and categories live in disjoint namespaces so are tracked separately.
+	// A taxonomy is registered only for locales that actually have articles using
+	// its Name; translation_key entries without article coverage in a locale do
+	// not appear (matches page-generation behaviour).
+	tagTranslations := buildTaxonomyTranslations(site, g.cfg, site.Tags, "tags", func(a *model.ProcessedArticle) []string { return a.FrontMatter.Tags })
+	categoryTranslations := buildTaxonomyTranslations(site, g.cfg, site.Categories, "categories", func(a *model.ProcessedArticle) []string { return a.FrontMatter.Categories })
+
 	// Index pages (paginated) — one set per locale when i18n is active.
 	if len(g.cfg.I18n.Locales) > 0 {
 		for _, loc := range g.cfg.I18n.Locales {
@@ -205,6 +214,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 					basePath = filepath.Join(locale, "tags", tagNorm(t.Name))
 					baseURLPath = "/" + locale + "/tags/" + tagNorm(t.Name)
 				}
+				t.Translations = taxonomyTranslationsFor(tagTranslations, t.TranslationKey, locale)
 				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, locale, &t)...)
 			}
 		}
@@ -225,6 +235,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 			sortByDateDesc(filtered)
 			basePath := filepath.Join("tags", tagNorm(t.Name))
 			baseURLPath := "/tags/" + tagNorm(t.Name)
+			t.Translations = taxonomyTranslationsFor(tagTranslations, t.TranslationKey, "")
 			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, "", &t)...)
 		}
 	}
@@ -258,6 +269,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 					basePath = filepath.Join(locale, "categories", tagNorm(c.Name))
 					baseURLPath = "/" + locale + "/categories/" + tagNorm(c.Name)
 				}
+				c.Translations = taxonomyTranslationsFor(categoryTranslations, c.TranslationKey, locale)
 				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, locale, &c)...)
 			}
 		}
@@ -278,6 +290,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 			sortByDateDesc(filtered)
 			basePath := filepath.Join("categories", tagNorm(c.Name))
 			baseURLPath := "/categories/" + tagNorm(c.Name)
+			c.Translations = taxonomyTranslationsFor(categoryTranslations, c.TranslationKey, "")
 			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, "", &c)...)
 		}
 	}
@@ -745,6 +758,89 @@ func tagNorm(s string) string {
 		}
 	}
 	return b.String()
+}
+
+// buildTaxonomyTranslations groups taxonomies by TranslationKey and returns
+// a map translationKey → locale → URL so templates can jump between matching
+// taxonomies across locales. urlSegment is the URL path segment after the
+// locale prefix (e.g. "tags" or "categories"). articleTaxonomies extracts
+// the relevant slice (tags or categories) from an article's frontmatter.
+//
+// A (taxonomy, locale) pair is included only when at least one article in
+// that locale references the taxonomy by Name; taxonomies with article
+// coverage in no locale are omitted entirely. This mirrors the page-emission
+// logic so no broken URLs are ever produced.
+func buildTaxonomyTranslations(
+	site *model.Site,
+	cfg model.Config,
+	taxonomies []model.Taxonomy,
+	urlSegment string,
+	articleTaxonomies func(*model.ProcessedArticle) []string,
+) map[string]map[string]string {
+	if len(cfg.I18n.Locales) == 0 {
+		return nil
+	}
+	out := map[string]map[string]string{}
+	for _, tax := range taxonomies {
+		if tax.TranslationKey == "" {
+			continue
+		}
+		for _, locale := range cfg.I18n.Locales {
+			hasArticle := false
+			for _, a := range site.Articles {
+				if a.Locale != locale {
+					continue
+				}
+				for _, t := range articleTaxonomies(a) {
+					if t == tax.Name {
+						hasArticle = true
+						break
+					}
+				}
+				if hasArticle {
+					break
+				}
+			}
+			if !hasArticle {
+				continue
+			}
+			var url string
+			if locale == cfg.I18n.DefaultLocale {
+				url = "/" + urlSegment + "/" + tagNorm(tax.Name) + "/"
+			} else {
+				url = "/" + locale + "/" + urlSegment + "/" + tagNorm(tax.Name) + "/"
+			}
+			if out[tax.TranslationKey] == nil {
+				out[tax.TranslationKey] = map[string]string{}
+			}
+			out[tax.TranslationKey][locale] = url
+		}
+	}
+	return out
+}
+
+// taxonomyTranslationsFor returns the map of locale → URL for other locales
+// (excluding currentLocale) matching the given translation key. Returns nil
+// when the key is empty, unknown, or has no non-current-locale entries.
+func taxonomyTranslationsFor(all map[string]map[string]string, key, currentLocale string) map[string]string {
+	if key == "" || len(all) == 0 {
+		return nil
+	}
+	src, ok := all[key]
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	for loc, url := range src {
+		if loc == currentLocale {
+			continue
+		}
+		out[loc] = url
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // siteFor creates a site copy with a custom article list.

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -357,6 +357,72 @@ func TestPaginatedJobs_TaxonomyURL(t *testing.T) {
 	}
 }
 
+func TestBuildTaxonomyTranslations(t *testing.T) {
+	cfg := model.Config{
+		I18n: model.I18nConfig{Locales: []string{"en", "ja"}, DefaultLocale: "en"},
+	}
+	site := &model.Site{
+		Config: cfg,
+		Articles: []*model.ProcessedArticle{
+			{Locale: "en", Article: model.Article{FrontMatter: model.FrontMatter{Tags: []string{"Go"}, Categories: []string{"Application"}}}},
+			{Locale: "ja", Article: model.Article{FrontMatter: model.FrontMatter{Tags: []string{"Go"}, Categories: []string{"アプリケーション"}}}},
+			{Locale: "en", Article: model.Article{FrontMatter: model.FrontMatter{Tags: []string{"EN-only"}}}},
+		},
+	}
+	tags := []model.Taxonomy{
+		{Name: "Go", TranslationKey: "go"},
+		{Name: "EN-only", TranslationKey: ""}, // no key
+	}
+	cats := []model.Taxonomy{
+		{Name: "Application", TranslationKey: "app"},
+		{Name: "アプリケーション", TranslationKey: "app"},
+	}
+
+	tagTrans := buildTaxonomyTranslations(site, cfg, tags, "tags", func(a *model.ProcessedArticle) []string { return a.FrontMatter.Tags })
+	if got := tagTrans["go"]["en"]; got != "/tags/go/" {
+		t.Errorf("tag go en URL = %q, want /tags/go/", got)
+	}
+	if got := tagTrans["go"]["ja"]; got != "/ja/tags/go/" {
+		t.Errorf("tag go ja URL = %q, want /ja/tags/go/", got)
+	}
+	if _, ok := tagTrans[""]; ok {
+		t.Error("empty translation_key must not appear in map")
+	}
+
+	catTrans := buildTaxonomyTranslations(site, cfg, cats, "categories", func(a *model.ProcessedArticle) []string { return a.FrontMatter.Categories })
+	if got := catTrans["app"]["en"]; got != "/categories/application/" {
+		t.Errorf("cat app en URL = %q", got)
+	}
+	if got := catTrans["app"]["ja"]; got != "/ja/categories/アプリケーション/" {
+		t.Errorf("cat app ja URL = %q", got)
+	}
+}
+
+func TestTaxonomyTranslationsFor(t *testing.T) {
+	all := map[string]map[string]string{
+		"go":  {"en": "/tags/go/", "ja": "/ja/tags/go/"},
+		"app": {"en": "/categories/application/", "ja": "/ja/categories/アプリケーション/"},
+	}
+	// excludes current locale
+	got := taxonomyTranslationsFor(all, "go", "en")
+	if len(got) != 1 || got["ja"] != "/ja/tags/go/" {
+		t.Errorf("taxonomyTranslationsFor(go, en) = %v", got)
+	}
+	// empty key
+	if got := taxonomyTranslationsFor(all, "", "en"); got != nil {
+		t.Errorf("empty key should return nil, got %v", got)
+	}
+	// unknown key
+	if got := taxonomyTranslationsFor(all, "unknown", "en"); got != nil {
+		t.Errorf("unknown key should return nil, got %v", got)
+	}
+	// only current-locale entry → nil
+	only := map[string]map[string]string{"x": {"en": "/x/"}}
+	if got := taxonomyTranslationsFor(only, "x", "en"); got != nil {
+		t.Errorf("only-current-locale should return nil, got %v", got)
+	}
+}
+
 func TestGenerate_ArchiveCurrentArchivePath(t *testing.T) {
 	outDir := t.TempDir()
 	cfg := model.Config{

--- a/internal/model/taxonomy.go
+++ b/internal/model/taxonomy.go
@@ -4,7 +4,16 @@ package model
 type Taxonomy struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
-	URL         string `yaml:"-"` // set at render time; locale-aware canonical URL
+	// TranslationKey links taxonomies that represent the same concept across
+	// locales (e.g. EN "Application" and JA "アプリケーション" both set
+	// translation_key: application). Empty means "no cross-locale binding".
+	TranslationKey string `yaml:"translation_key"`
+	URL            string `yaml:"-"` // set at render time; locale-aware canonical URL
+	// Translations maps locale → URL for every other locale's taxonomy that
+	// shares the same TranslationKey. Populated at render time on
+	// CurrentTaxonomy; nil elsewhere. Template access:
+	//   {{index .CurrentTaxonomy.Translations "en"}}
+	Translations map[string]string `yaml:"-"`
 }
 
 // TaxonomyRegistry holds the master lists loaded from taxonomy YAML files.


### PR DESCRIPTION
## Summary

Add cross-locale taxonomy translation. When taxonomies in different locales share the same `translation_key` in their YAML, the generator exposes `{{ .CurrentTaxonomy.Translations }}` as a `map[locale]URL` in templates so authors can render proper locale-switcher links on taxonomy pages (tags/categories).

This closes the last structural gap for i18n taxonomies: previously the locale switcher on e.g. `/categories/application/` could not find the JA counterpart `/ja/categories/アプリケーション/` because the URL slugs differ.

## Changes

- `model/taxonomy.go`
  - `TranslationKey string \`yaml:"translation_key"\`` — authored in `content/{locale}/{tags,categories}.yaml`.
  - `Translations map[string]string \`yaml:"-"\`` — populated at render time; available in templates as `.CurrentTaxonomy.Translations`.
- `generator/html.go`
  - New `buildTaxonomyTranslations` helper builds `translationKey → locale → URL` maps for tags and categories. Only (taxonomy, locale) pairs with at least one article of that locale referencing the taxonomy by name are registered — mirroring existing page-emission logic so no broken URLs are ever produced.
  - New `taxonomyTranslationsFor` helper returns per-taxonomy view with current locale excluded.
  - Populates `CurrentTaxonomy.Translations` at all four `paginatedJobs` call sites (tags/categories × i18n on/off).
- Unit tests: `TestBuildTaxonomyTranslations`, `TestTaxonomyTranslationsFor`.

## Template usage

```go-html-template
{{ with .CurrentTaxonomy }}
  {{ range $loc, $url := .Translations }}
    <a href="{{ $url }}">{{ $loc }}</a>
  {{ end }}
{{ end }}
```

## Test

- `go test ./...` — all packages pass.