### PR TITLE
feat(docs): publish docs site via gohan + sleyt on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build gohan binary
+        run: go build -o /usr/local/bin/gohan ./cmd/gohan
+
+      - name: Install sleyt
+        working-directory: docs
+        run: npm install
+
+      - name: Build docs site
+        working-directory: docs
+        run: npm run build
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,5 @@
+public/
+node_modules/
+assets/css/
+package-lock.json
+.gohan/

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,0 +1,33 @@
+site:
+  title: "gohan"
+  description: "A simple, fast static site generator written in Go."
+  base_url: "https://bmf-san.github.io/gohan"
+  language: "en"
+  github_repo: "https://github.com/bmf-san/gohan"
+  github_branch: "main"
+
+build:
+  content_dir: "content"
+  output_dir: "public"
+  assets_dir: "assets"
+  static_dir: "static"
+  parallelism: 4
+
+theme:
+  name: "sleyt"
+  dir: "themes/sleyt"
+  params:
+    # GitHub Pages serves the site at https://bmf-san.github.io/gohan/.
+    # All in-template links MUST be prefixed with this base_path; when the
+    # site is published at a custom domain (root), set this to an empty string.
+    base_path: "/gohan"
+    sleyt_css: "/gohan/assets/css/sleyt.css"
+    github_url: "https://github.com/bmf-san/gohan"
+
+syntax_highlight:
+  theme: "github"
+  line_numbers: false
+
+i18n:
+  locales: [en, ja]
+  default_locale: en

