### PR TITLE
feat(taxonomy): fall back to Name as implicit translation key

### DIFF
--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -214,7 +214,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 					basePath = filepath.Join(locale, "tags", tagNorm(t.Name))
 					baseURLPath = "/" + locale + "/tags/" + tagNorm(t.Name)
 				}
-				t.Translations = taxonomyTranslationsFor(tagTranslations, t.TranslationKey, locale)
+				t.Translations = taxonomyTranslationsFor(tagTranslations, taxonomyTranslationKey(t), locale)
 				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, locale, &t)...)
 			}
 		}
@@ -235,7 +235,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 			sortByDateDesc(filtered)
 			basePath := filepath.Join("tags", tagNorm(t.Name))
 			baseURLPath := "/tags/" + tagNorm(t.Name)
-			t.Translations = taxonomyTranslationsFor(tagTranslations, t.TranslationKey, "")
+			t.Translations = taxonomyTranslationsFor(tagTranslations, taxonomyTranslationKey(t), "")
 			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "tag.html", basePath, baseURLPath, perPage, "", &t)...)
 		}
 	}
@@ -269,7 +269,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 					basePath = filepath.Join(locale, "categories", tagNorm(c.Name))
 					baseURLPath = "/" + locale + "/categories/" + tagNorm(c.Name)
 				}
-				c.Translations = taxonomyTranslationsFor(categoryTranslations, c.TranslationKey, locale)
+				c.Translations = taxonomyTranslationsFor(categoryTranslations, taxonomyTranslationKey(c), locale)
 				jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, locale, &c)...)
 			}
 		}
@@ -290,7 +290,7 @@ func (g *HTMLGenerator) buildJobs(site *model.Site) []writeJob {
 			sortByDateDesc(filtered)
 			basePath := filepath.Join("categories", tagNorm(c.Name))
 			baseURLPath := "/categories/" + tagNorm(c.Name)
-			c.Translations = taxonomyTranslationsFor(categoryTranslations, c.TranslationKey, "")
+			c.Translations = taxonomyTranslationsFor(categoryTranslations, taxonomyTranslationKey(c), "")
 			jobs = append(jobs, paginatedJobs(site, filtered, g.outDir, "category.html", basePath, baseURLPath, perPage, "", &c)...)
 		}
 	}
