### PR TITLE
feat(build): add --stats and --explain build observability flags

### DIFF
--- a/cmd/gohan/build.go
+++ b/cmd/gohan/build.go
@@ -28,12 +28,15 @@ func runBuild(args []string) error {
 	logFmt := fs.String("log-format", "text", "log format: text or json")
 	draft := fs.Bool("draft", false, "include draft articles in the build")
 	future := fs.Bool("future", false, "include articles with a future date in the build")
+	stats := fs.Bool("stats", false, "print per-phase timing and file counts after the build")
+	explain := fs.Bool("explain", false, "print which files triggered a rebuild and why")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	_ = logFmt // reserved for structured logging
 
 	start := time.Now()
+	phases := newPhaseTimer()
 
 	// Determine project root from config file location.
 	cfgAbs, err := filepath.Abs(*configPath)
@@ -107,8 +110,12 @@ func runBuild(args []string) error {
 	if cfg.Build.StaticDir != "" {
 		cfg.Build.StaticDir = filepath.Join(rootDir, cfg.Build.StaticDir)
 	}
-	articles, err := p.ParseAll(contentDir)
-	if err != nil {
+	var articles []*model.Article
+	if err := phases.Phase("parse", func() error {
+		var perr error
+		articles, perr = p.ParseAll(contentDir)
+		return perr
+	}); err != nil {
 		return fmt.Errorf("parse content: %w", err)
 	}
 
@@ -139,16 +146,23 @@ func runBuild(args []string) error {
 	var changeSet *model.ChangeSet
 	if !forceFullBuild {
 		engine := diff.NewGitDiffEngine(contentDir)
-		changeSet, err = engine.Detect(manifest)
-		if err != nil {
+		if err := phases.Phase("diff", func() error {
+			var derr error
+			changeSet, derr = engine.Detect(manifest)
+			return derr
+		}); err != nil {
 			return fmt.Errorf("detect changes: %w", err)
 		}
 	}
 
 	// Process articles.
 	proc := processor.NewSiteProcessor()
-	processed, err := proc.Process(articles, *cfg)
-	if err != nil {
+	var processed []*model.ProcessedArticle
+	if err := phases.Phase("process", func() error {
+		var perr error
+		processed, perr = proc.Process(articles, *cfg)
+		return perr
+	}); err != nil {
 		return fmt.Errorf("process articles: %w", err)
 	}
 
@@ -201,19 +215,28 @@ func runBuild(args []string) error {
 		Categories: taxo.Categories,
 	}
 
-	// Run plugins.
-	if err := plugin.DefaultRegistry().Enrich(site); err != nil {
-		return fmt.Errorf("plugin enrichment: %w", err)
-	}
-
-	// Run site-level plugins (generate virtual pages).
-	if err := plugin.DefaultRegistry().EnrichVirtual(site); err != nil {
-		return fmt.Errorf("plugin virtual pages: %w", err)
+	// Run plugins (article enrichment + virtual page generation).
+	if err := phases.Phase("plugins", func() error {
+		if err := plugin.DefaultRegistry().Enrich(site); err != nil {
+			return fmt.Errorf("plugin enrichment: %w", err)
+		}
+		if err := plugin.DefaultRegistry().EnrichVirtual(site); err != nil {
+			return fmt.Errorf("plugin virtual pages: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	if *dryRun {
 		elapsed := time.Since(start)
 		fmt.Printf("dry-run: %d articles, %s\n", len(processed), elapsed.Round(time.Millisecond))
+		if *explain {
+			writeExplain(os.Stdout, forceFullBuild, explainFullReason(*full, configHashErr, manifest == nil), changeSet)
+		}
+		if *stats {
+			phases.writeStats(os.Stdout, elapsed)
+		}
 		return nil
 	}
 
@@ -225,35 +248,63 @@ func runBuild(args []string) error {
 		return fmt.Errorf("load templates: %w", loadErr)
 	}
 	gen := generator.NewHTMLGenerator(outDir, tmpl, *cfg)
-	if err := gen.Generate(site, changeSet); err != nil {
+	if err := phases.Phase("render", func() error {
+		return gen.Generate(site, changeSet)
+	}); err != nil {
 		return fmt.Errorf("generate HTML: %w", err)
 	}
 
 	// Sitemap + feeds.
-	if err := generator.GenerateSitemap(outDir, cfg.Site.BaseURL, processed, site.VirtualPages, generator.TaxonomyURLs(site, *cfg), *cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "warn: sitemap: %v\n", err)
-	}
-	if err := generator.GenerateFeeds(outDir, cfg.Site.BaseURL, cfg.Site.Title, processed, *cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "warn: feeds: %v\n", err)
-	}
+	_ = phases.Phase("feeds", func() error {
+		if err := generator.GenerateSitemap(outDir, cfg.Site.BaseURL, processed, site.VirtualPages, generator.TaxonomyURLs(site, *cfg), *cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "warn: sitemap: %v\n", err)
+		}
+		if err := generator.GenerateFeeds(outDir, cfg.Site.BaseURL, cfg.Site.Title, processed, *cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "warn: feeds: %v\n", err)
+		}
+		return nil
+	})
 
 	// Update manifest.
-	newManifest := diff.NewManifest(configHash)
-	hashEngine := diff.NewGitDiffEngine(contentDir)
-	for _, a := range articles {
-		rel, relErr := filepath.Rel(contentDir, a.FilePath)
-		if relErr != nil {
-			continue
+	_ = phases.Phase("manifest", func() error {
+		newManifest := diff.NewManifest(configHash)
+		hashEngine := diff.NewGitDiffEngine(contentDir)
+		for _, a := range articles {
+			rel, relErr := filepath.Rel(contentDir, a.FilePath)
+			if relErr != nil {
+				continue
+			}
+			if h, herr := hashEngine.Hash(a.FilePath); herr == nil {
+				newManifest.FileHashes[rel] = h
+			}
 		}
-		if h, herr := hashEngine.Hash(a.FilePath); herr == nil {
-			newManifest.FileHashes[rel] = h
+		if err := diff.WriteManifest(cacheDir, newManifest); err != nil {
+			fmt.Fprintf(os.Stderr, "warn: write manifest: %v\n", err)
 		}
-	}
-	if err := diff.WriteManifest(cacheDir, newManifest); err != nil {
-		fmt.Fprintf(os.Stderr, "warn: write manifest: %v\n", err)
-	}
+		return nil
+	})
 
 	elapsed := time.Since(start)
 	fmt.Printf("build: %d articles, 0 errors, %s\n", len(processed), elapsed.Round(time.Millisecond))
+	if *explain {
+		writeExplain(os.Stdout, forceFullBuild, explainFullReason(*full, configHashErr, manifest == nil), changeSet)
+	}
+	if *stats {
+		phases.writeStats(os.Stdout, elapsed)
+	}
 	return nil
+}
+
+// explainFullReason returns a human-readable reason why a full build was
+// performed. It is used by writeExplain when forceFullBuild is true.
+func explainFullReason(fullFlag bool, configHashErr error, manifestMissing bool) string {
+	switch {
+	case fullFlag:
+		return "--full flag"
+	case configHashErr != nil:
+		return fmt.Sprintf("config hash unavailable: %v", configHashErr)
+	case manifestMissing:
+		return "no build manifest (first build or config changed)"
+	}
+	return ""
 }

--- a/cmd/gohan/build_test.go
+++ b/cmd/gohan/build_test.go
@@ -180,3 +180,41 @@ func TestRunBuild_ScheduledArticlesExcludedByDefault(t *testing.T) {
 		t.Fatalf("build with future article: %v", err)
 	}
 }
+
+func TestRunBuild_StatsFlagAccepted(t *testing.T) {
+dir := t.TempDir()
+cfg := []byte("site:\n  title: Test\n  base_url: http://localhost\n")
+if err := os.WriteFile(filepath.Join(dir, "config.yaml"), cfg, 0644); err != nil {
+t.Fatal(err)
+}
+if err := os.MkdirAll(filepath.Join(dir, "content"), 0755); err != nil {
+t.Fatal(err)
+}
+err := runBuild([]string{
+"--config=" + filepath.Join(dir, "config.yaml"),
+"--stats",
+"--dry-run",
+})
+if err != nil {
+t.Fatalf("--stats --dry-run: %v", err)
+}
+}
+
+func TestRunBuild_ExplainFlagAccepted(t *testing.T) {
+dir := t.TempDir()
+cfg := []byte("site:\n  title: Test\n  base_url: http://localhost\n")
+if err := os.WriteFile(filepath.Join(dir, "config.yaml"), cfg, 0644); err != nil {
+t.Fatal(err)
+}
+if err := os.MkdirAll(filepath.Join(dir, "content"), 0755); err != nil {
+t.Fatal(err)
+}
+err := runBuild([]string{
+"--config=" + filepath.Join(dir, "config.yaml"),
+"--explain",
+"--dry-run",
+})
+if err != nil {
+t.Fatalf("--explain --dry-run: %v", err)
+}
+}

--- a/cmd/gohan/stats.go
+++ b/cmd/gohan/stats.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/bmf-san/gohan/internal/model"
+)
+
+// phaseTimer accumulates wall-clock durations for named build phases. It is
+// safe to call Phase repeatedly for the same name; durations are summed.
+type phaseTimer struct {
+	order    []string
+	duration map[string]time.Duration
+}
+
+func newPhaseTimer() *phaseTimer {
+	return &phaseTimer{duration: make(map[string]time.Duration)}
+}
+
+// Phase runs fn while recording its wall-clock duration under name. The first
+// time a name is seen its order is remembered so the final report is stable.
+func (p *phaseTimer) Phase(name string, fn func() error) error {
+	if _, seen := p.duration[name]; !seen {
+		p.order = append(p.order, name)
+	}
+	t0 := time.Now()
+	err := fn()
+	p.duration[name] += time.Since(t0)
+	return err
+}
+
+// writeStats writes a human-readable phase-timing report to w. Phases are
+// printed in the order they were first observed, followed by the total.
+func (p *phaseTimer) writeStats(w io.Writer, total time.Duration) {
+	fmt.Fprintln(w, "stats:")
+	for _, name := range p.order {
+		fmt.Fprintf(w, "  %-12s %v\n", name+":", p.duration[name].Round(time.Microsecond))
+	}
+	fmt.Fprintf(w, "  %-12s %v\n", "total:", total.Round(time.Millisecond))
+}
+
+// writeExplain reports the reason for the current build's scope of work to w.
+// `forceFull` indicates that a full rebuild was forced (CLI flag, missing
+// manifest, or config hash change). `changeSet` lists incremental changes
+// when a partial rebuild was performed.
+func writeExplain(w io.Writer, forceFull bool, fullReason string, changeSet *model.ChangeSet) {
+	fmt.Fprintln(w, "explain:")
+	if forceFull {
+		if fullReason == "" {
+			fullReason = "full build forced"
+		}
+		fmt.Fprintf(w, "  full build: %s\n", fullReason)
+		return
+	}
+	if changeSet == nil {
+		fmt.Fprintln(w, "  no change set available")
+		return
+	}
+	if len(changeSet.AddedFiles) == 0 && len(changeSet.ModifiedFiles) == 0 && len(changeSet.DeletedFiles) == 0 {
+		fmt.Fprintln(w, "  no content changes detected")
+		return
+	}
+	printList(w, "added", changeSet.AddedFiles)
+	printList(w, "modified", changeSet.ModifiedFiles)
+	printList(w, "deleted", changeSet.DeletedFiles)
+}
+
+func printList(w io.Writer, label string, files []string) {
+	if len(files) == 0 {
+		return
+	}
+	sorted := append([]string(nil), files...)
+	sort.Strings(sorted)
+	fmt.Fprintf(w, "  %s (%d):\n", label, len(sorted))
+	for _, f := range sorted {
+		fmt.Fprintf(w, "    %s\n", f)
+	}
+}

--- a/docs/content/en/guide/cli.md
+++ b/docs/content/en/guide/cli.md
@@ -16,6 +16,8 @@ translation_key: "cli"
 | `gohan build --dry-run` | Simulate a build without writing files |
 | `gohan build --draft` | Include draft articles (`draft: true`) in the build |
 | `gohan build --future` | Include articles whose `date` is in the future |
+| `gohan build --stats` | Print per-phase timing and counts after the build |
+| `gohan build --explain` | Print which files triggered a rebuild and why |
 | `gohan new [--type=post] [--title=<t>] <slug>` | Create a new post skeleton |
 | `gohan new --type=page [--title=<t>] <slug>` | Create a new page skeleton |
 | `gohan serve` | Start the live-reload development server |
@@ -37,6 +39,8 @@ By default, only files that have changed since the last build are regenerated (i
 | `--dry-run` | Print what would be generated without writing any files |
 | `--draft` | Include articles with `draft: true` in their Front Matter. By default drafts are excluded. |
 | `--future` | Include articles whose `date` is later than the current time. By default future-dated articles are excluded, allowing them to be "scheduled" by setting a future `date`. |
+| `--stats` | Print a per-phase timing report (parse / diff / process / plugins / render / feeds / manifest) and total wall-clock time. |
+| `--explain` | Print which content files triggered the rebuild. For a full rebuild it also prints the reason (e.g. `--full` flag, config hash change, missing manifest). |
 
 ---
 

--- a/docs/content/ja/guide/cli.md
+++ b/docs/content/ja/guide/cli.md
@@ -16,6 +16,8 @@ translation_key: "cli"
 | `gohan build --dry-run` | ファイルを書き出さずにビルドをシミュレート |
 | `gohan build --draft` | `draft: true` の記事をビルドに含める |
 | `gohan build --future` | `date` が未来の記事をビルドに含める |
+| `gohan build --stats` | ビルド後にフェーズごとの所要時間と件数を表示 |
+| `gohan build --explain` | 再ビルド対象のファイルとその理由を表示 |
 | `gohan new [--type=post] [--title=<t>] <slug>` | 新規記事スケルトンを作成 |
 | `gohan new --type=page [--title=<t>] <slug>` | 新規ページスケルトンを作成 |
 | `gohan serve` | ライブリロード付き開発サーバーを起動 |
@@ -37,6 +39,8 @@ translation_key: "cli"
 | `--dry-run` | ファイルを書き出さずに生成対象を表示 |
 | `--draft` | Front Matter に `draft: true` を持つ記事をビルドに含める。デフォルトではドラフトは除外される。 |
 | `--future` | `date` が現在時刻よりも未来の記事をビルドに含める。デフォルトでは未来日付の記事は除外されるため、`date` を未来に設定すれば記事を「予約公開」できる。 |
+| `--stats` | フェーズごと（parse / diff / process / plugins / render / feeds / manifest）の所要時間と合計時間をビルド完了後に表示する。 |
+| `--explain` | 再ビルドのトリガーとなったコンテンツファイルを表示する。フルビルドの場合は理由（`--full` フラグ、設定ハッシュの変化、マニフェスト未生成など）も併せて表示する。 |
 
 ---
 


### PR DESCRIPTION
## Summary

Add two flags to `gohan build` for build observability.

- **`--stats`**: prints per-phase timing and total elapsed time after the build.
  - Measured phases: `parse` / `diff` / `process` / `plugins` / `render` / `feeds` / `manifest`
- **`--explain`**: prints which files were processed in this build and why.
  - Incremental build: lists `added` / `modified` / `deleted` files
  - Full build: prints the reason (`--full` flag / config-hash unavailable / no manifest yet)

Both flags also work with `--dry-run`.

## Implementation

- Add `cmd/gohan/stats.go` (`phaseTimer` plus `writeStats` / `writeExplain` helpers).
- Wrap each phase in `cmd/gohan/build.go` with `phases.Phase(name, fn)`. No behaviour change to existing paths.
- Update EN/JA CLI docs.
- Two flag-parsing unit tests added.

## Test

`go test ./...` all green