### PR TITLE
ci: skip Codecov upload on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,10 @@ jobs:
         run: make coverage-check
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        # Dependabot PRs don't receive repository secrets, so CODECOV_TOKEN
+        # is empty and Codecov rejects the upload ("Token required because
+        # branch is protected"). Skip the upload for those PRs.
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Context

All open Dependabot PRs in this repository fail CI on the **Test (ubuntu-latest)** job because of the Codecov upload step:

```
error - Upload queued for processing failed:
{"message":"Token required because branch is protected"}
==> Failed to run upload-coverage
##[error]Process completed with exit code 1.
```

For PRs created by `dependabot[bot]`, GitHub Actions intentionally withholds repository secrets (security boundary). `CODECOV_TOKEN` is therefore empty, Codecov rejects the upload, and `fail_ci_if_error: true` brings the whole CI red — which blocks Dependabot auto-merge.

## Change

Add `github.actor != 'dependabot[bot]'` to the existing `if` on the Codecov step so the upload is simply skipped on Dependabot PRs. Coverage continues to be uploaded normally for human PRs and pushes to `main`.

## Verification

YAML edit only; no test changes. CI on this PR is run with a regular actor and will exercise the unmodified path.