### PR TITLE
fix(docs): auto-enable GitHub Pages in deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,6 +44,8 @@ jobs:
         run: npm run build
 
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
The first run of `deploy-docs.yml` failed because Pages was not yet enabled on the repository. Setting `enablement: true` on `actions/configure-pages@v5` lets the workflow bootstrap Pages itself on the first run.