### PR TITLE
docs: refresh README and getting-started for new CLI features

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,12 +23,18 @@ This logo was created by [gopherize.me](https://gopherize.me/gopher/f64aa0974e77
 ## 特徴
 
 - **差分ビルド** — 変更されたファイルのみを再生成し、ビルド時間を最小化
+- **プロジェクトスカフォルド** — `gohan init` で `config.yaml`・コンテンツフォルダ・archetype を一括生成
+- **コンテンツリンタ** — `gohan check` で重複スラッグ・front matter 不足・孤立した translation_key を検出
+- **Archetype テンプレート** — `gohan new --archetype=<name>` で `archetypes/<name>.md` を雛型としてレンダリング
 - **Markdown + Front Matter** — GFM (GitHub Flavored Markdown) 対応
+- **TOC / 単語数 / 読了時間** — 記事ごとに自動計算しテンプレートに公開
+- **予約投稿** — 未来日付の記事はデフォルトでスキップ。`gohan build --future` で含める
+- **ビルドの可視化** — `--stats` でフェーズごとの所要時間、`--explain` で再ビルド要因を表示
 - **シンタックスハイライト** — [chroma](https://github.com/alecthomas/chroma) によるコードブロックのスタイリング
 - **Mermaid 図** — `mermaid` フェンスコードブロックをインタラクティブな図に変換
 - **タクソノミー** — タグ・カテゴリーページを自動生成
 - **Atom フィード / サイトマップ** — `atom.xml`・`sitemap.xml` を自動生成
-- **ライブリロード開発サーバー** — `gohan serve` でファイル変更を検知してブラウザを自動リロード
+- **ライブリロード開発サーバー** — `gohan serve` でファイル変更を検知してブラウザを自動リロード（CSS のみの変更はスタイルシートをホットスワップ）
 - **カスタマイズ可能なテーマ** — Go `html/template` による完全制御
 - **プラグインシステム** — `config.yaml` で有効化できるビルトインプラグイン（Goコード不要）
 - **i18n** — 多言語コンテンツ、翻訳リンク・`hreflang` 対応
@@ -60,24 +66,14 @@ make install
 ## クイックスタート
 
 ```bash
-# 1. プロジェクトディレクトリを作成
-mkdir myblog && cd myblog
+# 1. プロジェクトをスカフォールド（config.yaml ・content/・archetypes/・README.md を生成）
+gohan init myblog && cd myblog
 
-# 2. config.yaml を作成（全オプションは https://bmf-san.github.io/gohan/ja/guide/configuration/ を参照）
-cat > config.yaml << 'EOF'
-site:
-  title: My Blog
-  base_url: https://example.com
-  language: ja
-build:
-  content_dir: content
-  output_dir: public
-theme:
-  name: default
-EOF
-
-# 3. 最初の記事を作成
+# 2. 最初の記事を作成（archetypes/post.md が使われる）
 gohan new --title="Hello, World!" hello-world
+
+# 3. コンテンツを検証（任意、CI での使用を推奨）
+gohan check
 
 # 4. サイトをビルド
 gohan build
@@ -85,6 +81,8 @@ gohan build
 # 5. 開発サーバーでプレビュー
 gohan serve   # http://127.0.0.1:1313 を開く
 ```
+
+全オプションは [Configuration](https://bmf-san.github.io/gohan/ja/guide/configuration/) を参照してください。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,18 @@ This logo was created by [gopherize.me](https://gopherize.me/gopher/f64aa0974e77
 ## Features
 
 - **Incremental builds** — Regenerate only changed files, minimising build time
+- **Project scaffolding** — `gohan init` bootstraps `config.yaml`, content folders, and archetype templates
+- **Content linter** — `gohan check` validates duplicate slugs, missing front matter, and orphan translation keys
+- **Archetype templates** — `gohan new --archetype=<name>` renders custom front-matter skeletons from `archetypes/<name>.md`
 - **Markdown + Front Matter** — GitHub Flavored Markdown with YAML metadata
+- **TOC / WordCount / ReadingTime** — Auto-derived per article and exposed to templates
+- **Scheduled posts** — Future-dated articles are skipped by default; opt in with `gohan build --future`
+- **Build observability** — `--stats` prints per-phase timing; `--explain` shows what triggered a rebuild
 - **Syntax highlighting** — Code blocks styled with [chroma](https://github.com/alecthomas/chroma)
 - **Mermaid diagrams** — Fenced `mermaid` blocks render as interactive diagrams
 - **Taxonomy** — Tag and category pages generated automatically
 - **Atom feed & sitemap** — `atom.xml` and `sitemap.xml` generated automatically
-- **Live-reload dev server** — `gohan serve` watches files and reloads the browser
+- **Live-reload dev server** — `gohan serve` watches files and reloads the browser (CSS-only changes hot-swap stylesheets without a full reload)
 - **Customisable themes** — Full control via Go `html/template`
 - **Plugin system** — Built-in plugins enabled per-project via `config.yaml` (no Go code required)
 - **i18n** — Multi-locale content with per-article translation links and `hreflang` support
@@ -60,24 +66,14 @@ Pre-built binaries are available on [GitHub Releases](https://github.com/bmf-san
 ## Quick Start
 
 ```bash
-# 1. Create a project directory
-mkdir myblog && cd myblog
+# 1. Scaffold a new project (creates config.yaml, content/, archetypes/, README.md)
+gohan init myblog && cd myblog
 
-# 2. Add config.yaml (see https://bmf-san.github.io/gohan/guide/configuration/ for all options)
-cat > config.yaml << 'EOF'
-site:
-  title: My Blog
-  base_url: https://example.com
-  language: en
-build:
-  content_dir: content
-  output_dir: public
-theme:
-  name: default
-EOF
-
-# 3. Create your first article
+# 2. Create your first article (uses archetypes/post.md)
 gohan new --title="Hello, World!" hello-world
+
+# 3. Validate the content (optional but recommended in CI)
+gohan check
 
 # 4. Build the site
 gohan build
@@ -85,6 +81,8 @@ gohan build
 # 5. Preview locally with live reload
 gohan serve   # open http://127.0.0.1:1313
 ```
+
+See [Configuration](https://bmf-san.github.io/gohan/guide/configuration/) for all `config.yaml` options.
 
 ---
 

--- a/docs/content/en/guide/getting-started.md
+++ b/docs/content/en/guide/getting-started.md
@@ -44,39 +44,30 @@ Download a pre-built binary for your platform from [GitHub Releases](https://git
 
 ## Create Your First Site
 
-### Step 1: Create a project directory
+### Step 1: Scaffold a new project
 
 ```bash
-mkdir myblog
+gohan init myblog
 cd myblog
 ```
 
-### Step 2: Create `config.yaml`
+This creates:
 
-```yaml
-site:
-  title: My Blog
-  description: A simple personal blog
-  base_url: https://myblog.example.com
-  language: en
-
-build:
-  content_dir: content
-  output_dir: public
-  assets_dir: assets
-  parallelism: 4
-
-theme:
-  name: default
-
-syntax_highlight:
-  theme: github
-  line_numbers: false
+```
+myblog/
+├── config.yaml
+├── README.md
+├── archetypes/
+│   ├── page.md
+│   └── post.md
+└── content/
+    ├── pages/.gitkeep
+    └── posts/.gitkeep
 ```
 
-See [Configuration](configuration.md) for all available fields.
+Edit `config.yaml` to customise the site title, base URL, and other options. See [Configuration](configuration.md) for all available fields.
 
-### Step 3: Create your first article
+### Step 2: Create your first article
 
 ```bash
 gohan new --title="Hello, World!" hello-world
@@ -119,7 +110,7 @@ func main() {
 ```
 ```
 
-### Step 4: Create theme templates
+### Step 3: Create theme templates
 
 ```bash
 mkdir -p themes/default/templates
@@ -190,7 +181,7 @@ mkdir -p themes/default/templates
 
 See [Templates](templates.md) for the complete template reference.
 
-### Step 5: Add static assets (optional)
+### Step 4: Add static assets (optional)
 
 ```bash
 mkdir -p assets
@@ -200,7 +191,7 @@ a { color: #0066cc; }
 EOF
 ```
 
-### Step 6: Build the site
+### Step 5: Build the site
 
 ```bash
 gohan build
@@ -220,7 +211,7 @@ public/
     └── style.css
 ```
 
-### Step 7: Preview with the development server
+### Step 6: Preview with the development server
 
 ```bash
 gohan serve

--- a/docs/content/ja/guide/getting-started.md
+++ b/docs/content/ja/guide/getting-started.md
@@ -44,39 +44,30 @@ make install
 
 ## 最初のサイトを作る
 
-### ステップ 1: プロジェクトを作成する
+### ステップ 1: プロジェクトをスカフォールドする
 
 ```bash
-mkdir myblog
+gohan init myblog
 cd myblog
 ```
 
-### ステップ 2: `config.yaml` を作成する
+次の構造が生成されます:
 
-```yaml
-site:
-  title: My Blog
-  description: A simple personal blog
-  base_url: https://myblog.example.com
-  language: ja
-
-build:
-  content_dir: content
-  output_dir: public
-  assets_dir: assets
-  parallelism: 4
-
-theme:
-  name: default
-
-syntax_highlight:
-  theme: github
-  line_numbers: false
+```
+myblog/
+├── config.yaml
+├── README.md
+├── archetypes/
+│   ├── page.md
+│   └── post.md
+└── content/
+    ├── pages/.gitkeep
+    └── posts/.gitkeep
 ```
 
-全フィールドの詳細は [Configuration](configuration.ja.md) を参照してください。
+サイトタイトル・base URL などは `config.yaml` を編集してカスタマイズしましょう。全フィールドの詳細は [Configuration](configuration.ja.md) を参照してください。
 
-### ステップ 3: 最初の記事を作成する
+### ステップ 2: 最初の記事を作成する
 
 ```bash
 gohan new --title="Hello, World!" hello-world
@@ -103,7 +94,7 @@ description: はじめての gohan ブログ記事
 **gohan** でブログを始めました！
 ```
 
-### ステップ 4: テーマテンプレートを作成する
+### ステップ 3: テーマテンプレートを作成する
 
 ```bash
 mkdir -p themes/default/templates
@@ -140,7 +131,7 @@ mkdir -p themes/default/templates
 
 テンプレートの詳細は [テンプレートガイド](templates.ja.md) を参照してください。
 
-### ステップ 5: アセットを追加する（任意）
+### ステップ 4: アセットを追加する（任意）
 
 ```bash
 mkdir -p assets
@@ -150,7 +141,7 @@ a { color: #0066cc; }
 EOF
 ```
 
-### ステップ 6: サイトをビルドする
+### ステップ 5: サイトをビルドする
 
 ```bash
 gohan build
@@ -170,7 +161,7 @@ public/
     └── style.css
 ```
 
-### ステップ 7: 開発サーバーで確認する
+### ステップ 6: 開発サーバーで確認する
 
 ```bash
 gohan serve


### PR DESCRIPTION
## Summary

Refresh the README and Getting Started guide to reflect the recent batch of feature PRs (#154, #156–#163).

## Changes

- **README.md / README.ja.md**
  - Add to the Features list: `gohan init` / `gohan check` / archetype templates / TOC + WordCount + ReadingTime / `--future` / `--stats` / `--explain` / CSS-only HMR.
  - Replace the Quick Start `mkdir + cat > config.yaml` recipe with a `gohan init` based flow; mention `gohan check` as part of the pipeline.
- **docs/content/{en,ja}/guide/getting-started.md**
  - Replace the manual config-creation step with `gohan init` and show the resulting directory layout.
  - Renumber the remaining steps for consistency.

## Notes

- Per-feature reference docs in `cli.md` were already updated in each individual PR.
- Docs-only change. No code or test impact.