### PR TITLE
feat(cli): add 'gohan init' to scaffold new projects

### DIFF
--- a/cmd/gohan/init.go
+++ b/cmd/gohan/init.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// runInit scaffolds a new gohan project directory containing a minimal
+// `config.yaml`, the standard content folders, and starter archetypes.
+//
+// Usage:
+//
+//	gohan init [--force] [<dir>]
+//
+// When <dir> is omitted the current working directory is used. The command
+// refuses to write into a non-empty directory unless --force is given.
+func runInit(args []string) error {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	force := fs.Bool("force", false, "allow scaffolding into a non-empty directory")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	target := "."
+	if fs.NArg() > 0 {
+		target = fs.Arg(0)
+	}
+
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return fmt.Errorf("resolve target dir: %w", err)
+	}
+	if err := os.MkdirAll(abs, 0o755); err != nil {
+		return fmt.Errorf("create target dir: %w", err)
+	}
+
+	if !*force {
+		entries, readErr := os.ReadDir(abs)
+		if readErr != nil {
+			return fmt.Errorf("read target dir: %w", readErr)
+		}
+		if len(entries) > 0 {
+			return fmt.Errorf("target dir %q is not empty; pass --force to scaffold anyway", target)
+		}
+	}
+
+	files := map[string]string{
+		"config.yaml":            initConfigYAML,
+		"content/posts/.gitkeep": "",
+		"content/pages/.gitkeep": "",
+		"archetypes/post.md":     initArchetypePost,
+		"archetypes/page.md":     initArchetypePage,
+		"README.md":              initReadme,
+	}
+
+	created := make([]string, 0, len(files))
+	for rel, body := range files {
+		path := filepath.Join(abs, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("create %s: %w", filepath.Dir(rel), err)
+		}
+		// O_EXCL prevents accidentally clobbering existing files when --force is set.
+		f, openErr := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if openErr != nil {
+			if os.IsExist(openErr) {
+				continue
+			}
+			return fmt.Errorf("create %s: %w", rel, openErr)
+		}
+		if _, werr := io.WriteString(f, body); werr != nil {
+			_ = f.Close()
+			return fmt.Errorf("write %s: %w", rel, werr)
+		}
+		if cerr := f.Close(); cerr != nil {
+			return fmt.Errorf("close %s: %w", rel, cerr)
+		}
+		created = append(created, rel)
+	}
+
+	fmt.Printf("initialised gohan project at %s\n", abs)
+	for _, rel := range created {
+		fmt.Printf("  + %s\n", rel)
+	}
+	fmt.Println("next steps:")
+	fmt.Println("  1. install a theme into themes/<name>/ (see https://github.com/bmf-san/gohan)")
+	fmt.Println("  2. set theme.dir in config.yaml")
+	fmt.Println("  3. run `gohan new my-first-post`")
+	fmt.Println("  4. run `gohan build`")
+	return nil
+}
+
+const initConfigYAML = `site:
+  title: My Gohan Site
+  description: A new site built with gohan.
+  base_url: http://localhost:8080
+  language: en
+
+build:
+  content_dir: content
+  output_dir: public
+  assets_dir: assets
+  static_dir: static
+
+theme:
+  dir: themes/default
+
+i18n:
+  default_locale: en
+  locales: [en]
+`
+
+const initArchetypePost = `---
+title: {{ .Title }}
+date: {{ .Date }}
+draft: true
+tags: []
+categories: []
+---
+
+`
+
+const initArchetypePage = `---
+title: {{ .Title }}
+date: {{ .Date }}
+draft: true
+---
+
+`
+
+const initReadme = `# My Gohan Site
+
+This site was scaffolded by ` + "`gohan init`" + `.
+
+## Quick start
+
+1. Install a theme into ` + "`themes/<name>/`" + ` and update ` + "`theme.dir`" + ` in ` + "`config.yaml`" + `.
+2. Create a new post: ` + "`gohan new my-first-post`" + `.
+3. Build the site: ` + "`gohan build`" + `.
+4. Preview locally: ` + "`gohan serve`" + `.
+
+See https://github.com/bmf-san/gohan for documentation.
+`

--- a/cmd/gohan/init_test.go
+++ b/cmd/gohan/init_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunInit_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := runInit([]string{dir}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	mustExist := []string{
+		"config.yaml",
+		"content/posts/.gitkeep",
+		"content/pages/.gitkeep",
+		"archetypes/post.md",
+		"archetypes/page.md",
+		"README.md",
+	}
+	for _, rel := range mustExist {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Errorf("expected %s to exist: %v", rel, err)
+		}
+	}
+}
+
+func TestRunInit_NonEmptyDirRefused(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "other"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := runInit([]string{dir})
+	if err == nil {
+		t.Fatal("expected error for non-empty dir")
+	}
+}
+
+func TestRunInit_ForceAllowsNonEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "other"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runInit([]string{"--force", dir}); err != nil {
+		t.Fatalf("init --force: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.yaml")); err != nil {
+		t.Errorf("config.yaml missing after --force: %v", err)
+	}
+	// Pre-existing file is preserved.
+	if _, err := os.Stat(filepath.Join(dir, "other")); err != nil {
+		t.Errorf("pre-existing file removed: %v", err)
+	}
+}
+
+func TestRunInit_ForceDoesNotClobberExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfg, []byte("existing: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runInit([]string{"--force", dir}); err != nil {
+		t.Fatalf("init --force: %v", err)
+	}
+	data, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "existing: true\n" {
+		t.Errorf("config.yaml was overwritten: %q", string(data))
+	}
+}

