### PR TITLE
feat(article): expose TOC, WordCount, and ReadingTime on ProcessedArticle

### DIFF
--- a/internal/model/article.go
+++ b/internal/model/article.go
@@ -34,6 +34,27 @@ type ProcessedArticle struct {
 	// PluginData holds per-article data injected by enabled plugins.
 	// Access in templates: {{index .PluginData "amazon_books"}}
 	PluginData map[string]interface{}
+	// WordCount is the number of words in the article body. For CJK content
+	// each character is counted as one word.
+	WordCount int
+	// ReadingTime is the estimated reading time in minutes, with a minimum of 1.
+	ReadingTime int
+	// TOC is the hierarchical table of contents extracted from the article's
+	// Markdown headings. Empty when the article has no headings.
+	TOC []TOCEntry
+}
+
+// TOCEntry represents a single Markdown heading in the table of contents.
+// Entries are nested via Children to reflect heading levels.
+type TOCEntry struct {
+	// Level is the Markdown heading level (1-6).
+	Level int
+	// ID is the auto-generated heading anchor (matches the rendered HTML id attribute).
+	ID string
+	// Text is the heading's plain-text content.
+	Text string
+	// Children holds nested headings (one level deeper) that appear under this entry.
+	Children []TOCEntry
 }
 
 // LocaleRef holds a locale code and the canonical URL for a translated variant

--- a/internal/parser/toc.go
+++ b/internal/parser/toc.go
@@ -1,0 +1,109 @@
+package parser
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	goldmarkparser "github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+
+	"github.com/bmf-san/gohan/internal/model"
+)
+
+// ExtractTOC parses Markdown source and returns the hierarchical table of
+// contents built from headings. Heading IDs match those produced by the
+// Markdown converter (goldmark with AutoHeadingID enabled).
+//
+// Headings at any depth are nested under the nearest preceding heading whose
+// level is strictly smaller. When the first heading in the document is not at
+// the top level (e.g. starts with H3), it becomes a top-level TOC entry.
+func ExtractTOC(src []byte) []model.TOCEntry {
+	md := goldmark.New(
+		goldmark.WithExtensions(extension.GFM),
+		goldmark.WithParserOptions(goldmarkparser.WithAutoHeadingID()),
+	)
+	reader := text.NewReader(src)
+	doc := md.Parser().Parse(reader)
+
+	var flat []model.TOCEntry
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		h, ok := n.(*ast.Heading)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		id, _ := h.AttributeString("id")
+		idStr := ""
+		if b, ok := id.([]byte); ok {
+			idStr = string(b)
+		}
+		flat = append(flat, model.TOCEntry{
+			Level: h.Level,
+			ID:    idStr,
+			Text:  headingText(h, src),
+		})
+		return ast.WalkSkipChildren, nil
+	})
+
+	return nestEntries(flat)
+}
+
+// headingText extracts the plain-text content of a heading node.
+func headingText(h *ast.Heading, src []byte) string {
+	var buf bytes.Buffer
+	for c := h.FirstChild(); c != nil; c = c.NextSibling() {
+		if t, ok := c.(*ast.Text); ok {
+			buf.Write(t.Segment.Value(src))
+			continue
+		}
+		// Fall back to walking the segments of any other inline node.
+		_ = ast.Walk(c, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+			if t, ok := n.(*ast.Text); ok {
+				buf.Write(t.Segment.Value(src))
+			}
+			return ast.WalkContinue, nil
+		})
+	}
+	return buf.String()
+}
+
+// nestEntries converts a flat slice of TOC entries into a hierarchical tree.
+// Each entry is nested under the most recently seen entry with a smaller level.
+func nestEntries(flat []model.TOCEntry) []model.TOCEntry {
+	if len(flat) == 0 {
+		return nil
+	}
+	var roots []model.TOCEntry
+	// Stack of pointers to entries currently being filled in by deeper levels.
+	type frame struct {
+		level   int
+		parent  *[]model.TOCEntry // slice owning the entry
+		index   int               // entry index within *parent
+	}
+	var stack []frame
+	// rootsRef lets the first frame point at the roots slice itself.
+	rootsRef := &roots
+	for _, e := range flat {
+		// Pop frames until the top has a strictly smaller level.
+		for len(stack) > 0 && stack[len(stack)-1].level >= e.Level {
+			stack = stack[:len(stack)-1]
+		}
+		var owner *[]model.TOCEntry
+		if len(stack) == 0 {
+			owner = rootsRef
+		} else {
+			top := stack[len(stack)-1]
+			owner = &(*top.parent)[top.index].Children
+		}
+		*owner = append(*owner, e)
+		stack = append(stack, frame{level: e.Level, parent: owner, index: len(*owner) - 1})
+	}
+	return roots
+}

