### PR TITLE
docs(readme): collapse duplicated doc tables to a single docs site link

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -131,34 +131,9 @@ books:
 
 ---
 
-## ユーザーガイド
+## ドキュメント
 
 ドキュメントサイト: **https://bmf-san.github.io/gohan/ja/**
-
-| ガイド | 内容 |
-|---|---|
-| [Getting Started](https://bmf-san.github.io/gohan/ja/guide/getting-started/) | インストール、最初のサイト作成、ビルド、プレビュー |
-| [Configuration](https://bmf-san.github.io/gohan/ja/guide/configuration/) | `config.yaml` の全フィールドと Front Matter |
-| [Templates](https://bmf-san.github.io/gohan/ja/guide/templates/) | テーマテンプレート・変数・組み込み関数 |
-| [Taxonomy](https://bmf-san.github.io/gohan/ja/guide/taxonomy/) | タグ・カテゴリー・アーカイブページ |
-| [CLI リファレンス](https://bmf-san.github.io/gohan/ja/guide/cli/) | 全コマンドとフラグ |
-
-## 機能一覧
-
-| 機能 | 内容 |
-|---|---|
-| [i18n](https://bmf-san.github.io/gohan/ja/features/i18n/) | 多言語コンテンツ、翻訳リンク・`hreflang` 対応 |
-| [OGP 画像生成](https://bmf-san.github.io/gohan/ja/features/ogp/) | ビルド時に記事ごとの Open Graph 画像を自動生成 |
-| [ページネーション](https://bmf-san.github.io/gohan/ja/features/pagination/) | `per_page` 設定とページナビゲーション |
-| [GitHub ソースリンク](https://bmf-san.github.io/gohan/ja/features/github-source-link/) | 記事ごとに GitHub ソースファイルへのリンクを付与 |
-| [プラグインシステム](https://bmf-san.github.io/gohan/ja/features/plugin-system/) | ビルトインプラグイン（`amazon_books` など）を `config.yaml` で管理 |
-| [関連記事](https://bmf-san.github.io/gohan/ja/features/related-articles/) | 記事ページに同カテゴリーの関連記事を自動表示 |
-
----
-
-## 設計
-
-アーキテクチャと設計方針については [設計ドキュメント](https://bmf-san.github.io/gohan/ja/guide/design/) を参照してください。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -88,34 +88,9 @@ gohan serve   # open http://127.0.0.1:1313
 
 ---
 
-## User Guide
+## Documentation
 
 Full documentation site: **https://bmf-san.github.io/gohan/**
-
-| Guide | Description |
-|---|---|
-| [Getting Started](https://bmf-san.github.io/gohan/guide/getting-started/) | Installation, first site, build & preview |
-| [Configuration](https://bmf-san.github.io/gohan/guide/configuration/) | All `config.yaml` fields and Front Matter |
-| [Templates](https://bmf-san.github.io/gohan/guide/templates/) | Theme templates, variables, built-in functions |
-| [Taxonomy](https://bmf-san.github.io/gohan/guide/taxonomy/) | Tags, categories, and archive pages |
-| [CLI Reference](https://bmf-san.github.io/gohan/guide/cli/) | All commands and flags |
-
-## Feature Documentation
-
-| Feature | Description |
-|---|---|
-| [i18n](https://bmf-san.github.io/gohan/features/i18n/) | Multi-locale content with translation links and `hreflang` |
-| [OGP Image Generation](https://bmf-san.github.io/gohan/features/ogp/) | Build-time Open Graph images per article |
-| [Pagination](https://bmf-san.github.io/gohan/features/pagination/) | Configurable `per_page` and page navigation |
-| [GitHub Source Link](https://bmf-san.github.io/gohan/features/github-source-link/) | Per-article link to the source file on GitHub |
-| [Plugin System](https://bmf-san.github.io/gohan/features/plugin-system/) | Built-in plugins (`amazon_books`, …) via `config.yaml` |
-| [Related Articles](https://bmf-san.github.io/gohan/features/related-articles/) | Same-category article recommendations on article pages |
-
----
-
-## Design
-
-For architecture and design decisions see [Design Document](https://bmf-san.github.io/gohan/guide/design/).
 
 ---
 


### PR DESCRIPTION
Drop the per-page Guide / Feature / Design tables from `README.md` and `README.ja.md` to avoid maintaining the same listing in two places. The docs site (https://bmf-san.github.io/gohan/) is now the single source of truth for that navigation.