### PR TITLE
ci: attach pre-compiled binaries to GitHub releases

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,23 +1,32 @@
-name: Release
+name: GoReleaser
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to build and release (e.g. v1.1.9)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build and release (e.g. v1.1.9). Used to backfill assets for past releases."
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
-  release:
-    name: Release
+  goreleaser:
+    name: Run GoReleaser
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -33,3 +42,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,23 @@ jobs:
   release-please:
     name: Run release-please
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: release-please
+        id: release
         uses: googleapis/release-please-action@v5
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  goreleaser:
+    name: Build release binaries
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/goreleaser.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    permissions:
+      contents: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,3 +70,7 @@ release:
   draft: false
   prerelease: auto
   name_template: "v{{ .Version }}"
+  # Append assets to existing releases so manual backfill runs (workflow_dispatch
+  # on goreleaser.yml) can upload binaries for past tags without recreating the
+  # release entry created by release-please.
+  mode: append


### PR DESCRIPTION
Closes #145

## Problem
v1.1.9 release page shipped without pre-compiled binaries, breaking downstream packagers (e.g. AUR `gohan-bin`).

## Root cause
`release-please` creates tags using the default `GITHUB_TOKEN`. By GitHub Actions design, events triggered by `GITHUB_TOKEN` do **not** trigger other workflows. The previous `release.yml`, which ran GoReleaser on `push: tags`, therefore never fired for releases created by `release-please`.

## Changes
- Move GoReleaser into a reusable workflow `.github/workflows/goreleaser.yml` supporting:
  - `workflow_call` — invoked by `release-please.yml` after a release is created
  - `workflow_dispatch` — manual backfill for past tags (input: `tag`)
- `release-please.yml` now calls the reusable workflow gated on the `release_created` output, so binaries are produced automatically on every new release.
- Delete the old `release.yml` (was never triggered in practice).
- Add `release.mode: append` in `.goreleaser.yaml` so backfill runs upload assets to the existing release entry instead of failing on conflict.

## Backfilling v1.1.9 and older
After merge, run the **GoReleaser** workflow from the Actions tab via *Run workflow*, supplying the tag (e.g. `v1.1.9`). Assets will be appended to the existing release.

## Verification
- `goreleaser check` passes locally on `.goreleaser.yaml`.
