### PR TITLE
chore: bump go to 1.26.3 to fix stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bmf-san/gohan
 
-go 1.26.2
+go 1.26.3
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
## Why

`Vulnerability Check` (govulncheck) is failing on every Dependabot PR after Go's 2026-05-07 security release:

- [GO-2026-4982](https://pkg.go.dev/vuln/GO-2026-4982) (CVE-2026-39823) — `html/template` `<meta>` content attr XSS
- [GO-2026-4980](https://pkg.go.dev/vuln/GO-2026-4980) (CVE-2026-39826) — `html/template` `<script type="">` escaping
- [GO-2026-4971](https://pkg.go.dev/vuln/GO-2026-4971) (CVE-2026-39836) — `net.Dial`/`LookupPort` NUL panic (Windows)

All fixed in go1.26.3.

## What

Bump `go.mod`'s `go` directive from `1.26.2` → `1.26.3`. The CI workflows use `go-version-file: go.mod`, so this transparently pulls go1.26.3 on every runner.

## Verify

```
$ GOTOOLCHAIN=go1.26.3+auto go test ./...
ok  (all packages pass)
```

## Impact

Unblocks all 4 open Dependabot PRs (#136, #137, #139, #140).