--- a/internal/parser/toc_test.go
+++ b/internal/parser/toc_test.go
@@ -1,0 +1,72 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestExtractTOC_FlatHeadings(t *testing.T) {
+	src := []byte("# A\n\ntext\n\n# B\n\nmore text\n")
+	got := ExtractTOC(src)
+	if len(got) != 2 {
+		t.Fatalf("got %d roots, want 2", len(got))
+	}
+	if got[0].Text != "A" || got[0].Level != 1 || got[0].ID != "a" {
+		t.Errorf("first entry = %+v", got[0])
+	}
+	if got[1].Text != "B" || got[1].Level != 1 || got[1].ID != "b" {
+		t.Errorf("second entry = %+v", got[1])
+	}
+}
+
+func TestExtractTOC_Nested(t *testing.T) {
+	src := []byte("# A\n\n## A1\n\n### A1a\n\n## A2\n\n# B\n")
+	got := ExtractTOC(src)
+	if len(got) != 2 {
+		t.Fatalf("got %d roots, want 2", len(got))
+	}
+	a := got[0]
+	if a.Text != "A" {
+		t.Fatalf("root[0] text = %q", a.Text)
+	}
+	if len(a.Children) != 2 {
+		t.Fatalf("A children = %d, want 2", len(a.Children))
+	}
+	if a.Children[0].Text != "A1" {
+		t.Errorf("A.children[0] = %q", a.Children[0].Text)
+	}
+	if len(a.Children[0].Children) != 1 || a.Children[0].Children[0].Text != "A1a" {
+		t.Errorf("A1 children = %+v", a.Children[0].Children)
+	}
+	if a.Children[1].Text != "A2" {
+		t.Errorf("A.children[1] = %q", a.Children[1].Text)
+	}
+}
+
+func TestExtractTOC_EmptyDocument(t *testing.T) {
+	if got := ExtractTOC([]byte("just a paragraph\n")); got != nil {
+		t.Errorf("want nil, got %+v", got)
+	}
+}
+
+func TestExtractTOC_StartsAtDeepLevel(t *testing.T) {
+	src := []byte("### deep\n\n## mid\n")
+	got := ExtractTOC(src)
+	if len(got) != 2 {
+		t.Fatalf("want 2 roots, got %d: %+v", len(got), got)
+	}
+	if got[0].Level != 3 || got[1].Level != 2 {
+		t.Errorf("levels = %d, %d", got[0].Level, got[1].Level)
+	}
+}
+
+func TestExtractTOC_InlineFormatting(t *testing.T) {
+	src := []byte("# Hello *world* `code`\n")
+	got := ExtractTOC(src)
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+	// Text content should include all inline text segments.
+	if got[0].Text == "" {
+		t.Errorf("text is empty")
+	}
+}

--- a/internal/processor/metrics.go
+++ b/internal/processor/metrics.go
@@ -1,0 +1,73 @@
+package processor
+
+import (
+	"math"
+	"unicode"
+)
+
+// readingSpeedWPM is the assumed reading speed in words per minute, used for
+// reading-time estimates. Each CJK character is treated as one "word" for the
+// purposes of this calculation.
+const readingSpeedWPM = 250
+
+// countWords returns the number of words in src. ASCII/Latin words are
+// counted as whitespace-separated tokens; each CJK character contributes one
+// to the count as well. Markdown syntax characters are not stripped; the
+// resulting count is approximate but stable.
+func countWords(src string) int {
+	var count int
+	inWord := false
+	for _, r := range src {
+		if isCJK(r) {
+			if inWord {
+				count++
+				inWord = false
+			}
+			count++
+			continue
+		}
+		if unicode.IsSpace(r) {
+			if inWord {
+				count++
+				inWord = false
+			}
+			continue
+		}
+		inWord = true
+	}
+	if inWord {
+		count++
+	}
+	return count
+}
+
+// isCJK reports whether r is a CJK ideograph, hiragana, katakana, or hangul
+// character. Punctuation and full-width Latin are not included.
+func isCJK(r rune) bool {
+	switch {
+	case r >= 0x4E00 && r <= 0x9FFF: // CJK Unified Ideographs
+		return true
+	case r >= 0x3400 && r <= 0x4DBF: // CJK Extension A
+		return true
+	case r >= 0x3040 && r <= 0x309F: // Hiragana
+		return true
+	case r >= 0x30A0 && r <= 0x30FF: // Katakana
+		return true
+	case r >= 0xAC00 && r <= 0xD7A3: // Hangul Syllables
+		return true
+	}
+	return false
+}
+
+// readingTimeMinutes returns the estimated reading time in minutes for the
+// given word count. The result is always at least 1 when the count is positive.
+func readingTimeMinutes(words int) int {
+	if words <= 0 {
+		return 0
+	}
+	m := int(math.Ceil(float64(words) / float64(readingSpeedWPM)))
+	if m < 1 {
+		m = 1
+	}
+	return m
+}

