### PR TITLE
ci: add benchmark workflow and parser ParseAll benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,42 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/benchmark.yml'
+  workflow_dispatch:
+
+jobs:
+  bench:
+    name: Go Benchmarks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      # Run benchmarks without running unit tests (-run=^$). Use a short
+      # benchtime so PRs get quick signal without dominating CI minutes.
+      - name: Run benchmarks
+        run: |
+          go test -run=^$ -bench=. -benchmem -benchtime=1x -timeout 5m ./... | tee bench.txt
+
+      - name: Upload benchmark output
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: bench.txt
+          retention-days: 30

--- a/internal/parser/frontmatter_bench_test.go
+++ b/internal/parser/frontmatter_bench_test.go
@@ -1,0 +1,49 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// BenchmarkFileParser_ParseAll measures the cost of parsing a content tree of
+// the given size. Tracked in CI to detect regressions in the hot parse path.
+func BenchmarkFileParser_ParseAll(b *testing.B) {
+	sizes := []int{10, 100, 1000}
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("articles=%d", n), func(b *testing.B) {
+			dir := b.TempDir()
+			seedBenchmarkArticles(b, dir, n)
+			p := NewFileParser()
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				articles, err := p.ParseAll(dir)
+				if err != nil {
+					b.Fatalf("ParseAll: %v", err)
+				}
+				if len(articles) != n {
+					b.Fatalf("expected %d articles, got %d", n, len(articles))
+				}
+			}
+		})
+	}
+}
+
+func seedBenchmarkArticles(b *testing.B, dir string, n int) {
+	b.Helper()
+	const body = "# Heading\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n\n" +
+		"## Subheading\n\nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\n\n" +
+		"```go\nfunc Hello() string { return \"world\" }\n```\n"
+	for i := 0; i < n; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("post-%04d.md", i))
+		content := fmt.Sprintf(
+			"---\ntitle: Post %d\ndate: 2024-01-%02d\ntags: [a, b, c]\ndescription: bench post %d\n---\n%s",
+			i, (i%28)+1, i, body,
+		)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			b.Fatalf("write: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Run benchmarks continuously in CI.

## Changes

- Add `internal/parser/frontmatter_bench_test.go`. Measures `FileParser.ParseAll` at 10 / 100 / 1000-article scales.
- Add `.github/workflows/benchmark.yml`. Runs `go test -run=^$ -bench=. -benchmem -benchtime=1x` on every PR and uploads the output as a `benchmark-results` artifact (30-day retention).

## Notes

- `-benchtime=1x` keeps per-PR CI time minimal; a full benchmark sweep can be moved to a nightly job later.
- Local run example:
  ```
  go test -run=^$ -bench=BenchmarkFileParser_ParseAll -benchmem ./internal/parser/...
  ```
- No impact on `go test ./...`.