### PR TITLE
feat(build): support scheduled posts via --future flag

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -27,6 +27,7 @@ func runBuild(args []string) error {
 	dryRun := fs.Bool("dry-run", false, "simulate build without writing files")
 	logFmt := fs.String("log-format", "text", "log format: text or json")
 	draft := fs.Bool("draft", false, "include draft articles in the build")
+	future := fs.Bool("future", false, "include articles with a future date in the build")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -116,6 +117,18 @@ func runBuild(args []string) error {
 		filtered := articles[:0]
 		for _, a := range articles {
 			if !a.FrontMatter.Draft {
+				filtered = append(filtered, a)
+			}
+		}
+		articles = filtered
+	}
+
+	// Filter scheduled (future-dated) articles unless --future flag is set.
+	if !*future {
+		now := time.Now()
+		filtered := articles[:0]
+		for _, a := range articles {
+			if a.FrontMatter.Date.IsZero() || !a.FrontMatter.Date.After(now) {
 				filtered = append(filtered, a)
 			}
 		}

--- a/cmd/gohan/build_test.go
+++ b/cmd/gohan/build_test.go
@@ -131,3 +131,52 @@ func TestRunBuild_DraftArticlesExcludedByDefault(t *testing.T) {
 		t.Fatalf("build with draft article: %v", err)
 	}
 }
+
+// TestRunBuild_FutureFlagAccepted verifies the --future CLI flag parses.
+func TestRunBuild_FutureFlagAccepted(t *testing.T) {
+	dir := t.TempDir()
+	cfg := []byte("site:\n  title: Test\n  base_url: http://localhost\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), cfg, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	err := runBuild([]string{
+		"--config=" + filepath.Join(dir, "config.yaml"),
+		"--future",
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("--future --dry-run: %v", err)
+	}
+}
+
+// TestRunBuild_ScheduledArticlesExcludedByDefault verifies that articles with a
+// future date are skipped unless --future is set.
+func TestRunBuild_ScheduledArticlesExcludedByDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfg := []byte("site:\n  title: Test\n  base_url: http://localhost\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), cfg, 0644); err != nil {
+		t.Fatal(err)
+	}
+	contentDir := filepath.Join(dir, "content")
+	if err := os.MkdirAll(contentDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	future := []byte("---\ntitle: Future Post\ndate: 2999-01-01T00:00:00Z\n---\nBody.\n")
+	pub := []byte("---\ntitle: Published Post\ndate: 2024-01-01T00:00:00Z\n---\nBody.\n")
+	if err := os.WriteFile(filepath.Join(contentDir, "future.md"), future, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(contentDir, "published.md"), pub, 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := runBuild([]string{
+		"--config=" + filepath.Join(dir, "config.yaml"),
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("build with future article: %v", err)
+	}
+}

--- a/docs/content/en/guide/cli.md
+++ b/docs/content/en/guide/cli.md
@@ -14,6 +14,8 @@ translation_key: "cli"
 | `gohan build` | Build the site (incremental by default) |
 | `gohan build --full` | Force a full rebuild |
 | `gohan build --dry-run` | Simulate a build without writing files |
+| `gohan build --draft` | Include draft articles (`draft: true`) in the build |
+| `gohan build --future` | Include articles whose `date` is in the future |
 | `gohan new [--type=post] [--title=<t>] <slug>` | Create a new post skeleton |
 | `gohan new --type=page [--title=<t>] <slug>` | Create a new page skeleton |
 | `gohan serve` | Start the live-reload development server |
@@ -33,6 +35,8 @@ By default, only files that have changed since the last build are regenerated (i
 |---|---|
 | `--full` | Skip diff detection and regenerate all pages |
 | `--dry-run` | Print what would be generated without writing any files |
+| `--draft` | Include articles with `draft: true` in their Front Matter. By default drafts are excluded. |
+| `--future` | Include articles whose `date` is later than the current time. By default future-dated articles are excluded, allowing them to be "scheduled" by setting a future `date`. |
 
 ---
 

--- a/docs/content/ja/guide/cli.md
+++ b/docs/content/ja/guide/cli.md
@@ -14,6 +14,8 @@ translation_key: "cli"
 | `gohan build` | サイトをビルド（デフォルトで差分ビルド） |
 | `gohan build --full` | フルビルドを強制実行 |
 | `gohan build --dry-run` | ファイルを書き出さずにビルドをシミュレート |
+| `gohan build --draft` | `draft: true` の記事をビルドに含める |
+| `gohan build --future` | `date` が未来の記事をビルドに含める |
 | `gohan new [--type=post] [--title=<t>] <slug>` | 新規記事スケルトンを作成 |
 | `gohan new --type=page [--title=<t>] <slug>` | 新規ページスケルトンを作成 |
 | `gohan serve` | ライブリロード付き開発サーバーを起動 |
@@ -33,6 +35,8 @@ translation_key: "cli"
 |---|---|
 | `--full` | 差分検出をスキップしてすべてのページを再生成 |
 | `--dry-run` | ファイルを書き出さずに生成対象を表示 |
+| `--draft` | Front Matter に `draft: true` を持つ記事をビルドに含める。デフォルトではドラフトは除外される。 |
+| `--future` | `date` が現在時刻よりも未来の記事をビルドに含める。デフォルトでは未来日付の記事は除外されるため、`date` を未来に設定すれば記事を「予約公開」できる。 |
 
 ---
 


### PR DESCRIPTION
## Summary

Add a `--future` flag to `gohan build` that, by default, excludes future-dated articles. This lets you commit posts ahead of time and have a scheduled rebuild publish them automatically (mirroring how `--draft` works today).

## Changes

- Add `gohan build --future` (future-dated articles are excluded by default)
- Apply the filter right after the existing `--draft` filter
- Existing behaviour: setting `date: 2999-01-01` excludes the article from normal builds; re-running CI at a chosen time publishes it
- Articles with no `date` set (zero value) are not filtered (backwards compatible)
- Update EN/JA CLI docs
- Unit tests added (flag is accepted; a build that includes a future-dated article succeeds)

## Test

`go test ./...` all green