--- a/internal/processor/metrics_test.go
+++ b/internal/processor/metrics_test.go
@@ -1,0 +1,52 @@
+package processor
+
+import "testing"
+
+func TestCountWords_English(t *testing.T) {
+	got := countWords("Hello world foo bar")
+	if got != 4 {
+		t.Errorf("got %d, want 4", got)
+	}
+}
+
+func TestCountWords_Japanese(t *testing.T) {
+	// 5 hiragana characters → 5 words.
+	got := countWords("こんにちは")
+	if got != 5 {
+		t.Errorf("got %d, want 5", got)
+	}
+}
+
+func TestCountWords_Mixed(t *testing.T) {
+	// "Hello 世界" → 1 English word + 2 CJK chars = 3.
+	got := countWords("Hello 世界")
+	if got != 3 {
+		t.Errorf("got %d, want 3", got)
+	}
+}
+
+func TestCountWords_Empty(t *testing.T) {
+	if got := countWords(""); got != 0 {
+		t.Errorf("got %d, want 0", got)
+	}
+}
+
+func TestReadingTimeMinutes(t *testing.T) {
+	cases := []struct {
+		words int
+		want  int
+	}{
+		{0, 0},
+		{1, 1},
+		{249, 1},
+		{250, 1},
+		{251, 2},
+		{500, 2},
+		{501, 3},
+	}
+	for _, c := range cases {
+		if got := readingTimeMinutes(c.words); got != c.want {
+			t.Errorf("readingTimeMinutes(%d) = %d, want %d", c.words, got, c.want)
+		}
+	}
+}

--- a/internal/processor/site.go
+++ b/internal/processor/site.go
@@ -37,6 +37,7 @@ func (p *SiteProcessor) Process(articles []*model.Article, cfg model.Config) ([]
 		if err != nil {
 			return nil, fmt.Errorf("processor: render %s: %w", a.FilePath, err)
 		}
+		words := countWords(a.RawContent)
 		processed := &model.ProcessedArticle{
 			Article:     *a,
 			HTMLContent: html,
@@ -45,6 +46,9 @@ func (p *SiteProcessor) Process(articles []*model.Article, cfg model.Config) ([]
 			ContentPath: computeContentPath(a, cfg),
 			Locale:      detectLocale(a, cfg),
 			URL:         computeArticleURL(a, cfg),
+			WordCount:   words,
+			ReadingTime: readingTimeMinutes(words),
+			TOC:         parser.ExtractTOC([]byte(a.RawContent)),
 		}
 		result = append(result, processed)
 	}


### PR DESCRIPTION
## Summary

Compute and expose per-article table of contents (TOC), word count, and reading time (in minutes) on `ProcessedArticle`. Templates can now reference `{{ .TOC }}`, `{{ .WordCount }}`, and `{{ .ReadingTime }}`.

## Changes

- Add fields to `ProcessedArticle`:
  - `WordCount int` — CJK-aware (1 CJK character = 1 word)
  - `ReadingTime int` — 250 WPM, minimum 1 minute
  - `TOC []TOCEntry` — hierarchical tree built from Markdown headings
- Add `model.TOCEntry` (`Level` / `ID` / `Text` / `Children`)
- `internal/parser/toc.go`: extract headings from the goldmark AST using the same `WithAutoHeadingID` algorithm, so the resulting IDs match existing rendered HTML anchors exactly
- `internal/processor/metrics.go`: `countWords` / `readingTimeMinutes`
- Populate the new fields from `SiteProcessor.Process`
- Unit tests added (flat / nested / empty / starting at a deep heading / inline-formatted heading text / EN / JA / mixed word counts / reading-time edge cases)

## Out of scope

- Template integration is left out of this PR. Theme template updates under `docs/themes/` are deferred so consumers can decide when to surface the new fields.

## Test

`go test ./...` all green