--- a/docs/content/en/features/i18n.md
+++ b/docs/content/en/features/i18n.md
@@ -1,0 +1,275 @@
+---
+title: "i18n"
+description: "Build multi-language sites with directory-based locales."
+slug: "i18n"
+categories:
+  - features
+translation_key: "i18n"
+---
+
+## Overview
+
+gohan supports multi-language sites through a directory-based locale structure. Each locale's content lives under a named sub-directory of the content directory (e.g. `content/en/`, `content/ja/`). The default locale is served at the root URL; other locales receive a URL prefix.
+
+This feature is entirely backward-compatible — existing single-language sites require no changes.
+
+## Configuration
+
+Add an `i18n` block to `config.yaml`:
+
+```yaml
+site:
+  language: en          # used as the default_locale fallback
+
+i18n:
+  locales: [en, ja]     # ordered list of locale codes
+  default_locale: en    # served at root URL without prefix; defaults to site.language
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `locales` | `[]string` | `[]` (disabled) | Locale codes present under the content directory |
+| `default_locale` | string | `site.language` | Locale served without a URL prefix |
+
+When `locales` is empty, i18n is disabled and gohan behaves exactly as a single-language site.
+
+## Content Structure
+
+```
+content/
+  en/
+    posts/
+      hello-world.md    → /posts/hello-world/
+  ja/
+    posts/
+      hello-world.md    → /ja/posts/hello-world/
+```
+
+Only the first path segment after `content/` is treated as a locale code; it must match one of the values in `i18n.locales`.
+
+## Translation Linking
+
+To connect articles that are translations of each other, add `translation_key` in the front matter. The value must be identical across all variants.
+
+```yaml
+---
+title: Hello World
+translation_key: hello-world
+---
+```
+
+After `BuildTranslationMap` runs (automatically during `gohan build`), each `ProcessedArticle.Translations` slice contains `LocaleRef` entries for every sibling locale. Templates can use these to render a language switcher.
+
+## Data Model
+
+### New types
+
+```go
+// I18nConfig holds multi-language content configuration.
+type I18nConfig struct {
+    Locales       []string `yaml:"locales"`
+    DefaultLocale string   `yaml:"default_locale"`
+}
+
+// LocaleRef holds a locale code and the canonical URL for a translated article.
+type LocaleRef struct {
+    Locale string
+    URL    string
+}
+```
+
+### Extended types
+
+```go
+// FrontMatter — new field
+TranslationKey string `yaml:"translation_key"`
+
+// ProcessedArticle — new fields
+Locale       string       // detected from content path, e.g. "en" or "ja"
+URL          string       // canonical URL path, e.g. "/posts/hello/" or "/ja/posts/hello/"
+Translations []LocaleRef  // populated by BuildTranslationMap
+
+// Config — new field
+I18n I18nConfig `yaml:"i18n"`
+```
+
+## URL Scheme
+
+| Content file | Locale | Output | URL |
+|---|---|---|---|
+| `content/en/posts/hello.md` | `en` (default) | `public/posts/hello/index.html` | `/posts/hello/` |
+| `content/ja/posts/hello.md` | `ja` | `public/ja/posts/hello/index.html` | `/ja/posts/hello/` |
+
+Index pages follow the same rule:
+
+| Locale | Output | URL |
+|---|---|---|
+| `en` (default) | `public/index.html` | `/` |
+| `ja` | `public/ja/index.html` | `/ja/` |
+
+## Template Usage
+
+### Language switcher
+
+For article pages, use `.Article.Translations` to link to the translated version:
+
+```html
+{{if .Article.Translations}}
+<nav aria-label="Language">
+  <a href="{{.Article.URL}}">{{.Config.Site.Language}}</a>
+  {{range .Article.Translations}}
+  <a href="{{.URL}}">{{.Locale}}</a>
+  {{end}}
+</nav>
+{{end}}
+```
+
+### Language switcher on listing pages
+
+Tag and category listing pages do not have `.Article.Translations`. Instead,
+use `.CurrentTaxonomy.Translations` (a `map[locale]URL` populated at render
+time) to look up the counterpart taxonomy page directly:
+
+```html
+{{/* tag.html / category.html */}}
+{{- $altURL := "/ja/"}}
+{{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
+{{- if .CurrentTaxonomy}}
+  {{- $targetLocale := "ja"}}
+  {{- if eq .CurrentLocale "ja"}}{{$targetLocale = "en"}}{{end}}
+  {{- with index .CurrentTaxonomy.Translations $targetLocale}}
+    {{- $altURL = .}}
+  {{- end}}
+{{- end}}
+<a href="{{$altURL}}">Switch language</a>
+```
+
+Paginated taxonomy pages always land on page 1 of the opposite locale — page
+counts may differ per locale, so propagating the current page number would
+produce broken links.
+
+Archive listing pages use `.CurrentArchivePath` in the same way:
+
+```html
+{{/* archive.html */}}
+{{- $altURL := "/ja/"}}
+{{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
+{{- if .CurrentArchivePath}}
+  {{- if eq .CurrentLocale "ja"}}
+    {{- $altURL = slice .CurrentArchivePath 3}}
+  {{- else}}
+    {{- $altURL = printf "/ja%s" .CurrentArchivePath}}
+  {{- end}}
+{{- end}}
+<a href="{{$altURL}}">Switch language</a>
+```
+
+Both fields are set by gohan for every listing page:
+
+| Template | Field | Example value (EN) | Example value (JA) |
+|---|---|---|---|
+| `tag.html`, `category.html` | `.CurrentTaxonomy.URL` | `/tags/go/` | `/ja/tags/go/` |
+| `archive.html` (year) | `.CurrentArchivePath` | `/archives/2024/` | `/ja/archives/2024/` |
+| `archive.html` (month) | `.CurrentArchivePath` | `/archives/2024/01/` | `/ja/archives/2024/01/` |
+
+### Locale-aware conditional content
+
+```html
+{{if eq .Article.Locale "ja"}}
+<p lang="ja">日本語版の記事です。</p>
+{{end}}
+```
+
+## Sitemap (hreflang)
+
+When articles have `Translations` populated, `sitemap.xml` automatically includes `xhtml:link` hreflang alternates as recommended by Google:
+
+```xml
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://example.com/posts/hello-world/</loc>
+    <lastmod>2024-01-01</lastmod>
+    <xhtml:link rel="alternate" hreflang="en" href="https://example.com/posts/hello-world/"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://example.com/ja/posts/hello-world/"/>
+  </url>
+  ...
+</urlset>
+```
+
+## Implementation Notes
+
+- **Locale detection** (`detectLocale` in `internal/processor/processor_impl.go`): matches the first path segment after `content/` against `I18n.Locales`.
+- **Output path** (`computeOutputPath`): strips the locale segment from the content path; re-prefixes with the locale code for non-default locales.
+- **Translation map** (`BuildTranslationMap`): called once in `build.go` after `Process()`; groups articles by `TranslationKey` and populates `Translations` on each article.
+- **Generator** (`internal/generator/html.go`): generates one index page per locale and one article page per article, using the locale-aware path.
+- **Backward compatibility**: when `I18n.Locales` is empty, all new helpers return empty values and no behaviour changes.
+
+## Locale-aware taxonomy
+
+When i18n is enabled, gohan loads a separate taxonomy registry for each locale.
+For each locale it looks for a locale-specific file first, then falls back to
+the global file:
+
+```
+content/
+  tags.yaml              # global / fallback
+  categories.yaml        # global / fallback
+  en/
+    tags.yaml            # EN-specific (optional)
+    categories.yaml      # EN-specific (optional)
+    posts/
+  ja/
+    tags.yaml            # JA-specific (optional)
+    categories.yaml      # JA-specific (optional)
+    posts/
+```
+
+Validation (`gohan build`) is locale-scoped: EN articles are checked against
+the EN registry, JA articles against the JA registry. If no locale-specific file
+exists the global file is used as the fallback — so existing single-language
+sites require no changes.
+
+`site.Tags` and `site.Categories` (used in templates) contain the deduplicated
+union of all locale registries, so all tags and categories are always accessible.
+
+### Cross-locale taxonomy linking
+
+To connect the same tag or category across locales (so a language switcher on a
+tag/category page can jump to the equivalent page in the other locale), add
+`translation_key` to each taxonomy entry. Entries sharing the same key are
+treated as translations of each other.
+
+```yaml
+# content/en/categories.yaml
+categories:
+  - name: Application
+    translation_key: application
+
+# content/ja/categories.yaml
+categories:
+  - name: アプリケーション
+    translation_key: application
+```
+
+At render time, gohan populates `.CurrentTaxonomy.Translations` — a
+`map[locale]URL` for every other locale that shares the same `translation_key`.
+On paginated pages the map always points at page 1 of the counterpart, since
+page counts can differ per locale.
+
+**Implicit fallback — shared names.** If `translation_key` is omitted, gohan
+falls back to matching by the taxonomy `Name` field (case-insensitive). This
+means taxonomies whose names are identical across locales — e.g. ASCII
+identifiers like `go`, `docker`, `aws` — are automatically linked without any
+configuration. Explicit `translation_key` always takes precedence.
+
+| Case | Configuration required | Behaviour |
+|---|---|---|
+| Same name in all locales (`go`, `docker`) | none | auto-linked via Name fallback |
+| Different names per locale (`Application` vs `アプリケーション`) | add matching `translation_key` in every locale file | linked via key |
+| No counterpart in other locale | none | `Translations` empty → switcher falls back to locale root |
+
+## Limitations (current version)
+
+- Feeds (`atom.xml`, `feed.xml`) include articles from all locales.
+- No automatic redirect from `/` to the user's preferred locale.

--- a/docs/content/en/guide/getting-started.md
+++ b/docs/content/en/guide/getting-started.md
@@ -1,0 +1,272 @@
+---
+title: "Getting Started"
+description: "Install gohan, create your first site, and preview it locally."
+slug: "getting-started"
+categories:
+  - guide
+translation_key: "getting-started"
+---
+
+
+## Prerequisites
+
+- Go 1.21 or later
+- Git (required for incremental builds)
+
+---
+
+## Installation
+
+```bash
+go install github.com/bmf-san/gohan/cmd/gohan@latest
+```
+
+Verify the installation:
+
+```bash
+gohan version
+# gohan v1.0.0 (commit: abc1234, built: 2024-01-01T00:00:00Z)
+```
+
+### Build from source
+
+```bash
+git clone https://github.com/bmf-san/gohan.git
+cd gohan
+make install
+```
+
+### Download a binary
+
+Download a pre-built binary for your platform from [GitHub Releases](https://github.com/bmf-san/gohan/releases).
+
+---
+
+## Create Your First Site
+
+### Step 1: Create a project directory
+
+```bash
+mkdir myblog
+cd myblog
+```
+
+### Step 2: Create `config.yaml`
+
+```yaml
+site:
+  title: My Blog
+  description: A simple personal blog
+  base_url: https://myblog.example.com
+  language: en
+
+build:
+  content_dir: content
+  output_dir: public
+  assets_dir: assets
+  parallelism: 4
+
+theme:
+  name: default
+
+syntax_highlight:
+  theme: github
+  line_numbers: false
+```
+
+See [Configuration](configuration.md) for all available fields.
+
+### Step 3: Create your first article
+
+```bash
+gohan new --title="Hello, World!" hello-world
+```
+
+This creates `content/posts/hello-world.md`. Edit it to add body content:
+
+```markdown
+---
+title: Hello, World!
+date: 2024-01-15
+slug: hello-world
+tags:
+  - go
+  - blog
+categories:
+  - tech
+draft: false
+description: My first gohan post
+---
+
+# Hello, World!
+
+Welcome to my blog powered by **gohan**!
+
+## Features
+
+- Incremental builds for fast generation
+- Customizable themes with Go html/template
+- Mermaid diagrams and syntax highlighting
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, gohan!")
+}
+```
+```
+
+### Step 4: Create theme templates
+
+```bash
+mkdir -p themes/default/templates
+```
+
+`themes/default/templates/index.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="{{.Config.Site.Language}}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{.Config.Site.Description}}">
+  <title>{{.Config.Site.Title}}</title>
+  <link rel="stylesheet" href="/assets/style.css">
+  <link rel="alternate" type="application/atom+xml" href="/atom.xml">
+</head>
+<body>
+  <header>
+    <h1><a href="/">{{.Config.Site.Title}}</a></h1>
+  </header>
+  <main>
+    <ul>
+      {{range .Articles}}
+      <li>
+        <span>{{formatDate "2006-01-02" .FrontMatter.Date}}</span>
+        <a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>
+      </li>
+      {{end}}
+    </ul>
+  </main>
+</body>
+</html>
+```
+
+`themes/default/templates/article.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="{{.Config.Site.Language}}">
+<head>
+  <meta charset="UTF-8">
+  <title>{{(index .Articles 0).FrontMatter.Title}} — {{.Config.Site.Title}}</title>
+  <link rel="stylesheet" href="/assets/style.css">
+</head>
+<body>
+  <header><a href="/">← {{.Config.Site.Title}}</a></header>
+  <main>
+    {{with (index .Articles 0)}}
+    <article>
+      <h1>{{.FrontMatter.Title}}</h1>
+      <time>{{formatDate "2006-01-02" .FrontMatter.Date}}</time>
+      {{if .FrontMatter.Tags}}
+      <ul class="tags">
+        {{range .FrontMatter.Tags}}
+        <li><a href="{{tagURL .}}">{{.}}</a></li>
+        {{end}}
+      </ul>
+      {{end}}
+      <div class="content">{{.HTMLContent}}</div>
+    </article>
+    {{end}}
+  </main>
+</body>
+</html>
+```
+
+See [Templates](templates.md) for the complete template reference.
+
+### Step 5: Add static assets (optional)
+
+```bash
+mkdir -p assets
+cat > assets/style.css << 'EOF'
+body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 1rem; }
+a { color: #0066cc; }
+EOF
+```
+
+### Step 6: Build the site
+
+```bash
+gohan build
+```
+
+The site is generated in `public/`:
+
+```
+public/
+├── index.html
+├── sitemap.xml
+├── atom.xml
+├── posts/
+│   └── hello-world/
+│       └── index.html
+└── assets/
+    └── style.css
+```
+
+### Step 7: Preview with the development server
+
+```bash
+gohan serve
+# Open http://127.0.0.1:1313
+```
+
+The browser reloads automatically whenever you save a file.
+
+---
+
+## Common Operations
+
+### Draft articles
+
+Articles with `draft: true` are excluded from builds:
+
+```yaml
+---
+title: Work in progress
+draft: true
+---
+```
+
+### Incremental builds
+
+After the first build, subsequent builds are automatically incremental (only changed files are regenerated):
+
+```bash
+gohan build        # First run: full build
+# edit content/
+gohan build        # Second run: only changed files
+gohan build --full # Force a full rebuild
+```
+
+### Recommended `.gitignore`
+
+```gitignore
+public/
+.gohan/
+gohan
+```
+
+---
+
+## Next Steps
+
+- [Configuration](configuration.md) — all `config.yaml` options
+- [Templates](templates.md) — customize your theme
+- [Taxonomy](taxonomy.md) — manage tags and categories

--- a/docs/content/ja/features/i18n.md
+++ b/docs/content/ja/features/i18n.md
@@ -1,0 +1,270 @@
+---
+title: "i18n（多言語対応）"
+description: "ディレクトリベースのロケール構造で多言語サイトを構築。"
+slug: "i18n"
+categories:
+  - features
+translation_key: "i18n"
+---
+
+## 概要
+
+gohan はディレクトリベースのロケール構造で多言語サイトをサポートする。各ロケールのコンテンツはコンテンツディレクトリ配下の名前付きサブディレクトリに格納する（例: `content/en/`、`content/ja/`）。デフォルトロケールはルートURLで提供され、その他のロケールはURLプレフィックスが付与される。
+
+既存の単一言語サイトは設定変更なしでそのまま動作する（完全後方互換）。
+
+## 設定
+
+`config.yaml` に `i18n` ブロックを追加する：
+
+```yaml
+site:
+  language: en          # default_locale のフォールバックとして使用
+
+i18n:
+  locales: [en, ja]     # ロケールコードのリスト（順序あり）
+  default_locale: en    # URLプレフィックスなしで提供するロケール。省略時は site.language
+```
+
+| フィールド | 型 | デフォルト | 説明 |
+|-----------|-----|-----------|------|
+| `locales` | `[]string` | `[]` (無効) | コンテンツディレクトリ配下のロケールコード |
+| `default_locale` | string | `site.language` | URLプレフィックスなしで提供するロケール |
+
+`locales` が空のとき、i18n は無効となり gohan は単一言語サイトとして動作する。
+
+## コンテンツ構造
+
+```
+content/
+  en/
+    posts/
+      hello-world.md    → /posts/hello-world/
+  ja/
+    posts/
+      hello-world.md    → /ja/posts/hello-world/
+```
+
+`content/` 直下の最初のパスセグメントのみがロケールコードとして扱われる。`i18n.locales` に含まれる値と一致する必要がある。
+
+## 翻訳リンク
+
+同じ記事の翻訳を関連付けるには、フロントマターに `translation_key` を追加する。全バリアントで同じ値を指定すること。
+
+```yaml
+---
+title: Hello World
+translation_key: hello-world
+---
+```
+
+`gohan build` 中に `BuildTranslationMap` が実行されると、各 `ProcessedArticle.Translations` に兄弟ロケールの `LocaleRef` エントリが設定される。テンプレートでこれを使って言語切替リンクを描画できる。
+
+## データモデル
+
+### 新規型
+
+```go
+// I18nConfig holds multi-language content configuration.
+type I18nConfig struct {
+    Locales       []string `yaml:"locales"`
+    DefaultLocale string   `yaml:"default_locale"`
+}
+
+// LocaleRef holds a locale code and the canonical URL for a translated article.
+type LocaleRef struct {
+    Locale string
+    URL    string
+}
+```
+
+### 拡張された型
+
+```go
+// FrontMatter — 追加フィールド
+TranslationKey string `yaml:"translation_key"`
+
+// ProcessedArticle — 追加フィールド
+Locale       string       // コンテンツパスから検出（例: "en"、"ja"）
+URL          string       // 正規URLパス（例: "/posts/hello/" または "/ja/posts/hello/"）
+Translations []LocaleRef  // BuildTranslationMap 後に設定される
+
+// Config — 追加フィールド
+I18n I18nConfig `yaml:"i18n"`
+```
+
+## URLスキーム
+
+| コンテンツファイル | ロケール | 出力 | URL |
+|---|---|---|---|
+| `content/en/posts/hello.md` | `en`（デフォルト） | `public/posts/hello/index.html` | `/posts/hello/` |
+| `content/ja/posts/hello.md` | `ja` | `public/ja/posts/hello/index.html` | `/ja/posts/hello/` |
+
+インデックスページも同じルール：
+
+| ロケール | 出力 | URL |
+|---|---|---|
+| `en`（デフォルト） | `public/index.html` | `/` |
+| `ja` | `public/ja/index.html` | `/ja/` |
+
+## テンプレートでの使い方
+
+### 言語切替リンク
+
+記事ページでは `.Article.Translations` を使って翻訳版へのリンクを生成します：
+
+```html
+{{if .Article.Translations}}
+<nav aria-label="Language">
+  <a href="{{.Article.URL}}">{{.Config.Site.Language}}</a>
+  {{range .Article.Translations}}
+  <a href="{{.URL}}">{{.Locale}}</a>
+  {{end}}
+</nav>
+{{end}}
+```
+
+### 一覧ページの言語切替リンク
+
+タグ・カテゴリ一覧ページには `.Article.Translations` がありません。代わりに
+`.CurrentTaxonomy.Translations`（レンダー時に設定される `map[locale]URL`）を
+使って対応するタクソノミーページへ直接ジャンプします：
+
+```html
+{{/* tag.html / category.html */}}
+{{- $altURL := "/ja/"}}
+{{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
+{{- if .CurrentTaxonomy}}
+  {{- $targetLocale := "ja"}}
+  {{- if eq .CurrentLocale "ja"}}{{$targetLocale = "en"}}{{end}}
+  {{- with index .CurrentTaxonomy.Translations $targetLocale}}
+    {{- $altURL = .}}
+  {{- end}}
+{{- end}}
+<a href="{{$altURL}}">言語を切り替える</a>
+```
+
+ページネーションがあるタクソノミーページでは、常に対向ロケールの 1 ページ目
+に遷移します。ロケールごとにページ数が異なる可能性があるため、現在のページ
+番号をそのまま引き継ぐとリンク切れを引き起こします。
+
+アーカイブ一覧ページでは `.CurrentArchivePath` を同様に使います：
+
+```html
+{{/* archive.html */}}
+{{- $altURL := "/ja/"}}
+{{- if eq .CurrentLocale "ja"}}{{$altURL = "/"}}{{end}}
+{{- if .CurrentArchivePath}}
+  {{- if eq .CurrentLocale "ja"}}
+    {{- $altURL = slice .CurrentArchivePath 3}}
+  {{- else}}
+    {{- $altURL = printf "/ja%s" .CurrentArchivePath}}
+  {{- end}}
+{{- end}}
+<a href="{{$altURL}}">言語を切り替える</a>
+```
+
+どちらのフィールドも gohan がすべての一覧ページで設定します：
+
+| テンプレート | フィールド | 値の例（EN） | 値の例（JA） |
+|---|---|---|---|
+| `tag.html`、`category.html` | `.CurrentTaxonomy.URL` | `/tags/go/` | `/ja/tags/go/` |
+| `archive.html`（年） | `.CurrentArchivePath` | `/archives/2024/` | `/ja/archives/2024/` |
+| `archive.html`（月） | `.CurrentArchivePath` | `/archives/2024/01/` | `/ja/archives/2024/01/` |
+
+### ロケール条件分岐
+
+```html
+{{if eq .Article.Locale "ja"}}
+<p lang="ja">日本語版の記事です。</p>
+{{end}}
+```
+
+## サイトマップ（hreflang）
+
+記事に `Translations` が設定されている場合、`sitemap.xml` にGoogleが推奨する `xhtml:link` hreflang alternateが自動的に追加される：
+
+```xml
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://example.com/posts/hello-world/</loc>
+    <lastmod>2024-01-01</lastmod>
+    <xhtml:link rel="alternate" hreflang="en" href="https://example.com/posts/hello-world/"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://example.com/ja/posts/hello-world/"/>
+  </url>
+</urlset>
+```
+
+## 実装メモ
+
+- **ロケール検出** (`detectLocale` in `internal/processor/processor_impl.go`): `content/` 以降の最初のパスセグメントを `I18n.Locales` と照合する。
+- **出力パス** (`computeOutputPath`): コンテンツパスからロケールセグメントを取り除き、デフォルト以外のロケールにはロケールコードを再付与する。
+- **翻訳マップ** (`BuildTranslationMap`): `build.go` で `Process()` の後に一度だけ呼び出す。`TranslationKey` で記事をグループ化し、各記事の `Translations` フィールドを設定する。
+- **ジェネレーター** (`internal/generator/html.go`): ロケールごとのインデックスページと記事ページをロケール対応パスで生成する。
+- **後方互換性**: `I18n.Locales` が空の場合、新しいヘルパーはすべて空文字を返し、動作変更はない。
+
+## ロケール別タクソノミー
+
+i18n が有効な場合、gohan はロケールごとに個別のタクソノミーレジストリを読み込みます。
+各ロケールごとにロケール固有のファイルを優先し、存在しない場合はグローバルファイルへフォールバックします:
+
+```
+content/
+  tags.yaml              # グローバル / フォールバック
+  categories.yaml        # グローバル / フォールバック
+  en/
+    tags.yaml            # EN 固有（任意）
+    categories.yaml      # EN 固有（任意）
+    posts/
+  ja/
+    tags.yaml            # JA 固有（任意）
+    categories.yaml      # JA 固有（任意）
+    posts/
+```
+
+バリデーション（`gohan build`）はロケールスコープで行われます：EN 記事は EN レジストリに対して、JA 記事は JA レジストリに対して検証されます。
+ロケール固有のファイルが存在しない場合はグローバルファイルがフォールバックとして使用されるため、既存のシングルランゲージサイトは変更不要です。
+
+`site.Tags` と `site.Categories`（テンプレートで使用）は全ロケールレジストリの重複除去済みユニオンを含むため、全タグ・カテゴリに常にアクセス可能です。
+
+### ロケール間タクソノミー連携
+
+同じタグ・カテゴリをロケール間で連携させる（タグ・カテゴリページ上の言語
+切替リンクから対向ロケールの同等ページへ遷移できるようにする）には、
+各タクソノミーエントリに `translation_key` を追加します。同じキーを持つ
+エントリは互いに翻訳として扱われます。
+
+```yaml
+# content/en/categories.yaml
+categories:
+  - name: Application
+    translation_key: application
+
+# content/ja/categories.yaml
+categories:
+  - name: アプリケーション
+    translation_key: application
+```
+
+レンダリング時、gohan は `.CurrentTaxonomy.Translations` に同じ
+`translation_key` を持つ他ロケールの URL を `map[locale]URL` として設定します。
+ページネーション対象ページでは、ロケールごとのページ数差異による
+リンク切れを防ぐため、常に対向ロケールの 1 ページ目を指します。
+
+**暗黙のフォールバック — 名前一致。** `translation_key` が省略された場合、
+gohan は `Name` フィールド（大文字小文字無視）による一致にフォールバック
+します。これにより `go`、`docker`、`aws` のようにロケール間で同名の
+ASCII 識別子は設定なしで自動的にリンクされます。明示的な `translation_key`
+が常に優先されます。
+
+| ケース | 必要な設定 | 動作 |
+|---|---|---|
+| 全ロケールで同名（`go`, `docker`） | なし | Name フォールバックで自動連携 |
+| ロケールごとに名前が異なる（`Application` ↔ `アプリケーション`） | 各ロケールファイルで同じ `translation_key` を設定 | キーで連携 |
+| 対向ロケールに対応するものがない | なし | `Translations` が空 → 切替リンクはロケールルートへフォールバック |
+
+## 現バージョンの制限事項
+
+- `atom.xml` / `feed.xml` フィードは全ロケールの記事を含む。
+- ユーザーの優先言語に基づく `/` からの自動リダイレクトは未実装。

--- a/docs/content/ja/guide/getting-started.md
+++ b/docs/content/ja/guide/getting-started.md
@@ -1,0 +1,222 @@
+---
+title: "はじめに"
+description: "gohan のインストールから最初のサイト作成・ローカルプレビューまで。"
+slug: "getting-started"
+categories:
+  - guide
+translation_key: "getting-started"
+---
+
+
+## 前提条件
+
+- Go 1.21 以上
+- Git（差分ビルド機能を使う場合）
+
+---
+
+## インストール
+
+```bash
+go install github.com/bmf-san/gohan/cmd/gohan@latest
+```
+
+インストールを確認します:
+
+```bash
+gohan version
+# gohan v1.0.0 (commit: abc1234, built: 2024-01-01T00:00:00Z)
+```
+
+### ソースからビルド
+
+```bash
+git clone https://github.com/bmf-san/gohan.git
+cd gohan
+make install
+```
+
+### バイナリダウンロード
+
+[GitHub Releases](https://github.com/bmf-san/gohan/releases) から各プラットフォーム向けのビルド済みバイナリをダウンロードできます。
+
+---
+
+## 最初のサイトを作る
+
+### ステップ 1: プロジェクトを作成する
+
+```bash
+mkdir myblog
+cd myblog
+```
+
+### ステップ 2: `config.yaml` を作成する
+
+```yaml
+site:
+  title: My Blog
+  description: A simple personal blog
+  base_url: https://myblog.example.com
+  language: ja
+
+build:
+  content_dir: content
+  output_dir: public
+  assets_dir: assets
+  parallelism: 4
+
+theme:
+  name: default
+
+syntax_highlight:
+  theme: github
+  line_numbers: false
+```
+
+全フィールドの詳細は [Configuration](configuration.ja.md) を参照してください。
+
+### ステップ 3: 最初の記事を作成する
+
+```bash
+gohan new --title="Hello, World!" hello-world
+```
+
+`content/posts/hello-world.md` が作成されます。編集して本文を追加しましょう:
+
+```markdown
+---
+title: Hello, World!
+date: 2024-01-15
+slug: hello-world
+tags:
+  - go
+  - blog
+categories:
+  - tech
+draft: false
+description: はじめての gohan ブログ記事
+---
+
+# Hello, World!
+
+**gohan** でブログを始めました！
+```
+
+### ステップ 4: テーマテンプレートを作成する
+
+```bash
+mkdir -p themes/default/templates
+```
+
+`themes/default/templates/index.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="{{.Config.Site.Language}}">
+<head>
+  <meta charset="UTF-8">
+  <title>{{.Config.Site.Title}}</title>
+  <link rel="stylesheet" href="/assets/style.css">
+  <link rel="alternate" type="application/atom+xml" href="/atom.xml">
+</head>
+<body>
+  <header>
+    <h1><a href="/">{{.Config.Site.Title}}</a></h1>
+  </header>
+  <main>
+    <ul>
+      {{range .Articles}}
+      <li>
+        <span>{{formatDate "2006-01-02" .FrontMatter.Date}}</span>
+        <a href="/posts/{{.FrontMatter.Slug}}/">{{.FrontMatter.Title}}</a>
+      </li>
+      {{end}}
+    </ul>
+  </main>
+</body>
+</html>
+```
+
+テンプレートの詳細は [テンプレートガイド](templates.ja.md) を参照してください。
+
+### ステップ 5: アセットを追加する（任意）
+
+```bash
+mkdir -p assets
+cat > assets/style.css << 'EOF'
+body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 1rem; }
+a { color: #0066cc; }
+EOF
+```
+
+### ステップ 6: サイトをビルドする
+
+```bash
+gohan build
+```
+
+`public/` ディレクトリにサイトが生成されます:
+
+```
+public/
+├── index.html
+├── sitemap.xml
+├── atom.xml
+├── posts/
+│   └── hello-world/
+│       └── index.html
+└── assets/
+    └── style.css
+```
+
+### ステップ 7: 開発サーバーで確認する
+
+```bash
+gohan serve
+# http://127.0.0.1:1313 でプレビュー
+```
+
+ファイルを保存するたびにブラウザが自動でリロードされます。
+
+---
+
+## よくある操作
+
+### 記事の下書き
+
+`draft: true` を設定した記事はビルドに含まれません:
+
+```yaml
+---
+title: 作成中の記事
+draft: true
+---
+```
+
+### 差分ビルド
+
+2 回目以降のビルドは自動的に差分ビルドになります:
+
+```bash
+gohan build          # 初回: フルビルド
+# content/ を編集
+gohan build          # 2 回目: 変更分のみ再生成
+gohan build --full   # 強制的なフルビルド
+```
+
+### 推奨 `.gitignore`
+
+```gitignore
+public/
+.gohan/
+gohan
+```
+
+---
+
+## 次のステップ
+
+- [設定リファレンス](configuration.ja.md) — すべての config.yaml オプション
+- [テンプレートガイド](templates.ja.md) — テーマのカスタマイズ
+- [タクソノミーガイド](taxonomy.ja.md) — タグ・カテゴリーの管理

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "gohan-docs",
+  "private": true,
+  "description": "gohan documentation site (built with gohan + sleyt).",
+  "scripts": {
+    "build:css": "mkdir -p assets/css && cp node_modules/sleyt/dist/css/index.css assets/css/sleyt.css",
+    "build": "npm run build:css && gohan build",
+    "serve": "npm run build:css && gohan serve",
+    "clean": "rm -rf public assets/css"
+  },
+  "dependencies": {
+    "sleyt": "^1.4.0"
+  }
+}

--- a/docs/themes/sleyt/templates/article.html
+++ b/docs/themes/sleyt/templates/article.html
@@ -1,0 +1,104 @@
+{{- $base := .Config.Theme.Params.base_path -}}
+{{- $article := index .Articles 0 -}}
+{{- $locale := $article.Locale -}}
+{{- $isJa := eq $locale "ja" -}}
+{{- $localeRoot := $base -}}{{if $isJa}}{{- $localeRoot = printf "%s/ja" $base -}}{{end}}
+<!DOCTYPE html>
+<html lang="{{if $isJa}}ja{{else}}en{{end}}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="{{$article.FrontMatter.Description}}">
+  <title>{{$article.FrontMatter.Title}} — {{.Config.Site.Title}}</title>
+  <link rel="stylesheet" href="{{.Config.Theme.Params.sleyt_css}}">
+  {{range $article.Translations}}<link rel="alternate" hreflang="{{.Locale}}" href="{{$.Config.Site.BaseURL}}{{.URL}}">
+  {{end}}
+</head>
+<body>
+  <nav class="navbar">
+    <a class="navbar-brand" href="{{$localeRoot}}/">gohan</a>
+    <input type="checkbox" id="navbar-toggle" class="navbar-toggle-checkbox">
+    <label for="navbar-toggle" class="navbar-toggle-label"><span></span><span></span><span></span></label>
+    <ul class="navbar-nav">
+      <li><a class="navbar-item" href="{{$localeRoot}}/guide/getting-started/">{{if $isJa}}ガイド{{else}}Guide{{end}}</a></li>
+      <li><a class="navbar-item" href="{{$localeRoot}}/features/i18n/">{{if $isJa}}機能{{else}}Features{{end}}</a></li>
+      <li><a class="navbar-item" href="{{$.Config.Theme.Params.github_url}}" target="_blank" rel="noopener">GitHub</a></li>
+      {{range $article.Translations}}<li><a class="navbar-item" href="{{$base}}{{.URL}}">{{if eq .Locale "ja"}}日本語{{else}}EN{{end}}</a></li>
+      {{end}}
+    </ul>
+  </nav>
+
+  <div class="dashboard">
+    <input type="checkbox" id="sidebar-toggle" class="sidebar-toggle-checkbox">
+    <aside class="sidebar">
+      <a class="sidebar-brand" href="{{$localeRoot}}/">
+        <span class="sidebar-brand-icon">g</span>
+        gohan docs
+      </a>
+      <nav class="sidebar-nav">
+        <span class="sidebar-section-label">{{if $isJa}}ガイド{{else}}Guide{{end}}</span>
+        <a class="sidebar-link" href="{{$localeRoot}}/guide/getting-started/">{{if $isJa}}はじめに{{else}}Getting Started{{end}}</a>
+        <a class="sidebar-link" href="{{$localeRoot}}/guide/configuration/">{{if $isJa}}設定{{else}}Configuration{{end}}</a>
+        <a class="sidebar-link" href="{{$localeRoot}}/guide/templates/">{{if $isJa}}テンプレート{{else}}Templates{{end}}</a>
+        <a class="sidebar-link" href="{{$localeRoot}}/guide/taxonomy/">{{if $isJa}}タクソノミー{{else}}Taxonomy{{end}}</a>
+        <a class="sidebar-link" href="{{$localeRoot}}/guide/cli/">{{if $isJa}}CLI{{else}}CLI Reference{{end}}</a>
+
+        <span class="sidebar-section-label">{{if $isJa}}機能{{else}}Features{{end}}</span>
+        <a class="sidebar-link" href="{{$localeRoot}}/features/i18n/">i18n</a>
+        <a class="sidebar-link" href="{{$localeRoot}}/features/ogp/">OGP</a>
+        <a class="sidebar-link" href="{{$localeRoot}}/features/pagination/">{{if $isJa}}ページネーション{{else}}Pagination{{end}}</a>
+        <a class="sidebar-link" href="{{$localeRoot}}/features/github-source-link/">{{if $isJa}}GitHubソースリンク{{else}}GitHub Source Link{{end}}</a>
+        <a class="sidebar-link" href="{{$localeRoot}}/features/plugin-system/">{{if $isJa}}プラグイン{{else}}Plugin System{{end}}</a>
+        <a class="sidebar-link" href="{{$localeRoot}}/features/related-articles/">{{if $isJa}}関連記事{{else}}Related Articles{{end}}</a>
+      </nav>
+    </aside>
+
+    <div class="dashboard-main">
+      <div class="dashboard-content">
+        <nav aria-label="breadcrumb">
+          <ol class="breadcrumbs">
+            <li class="breadcrumbs-item"><a class="breadcrumbs-link" href="{{$localeRoot}}/">{{if $isJa}}ホーム{{else}}Home{{end}}</a></li>
+            <li class="breadcrumbs-separator">/</li>
+            {{if $article.FrontMatter.Categories}}<li class="breadcrumbs-item"><a class="breadcrumbs-link" href="{{$localeRoot}}/categories/{{index $article.FrontMatter.Categories 0}}/">{{index $article.FrontMatter.Categories 0}}</a></li>
+            <li class="breadcrumbs-separator">/</li>{{end}}
+            <li class="breadcrumbs-item active"><span class="breadcrumbs-link">{{$article.FrontMatter.Title}}</span></li>
+          </ol>
+        </nav>
+
+        <article class="prose prose-full mt-6">
+          <h1>{{$article.FrontMatter.Title}}</h1>
+          {{$article.HTMLContent}}
+        </article>
+
+        {{if $.Config.Site.GitHubRepo}}
+        <div class="mt-8 pt-6 border-t">
+          <a class="btn btn-sm btn-outline-primary" href="{{$.Config.Site.GitHubRepo}}/edit/{{$.Config.Site.GitHubBranch}}/docs/content/{{$article.ContentPath}}" target="_blank" rel="noopener">
+            {{if $isJa}}このページを編集{{else}}Edit this page on GitHub{{end}}
+          </a>
+        </div>
+        {{end}}
+
+        {{if $.RelatedArticles}}
+        <section class="mt-12">
+          <h2 class="text-2xl font-bold mb-4">{{if $isJa}}関連ページ{{else}}Related{{end}}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {{range $.RelatedArticles}}
+            <a class="card" href="{{$base}}{{.URL}}">
+              <div class="card-header-compact">{{.FrontMatter.Title}}</div>
+              <div class="card-body-compact"><p class="text-sm text-secondary">{{.FrontMatter.Description}}</p></div>
+            </a>
+            {{end}}
+          </div>
+        </section>
+        {{end}}
+      </div>
+    </div>
+  </div>
+
+  <footer class="border-t py-8 text-center text-sm text-secondary">
+    <div class="container">
+      <p>&copy; bmf-san. Built with <a href="{{$.Config.Theme.Params.github_url}}">gohan</a> &amp; <a href="https://github.com/bmf-san/sleyt" target="_blank" rel="noopener">sleyt</a>.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/themes/sleyt/templates/category.html
+++ b/docs/themes/sleyt/templates/category.html
@@ -1,0 +1,54 @@
+{{- $base := .Config.Theme.Params.base_path -}}
+{{- $locale := .CurrentLocale -}}
+{{- $isJa := eq $locale "ja" -}}
+{{- $localeRoot := $base -}}{{if $isJa}}{{- $localeRoot = printf "%s/ja" $base -}}{{end}}
+{{- $name := "" -}}{{if .CurrentTaxonomy}}{{- $name = .CurrentTaxonomy.Name -}}{{end}}
+<!DOCTYPE html>
+<html lang="{{if $isJa}}ja{{else}}en{{end}}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{$name}} — {{.Config.Site.Title}}</title>
+  <link rel="stylesheet" href="{{.Config.Theme.Params.sleyt_css}}">
+</head>
+<body>
+  <nav class="navbar">
+    <a class="navbar-brand" href="{{$localeRoot}}/">gohan</a>
+    <ul class="navbar-nav">
+      <li><a class="navbar-item" href="{{.Config.Theme.Params.github_url}}" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a class="navbar-item" href="{{if $isJa}}{{$base}}/{{else}}{{$base}}/ja/{{end}}">{{if $isJa}}EN{{else}}日本語{{end}}</a></li>
+    </ul>
+  </nav>
+
+  <main class="container py-12">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumbs">
+        <li class="breadcrumbs-item"><a class="breadcrumbs-link" href="{{$localeRoot}}/">{{if $isJa}}ホーム{{else}}Home{{end}}</a></li>
+        <li class="breadcrumbs-separator">/</li>
+        <li class="breadcrumbs-item active"><span class="breadcrumbs-link">{{$name}}</span></li>
+      </ol>
+    </nav>
+
+    <header class="mt-6 mb-8">
+      <h1 class="text-4xl font-bold capitalize">{{$name}}</h1>
+    </header>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {{range .Articles}}
+      <a class="card" href="{{$base}}{{.URL}}">
+        <div class="card-header">{{.FrontMatter.Title}}</div>
+        <div class="card-body">
+          <p class="text-sm text-secondary">{{.FrontMatter.Description}}</p>
+        </div>
+      </a>
+      {{end}}
+    </div>
+  </main>
+
+  <footer class="border-t mt-12 py-8 text-center text-sm text-secondary">
+    <div class="container">
+      <p>&copy; bmf-san. Built with <a href="{{.Config.Theme.Params.github_url}}">gohan</a> &amp; <a href="https://github.com/bmf-san/sleyt" target="_blank" rel="noopener">sleyt</a>.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/themes/sleyt/templates/index.html
+++ b/docs/themes/sleyt/templates/index.html
@@ -1,0 +1,72 @@
+{{- $base := .Config.Theme.Params.base_path -}}
+{{- $locale := .CurrentLocale -}}
+{{- $isJa := eq $locale "ja" -}}
+<!DOCTYPE html>
+<html lang="{{if $isJa}}ja{{else}}en{{end}}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="{{.Config.Site.Description}}">
+  <title>{{.Config.Site.Title}}{{if $isJa}} — Go製の高速静的サイトジェネレーター{{else}} — A fast static site generator in Go{{end}}</title>
+  <link rel="stylesheet" href="{{.Config.Theme.Params.sleyt_css}}">
+  <link rel="alternate" type="application/atom+xml" title="{{.Config.Site.Title}}" href="{{$base}}/atom.xml">
+</head>
+<body>
+  <nav class="navbar">
+    <a class="navbar-brand" href="{{if $isJa}}{{$base}}/ja/{{else}}{{$base}}/{{end}}">gohan</a>
+    <input type="checkbox" id="navbar-toggle" class="navbar-toggle-checkbox">
+    <label for="navbar-toggle" class="navbar-toggle-label"><span></span><span></span><span></span></label>
+    <ul class="navbar-nav">
+      <li><a class="navbar-item" href="{{if $isJa}}{{$base}}/ja/guide/getting-started/{{else}}{{$base}}/guide/getting-started/{{end}}">{{if $isJa}}ガイド{{else}}Guide{{end}}</a></li>
+      <li><a class="navbar-item" href="{{if $isJa}}{{$base}}/ja/features/i18n/{{else}}{{$base}}/features/i18n/{{end}}">{{if $isJa}}機能{{else}}Features{{end}}</a></li>
+      <li><a class="navbar-item" href="{{.Config.Theme.Params.github_url}}" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a class="navbar-item" href="{{if $isJa}}{{$base}}/{{else}}{{$base}}/ja/{{end}}">{{if $isJa}}EN{{else}}日本語{{end}}</a></li>
+    </ul>
+  </nav>
+
+  <main class="container py-12">
+    <header class="text-center mb-12">
+      <h1 class="text-5xl font-bold mb-4">gohan</h1>
+      <p class="text-lg text-secondary mb-6">{{if $isJa}}Go製のシンプルで高速な静的サイトジェネレーター{{else}}A simple, fast static site generator written in Go.{{end}}</p>
+      <div class="flex justify-center gap-3 flex-wrap">
+        <a class="btn btn-primary" href="{{if $isJa}}{{$base}}/ja/guide/getting-started/{{else}}{{$base}}/guide/getting-started/{{end}}">{{if $isJa}}はじめる{{else}}Get Started{{end}}</a>
+        <a class="btn btn-outline-primary" href="{{.Config.Theme.Params.github_url}}" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </header>
+
+    <section class="mb-12">
+      <h2 class="text-3xl font-bold mb-6">{{if $isJa}}ガイド{{else}}Guide{{end}}</h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {{range .Articles}}{{if eq (index .FrontMatter.Categories 0) "guide"}}
+        <a class="card" href="{{$base}}{{.URL}}">
+          <div class="card-header">{{.FrontMatter.Title}}</div>
+          <div class="card-body">
+            <p class="text-sm text-secondary">{{.FrontMatter.Description}}</p>
+          </div>
+        </a>
+        {{end}}{{end}}
+      </div>
+    </section>
+
+    <section class="mb-12">
+      <h2 class="text-3xl font-bold mb-6">{{if $isJa}}機能{{else}}Features{{end}}</h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {{range .Articles}}{{if eq (index .FrontMatter.Categories 0) "features"}}
+        <a class="card" href="{{$base}}{{.URL}}">
+          <div class="card-header">{{.FrontMatter.Title}}</div>
+          <div class="card-body">
+            <p class="text-sm text-secondary">{{.FrontMatter.Description}}</p>
+          </div>
+        </a>
+        {{end}}{{end}}
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t mt-12 py-8 text-center text-sm text-secondary">
+    <div class="container">
+      <p>&copy; bmf-san. Built with <a href="{{.Config.Theme.Params.github_url}}">gohan</a> &amp; <a href="https://github.com/bmf-san/sleyt" target="_blank" rel="noopener">sleyt</a>.</p>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Set up the documentation site as a self-hosted gohan project under `docs/`, deployed to GitHub Pages with sleyt-only styling.

- **Theme**: 100% [sleyt](https://github.com/bmf-san/sleyt) CSS classes — no inline styles, no custom CSS classes, no `<style>` tags.
- **Hosting**: GitHub Pages at https://bmf-san.github.io/gohan/ (and `/ja/` for Japanese).
- **i18n**: `en` (default, served at root) + `ja` (served at `/ja/`).
- **Sleyt distribution**: installed via npm (`sleyt@^1.4.0`) and copied to `assets/css/sleyt.css` at build time.

## What's in this PR (Phase 1 — foundation + 2 example pages)

| File | Purpose |
| --- | --- |
| `docs/config.yaml` | gohan project config (base_url, theme, i18n locales) |
| `docs/package.json` | Installs sleyt and copies CSS into `assets/` |
| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores | | `docs/.(si| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores `public/`| `do{en,j| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores `public/`| `docs/.gi feature| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Ignores `public/`| `docs/.gi t| `docs/.gitignore` | Ignores `public/`| `docs/.gitignore` | Igndocs
nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn` base path required by the GitHub Pages subpath.

## Required setup## Required setupde## y

In the repository **Settings → Pages**, set **Source** to **GitHub Actions** (one-time).

## Phase 2 (follow-up PR)

Migrate the remaining markdown files (guide + features pairs in both locales) and `DESIGN_DOC.md` into the new content tree with front matter.