@@ -770,6 +770,13 @@ func tagNorm(s string) string {
 // that locale references the taxonomy by Name; taxonomies with article
 // coverage in no locale are omitted entirely. This mirrors the page-emission
 // logic so no broken URLs are ever produced.
+//
+// When a taxonomy has no explicit TranslationKey, its Name is used as an
+// implicit key. This auto-links taxonomies that share a Name across locales
+// (common for ASCII tag names like "Golang") without requiring per-entry
+// YAML edits. Taxonomies with different Names across locales (e.g. EN
+// "Application" ↔ JA "アプリケーション") still require an explicit
+// translation_key on both entries.
 func buildTaxonomyTranslations(
 	site *model.Site,
 	cfg model.Config,
@@ -782,7 +789,8 @@ func buildTaxonomyTranslations(
 	}
 	out := map[string]map[string]string{}
 	for _, tax := range taxonomies {
-		if tax.TranslationKey == "" {
+		key := taxonomyTranslationKey(tax)
+		if key == "" {
 			continue
 		}
 		for _, locale := range cfg.I18n.Locales {
@@ -810,13 +818,22 @@ func buildTaxonomyTranslations(
 			} else {
 				url = "/" + locale + "/" + urlSegment + "/" + tagNorm(tax.Name) + "/"
 			}
-			if out[tax.TranslationKey] == nil {
-				out[tax.TranslationKey] = map[string]string{}
+			if out[key] == nil {
+				out[key] = map[string]string{}
 			}
-			out[tax.TranslationKey][locale] = url
+			out[key][locale] = url
 		}
 	}
 	return out
+}
+
+// taxonomyTranslationKey returns the effective translation key for a
+// taxonomy: its explicit TranslationKey if set, otherwise its Name.
+func taxonomyTranslationKey(tax model.Taxonomy) string {
+	if tax.TranslationKey != "" {
+		return tax.TranslationKey
+	}
+	return tax.Name
 }
 
 // taxonomyTranslationsFor returns the map of locale → URL for other locales

--- a/internal/generator/html_test.go
+++ b/internal/generator/html_test.go
@@ -371,7 +371,7 @@ func TestBuildTaxonomyTranslations(t *testing.T) {
 	}
 	tags := []model.Taxonomy{
 		{Name: "Go", TranslationKey: "go"},
-		{Name: "EN-only", TranslationKey: ""}, // no key
+		{Name: "EN-only", TranslationKey: ""}, // no key, EN-only → no pair emitted
 	}
 	cats := []model.Taxonomy{
 		{Name: "Application", TranslationKey: "app"},
@@ -385,8 +385,12 @@ func TestBuildTaxonomyTranslations(t *testing.T) {
 	if got := tagTrans["go"]["ja"]; got != "/ja/tags/go/" {
 		t.Errorf("tag go ja URL = %q, want /ja/tags/go/", got)
 	}
-	if _, ok := tagTrans[""]; ok {
-		t.Error("empty translation_key must not appear in map")
+	// EN-only taxonomy with implicit Name-as-key: single-locale entry registered.
+	if got := tagTrans["EN-only"]["en"]; got != "/tags/en-only/" {
+		t.Errorf("implicit-key EN-only en URL = %q", got)
+	}
+	if _, ok := tagTrans["EN-only"]["ja"]; ok {
+		t.Error("EN-only must not have ja entry (no article coverage in ja)")
 	}
 
 	catTrans := buildTaxonomyTranslations(site, cfg, cats, "categories", func(a *model.ProcessedArticle) []string { return a.FrontMatter.Categories })
@@ -420,6 +424,18 @@ func TestTaxonomyTranslationsFor(t *testing.T) {
 	only := map[string]map[string]string{"x": {"en": "/x/"}}
 	if got := taxonomyTranslationsFor(only, "x", "en"); got != nil {
 		t.Errorf("only-current-locale should return nil, got %v", got)
+	}
+}
+
+func TestTaxonomyTranslationKey(t *testing.T) {
+	if got := taxonomyTranslationKey(model.Taxonomy{Name: "Go", TranslationKey: "go"}); got != "go" {
+		t.Errorf("explicit key = %q, want go", got)
+	}
+	if got := taxonomyTranslationKey(model.Taxonomy{Name: "Golang"}); got != "Golang" {
+		t.Errorf("implicit name fallback = %q, want Golang", got)
+	}
+	if got := taxonomyTranslationKey(model.Taxonomy{}); got != "" {
+		t.Errorf("empty taxonomy = %q, want \"\"", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #132. When a `Taxonomy` has no explicit `TranslationKey`, use its `Name` as an implicit key. This auto-links taxonomies that share a `Name` across locales (common for ASCII tag names like `Golang`) without requiring per-entry YAML edits.

Taxonomies with different `Name`s across locales (e.g. EN `Application` vs JA `アプリケーション`) still require an explicit `translation_key` on both entries.

## Why

In sites with many shared-name tags, requiring `translation_key` on every tag pair is tedious. Since the registry merge step already dedupes by `Name`, same-named taxonomies across locales naturally represent the same concept — so using `Name` as the implicit key is correct by construction.

## Changes

- `generator/html.go`:
  - New `taxonomyTranslationKey(tax)` helper returns explicit `TranslationKey` or falls back to `Name`.
  - `buildTaxonomyTranslations` now uses the effective key so taxonomies without `translation_key` are still registered.
  - All 4 `paginatedJobs` call sites pass `taxonomyTranslationKey(t)` to `taxonomyTranslationsFor`.
- Unit tests: `TestTaxonomyTranslationKey`, and extended `TestBuildTaxonomyTranslations` to assert implicit-name behavior.

## Test

- `go test ./...` — all packages pass.