--- a/cmd/gohan/main.go
+++ b/cmd/gohan/main.go
@@ -25,6 +25,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
+	case "init":
+		if err := runInit(args); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 	case "new":
 		if err := runNew(args); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -49,6 +54,7 @@ func printUsage() {
 
 Commands:
   build    Build the site
+  init     Scaffold a new gohan project in a directory
   new      Create a new article or page
   serve    Start the development server
   version  Print version information

--- a/docs/content/en/guide/cli.md
+++ b/docs/content/en/guide/cli.md
@@ -18,6 +18,7 @@ translation_key: "cli"
 | `gohan build --future` | Include articles whose `date` is in the future |
 | `gohan build --stats` | Print per-phase timing and counts after the build |
 | `gohan build --explain` | Print which files triggered a rebuild and why |
+| `gohan init [--force] [<dir>]` | Scaffold a new gohan project (config + content + archetypes) |
 | `gohan new [--type=post] [--title=<t>] <slug>` | Create a new post skeleton |
 | `gohan new --type=page [--title=<t>] <slug>` | Create a new page skeleton |
 | `gohan serve` | Start the live-reload development server |
@@ -41,6 +42,28 @@ By default, only files that have changed since the last build are regenerated (i
 | `--future` | Include articles whose `date` is later than the current time. By default future-dated articles are excluded, allowing them to be "scheduled" by setting a future `date`. |
 | `--stats` | Print a per-phase timing report (parse / diff / process / plugins / render / feeds / manifest) and total wall-clock time. |
 | `--explain` | Print which content files triggered the rebuild. For a full rebuild it also prints the reason (e.g. `--full` flag, config hash change, missing manifest). |
+
+---
+
+---
+
+## `gohan init`
+
+Scaffolds a new gohan project under the given directory (or the current directory if omitted).
+
+**Usage**
+
+```sh
+gohan init [--force] [<dir>]
+```
+
+Generates a minimal `config.yaml`, the standard `content/` and `archetypes/` folders, and a starter `README.md`. The command refuses to write into a non-empty directory unless `--force` is given. Existing files are never overwritten — `--force` only allows writing alongside them.
+
+**Flags**
+
+| Flag | Description |
+|---|---|
+| `--force` | Allow scaffolding into a non-empty directory. Existing files are preserved. |
 
 ---
 

--- a/docs/content/ja/guide/cli.md
+++ b/docs/content/ja/guide/cli.md
@@ -18,6 +18,7 @@ translation_key: "cli"
 | `gohan build --future` | `date` が未来の記事をビルドに含める |
 | `gohan build --stats` | ビルド後にフェーズごとの所要時間と件数を表示 |
 | `gohan build --explain` | 再ビルド対象のファイルとその理由を表示 |
+| `gohan init [--force] [<dir>]` | 新規プロジェクト（config / content / archetypes）をスキャフォールド |
 | `gohan new [--type=post] [--title=<t>] <slug>` | 新規記事スケルトンを作成 |
 | `gohan new --type=page [--title=<t>] <slug>` | 新規ページスケルトンを作成 |
 | `gohan serve` | ライブリロード付き開発サーバーを起動 |
@@ -41,6 +42,28 @@ translation_key: "cli"
 | `--future` | `date` が現在時刻よりも未来の記事をビルドに含める。デフォルトでは未来日付の記事は除外されるため、`date` を未来に設定すれば記事を「予約公開」できる。 |
 | `--stats` | フェーズごと（parse / diff / process / plugins / render / feeds / manifest）の所要時間と合計時間をビルド完了後に表示する。 |
 | `--explain` | 再ビルドのトリガーとなったコンテンツファイルを表示する。フルビルドの場合は理由（`--full` フラグ、設定ハッシュの変化、マニフェスト未生成など）も併せて表示する。 |
+
+---
+
+---
+
+## `gohan init`
+
+指定したディレクトリ（省略時はカレントディレクトリ）に新規 gohan プロジェクトをスキャフォールドします。
+
+**使い方**
+
+```sh
+gohan init [--force] [<dir>]
+```
+
+最小構成の `config.yaml`、標準の `content/` および `archetypes/` ディレクトリ、スタータ用の `README.md` を生成します。対象ディレクトリが空でない場合は `--force` を付けない限り処理を中止します。既存ファイルは上書きされません（`--force` は新規ファイルの追加のみを許可します）。
+
+**フラグ**
+
+| フラグ | 説明 |
+|---|---|
+| `--force` | 空でないディレクトリへのスキャフォールドを許可する。既存ファイルは保持される。 |
 
 ---
 


### PR DESCRIPTION
## Summary

Add `gohan init` to scaffold a new project in a single command.

## Behaviour

```sh
gohan init [--force] [<dir>]
```

- `<dir>` defaults to the current working directory.
- Writing into a non-empty directory requires `--force`.
- Even with `--force`, existing files are never overwritten (`O_CREATE|O_EXCL`).
- Generated files:
  - `config.yaml` — minimal site configuration
  - `content/posts/.gitkeep` / `content/pages/.gitkeep`
  - `archetypes/post.md` / `archetypes/page.md`
  - `README.md`
- Prints a "next steps" hint to stdout on completion.

## Test

- 4 unit tests added (empty directory / non-empty directory refused / `--force` accepted / pre-existing file not clobbered).
- `go test ./...` all green