### PR TITLE
feat(bookshelf): expose recently-read books on every page via SiteData

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bmf-san/gohan
 
-go 1.26.3
+go 1.26.4
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/internal/generator/html.go
+++ b/internal/generator/html.go
@@ -868,6 +868,7 @@ func siteFor(base *model.Site, articles []*model.ProcessedArticle) *model.Site {
 		Tags:         base.Tags,
 		Categories:   base.Categories,
 		ArchiveYears: base.ArchiveYears,
+		SiteData:     base.SiteData,
 	}
 }
 
@@ -921,6 +922,7 @@ func localeTaxonomyBase(base *model.Site, articles []*model.ProcessedArticle) *m
 		Tags:         tags,
 		Categories:   cats,
 		ArchiveYears: archiveYears(articles),
+		SiteData:     base.SiteData,
 	}
 }
 

--- a/internal/model/site.go
+++ b/internal/model/site.go
@@ -26,6 +26,12 @@ type Site struct {
 	// current virtual page being rendered.  Nil for all non-virtual pages.
 	// Access in templates: {{.VirtualPageData}}
 	VirtualPageData map[string]interface{}
+	// SiteData holds global, cross-page data injected by SitePlugins, keyed by
+	// plugin name. Unlike VirtualPageData (scoped to a single virtual page),
+	// SiteData is propagated to every page so any template can read it.
+	// Populated by plugin.Registry.EnrichVirtual from plugins implementing
+	// SiteDataProvider. Access in templates: {{index .SiteData "<plugin>"}}.
+	SiteData map[string]interface{}
 }
 
 // Pagination holds computed paging metadata for listing pages.

--- a/internal/plugin/bookshelf/bookshelf.go
+++ b/internal/plugin/bookshelf/bookshelf.go
@@ -7,6 +7,7 @@
 //	  bookshelf:
 //	    enabled: true
 //	    tag: "your-associate-tag-22"   # Amazon Associates tracking tag
+//	    recent_limit: 5                # optional; books exposed via SiteData (default 5)
 //
 // # Front-matter (article .md) — same key used by amazon_books plugin
 //
@@ -25,6 +26,20 @@
 //	      <img src="{{.ImageURL}}" alt="{{.Title}}">
 //	    </a>
 //	    {{if .ArticleURL}}<a href="{{.ArticleURL}}">{{.ArticleTitle}}</a>{{end}}
+//	  {{end}}
+//	{{end}}
+//
+// # Recently-read widget (any template, e.g. homepage sidebar)
+//
+// In addition to the bookshelf VirtualPage, the plugin exposes the newest
+// books per locale on every page via Site.SiteData (see SiteDataProvider):
+//
+//	{{$bs := index .SiteData "bookshelf"}}
+//	{{if $bs}}{{$recent := index (index $bs "recent") .CurrentLocale}}
+//	  {{range $recent}}
+//	    <a href="{{.LinkURL}}" rel="sponsored noopener noreferrer">
+//	      <img src="{{.ImageURL}}" alt="{{.Title}}">
+//	    </a>
 //	  {{end}}
 //	{{end}}
 package bookshelf
@@ -46,6 +61,10 @@ const (
 	imageURLTemplate = "https://images-na.ssl-images-amazon.com/images/P/%s.01._SL250_.jpg"
 	linkURLTemplate  = "https://www.amazon.co.jp/dp/%s?tag=%s"
 	defaultTag       = ""
+
+	// defaultRecentLimit is the number of newest books exposed per locale via
+	// SiteData when `recent_limit` is not set in config.
+	defaultRecentLimit = 5
 )
 
 // BookEntry is the data exposed to templates for a single book on the bookshelf.
@@ -79,6 +98,7 @@ var _ interface {
 	Name() string
 	Enabled(map[string]interface{}) bool
 	VirtualPages(*model.Site, map[string]interface{}) ([]*model.VirtualPage, error)
+	SiteData(*model.Site, map[string]interface{}) (interface{}, error)
 } = (*Bookshelf)(nil)
 
 // Name returns the plugin identifier.
@@ -103,11 +123,84 @@ func (b *Bookshelf) Enabled(cfg map[string]interface{}) bool {
 func (b *Bookshelf) VirtualPages(site *model.Site, cfg map[string]interface{}) ([]*model.VirtualPage, error) {
 	tag := strVal(cfg, "tag", defaultTag)
 
-	// Group BookEntries by locale.
-	type localeEntries struct {
-		entries []BookEntry
+	byLocale, err := collectEntriesByLocale(site, tag)
+	if err != nil {
+		return nil, err
 	}
-	byLocale := map[string]*localeEntries{}
+	if len(byLocale) == 0 {
+		return nil, nil
+	}
+
+	defaultLocale := site.Config.I18n.DefaultLocale
+	if defaultLocale == "" {
+		defaultLocale = site.Config.Site.Language
+	}
+
+	var pages []*model.VirtualPage
+	for locale, entries := range byLocale {
+		var outputPath, pageURL string
+		if locale == defaultLocale || locale == "" {
+			outputPath = path.Join("bookshelf", "index.html")
+			pageURL = "/bookshelf/"
+		} else {
+			outputPath = path.Join(locale, "bookshelf", "index.html")
+			pageURL = "/" + locale + "/bookshelf/"
+		}
+
+		pages = append(pages, &model.VirtualPage{
+			OutputPath: outputPath,
+			URL:        pageURL,
+			Template:   "bookshelf.html",
+			Locale:     locale,
+			Data: map[string]interface{}{
+				"books":      entries,
+				"categories": buildCategoryGroups(entries),
+			},
+		})
+	}
+
+	return pages, nil
+}
+
+// SiteData implements plugin.SiteDataProvider. It exposes the most recently
+// read books per locale on every rendered page, so themes can show a "recently
+// read" widget outside the bookshelf page (e.g. the homepage sidebar).
+//
+// The returned value has the shape:
+//
+//	{ "recent": { "<locale>": []BookEntry } }
+//
+// Each locale's slice is sorted newest-first and capped at `recent_limit`
+// books (config key under plugins.bookshelf; default defaultRecentLimit).
+// Returns nil when no article declares books.
+func (b *Bookshelf) SiteData(site *model.Site, cfg map[string]interface{}) (interface{}, error) {
+	tag := strVal(cfg, "tag", defaultTag)
+	limit := intVal(cfg, "recent_limit", defaultRecentLimit)
+
+	byLocale, err := collectEntriesByLocale(site, tag)
+	if err != nil {
+		return nil, err
+	}
+	if len(byLocale) == 0 {
+		return nil, nil
+	}
+
+	recent := make(map[string]interface{}, len(byLocale))
+	for locale, entries := range byLocale {
+		if limit > 0 && len(entries) > limit {
+			entries = entries[:limit]
+		}
+		recent[locale] = entries
+	}
+
+	return map[string]interface{}{"recent": recent}, nil
+}
+
+// collectEntriesByLocale aggregates book entries from every article's
+// front-matter, grouped by locale and sorted by date descending (newest
+// first). Returns an empty map when no article declares books.
+func collectEntriesByLocale(site *model.Site, tag string) (map[string][]BookEntry, error) {
+	byLocale := map[string][]BookEntry{}
 
 	for _, article := range site.Articles {
 		raw, ok := article.FrontMatter.Extra["books"]
@@ -120,10 +213,6 @@ func (b *Bookshelf) VirtualPages(site *model.Site, cfg map[string]interface{}) (
 		}
 
 		locale := article.Locale
-
-		if _, exists := byLocale[locale]; !exists {
-			byLocale[locale] = &localeEntries{}
-		}
 
 		for _, item := range items {
 			m, ok := item.(map[string]interface{})
@@ -148,7 +237,7 @@ func (b *Bookshelf) VirtualPages(site *model.Site, cfg map[string]interface{}) (
 				imageURL = ""
 				linkURL = directURL
 			}
-			entry := BookEntry{
+			byLocale[locale] = append(byLocale[locale], BookEntry{
 				ASIN:         asin,
 				Title:        title,
 				ImageURL:     imageURL,
@@ -158,49 +247,20 @@ func (b *Bookshelf) VirtualPages(site *model.Site, cfg map[string]interface{}) (
 				ArticleURL:   article.URL,
 				Date:         article.FrontMatter.Date,
 				Categories:   article.FrontMatter.Categories,
-			}
-			byLocale[locale].entries = append(byLocale[locale].entries, entry)
+			})
 		}
 	}
 
-	if len(byLocale) == 0 {
-		return nil, nil
-	}
-
-	defaultLocale := site.Config.I18n.DefaultLocale
-	if defaultLocale == "" {
-		defaultLocale = site.Config.Site.Language
-	}
-
-	var pages []*model.VirtualPage
-	for locale, le := range byLocale {
-		// Sort all entries by date descending (newest first).
-		sort.Slice(le.entries, func(i, j int) bool {
-			return le.entries[i].Date.After(le.entries[j].Date)
+	// Sort each locale's entries by date descending (newest first).
+	for locale := range byLocale {
+		entries := byLocale[locale]
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Date.After(entries[j].Date)
 		})
-
-		var outputPath, pageURL string
-		if locale == defaultLocale || locale == "" {
-			outputPath = path.Join("bookshelf", "index.html")
-			pageURL = "/bookshelf/"
-		} else {
-			outputPath = path.Join(locale, "bookshelf", "index.html")
-			pageURL = "/" + locale + "/bookshelf/"
-		}
-
-		pages = append(pages, &model.VirtualPage{
-			OutputPath: outputPath,
-			URL:        pageURL,
-			Template:   "bookshelf.html",
-			Locale:     locale,
-			Data: map[string]interface{}{
-				"books":      le.entries,
-				"categories": buildCategoryGroups(le.entries),
-			},
-		})
+		byLocale[locale] = entries
 	}
 
-	return pages, nil
+	return byLocale, nil
 }
 
 // buildCategoryGroups groups entries by category and returns them sorted
@@ -253,4 +313,23 @@ func strVal(m map[string]interface{}, key, def string) string {
 		return def
 	}
 	return s
+}
+
+// intVal extracts an int value from a map, returning def when missing or of an
+// unexpected type. YAML may decode integers as int, int64, or float64.
+func intVal(m map[string]interface{}, key string, def int) int {
+	v, ok := m[key]
+	if !ok {
+		return def
+	}
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	default:
+		return def
+	}
 }

--- a/internal/plugin/bookshelf/bookshelf_test.go
+++ b/internal/plugin/bookshelf/bookshelf_test.go
@@ -439,3 +439,148 @@ func TestBookshelf_NonAsinURL(t *testing.T) {
 		t.Errorf("ArticleURL = %q, expected to contain article slug", bk.ArticleURL)
 	}
 }
+
+// recentBooks is a test helper that extracts the per-locale recent book slice
+// from the value returned by Bookshelf.SiteData.
+func recentBooks(t *testing.T, data interface{}, locale string) []bookshelf.BookEntry {
+	t.Helper()
+	m, ok := data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("SiteData type = %T, want map[string]interface{}", data)
+	}
+	recent, ok := m["recent"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("SiteData[\"recent\"] type = %T, want map[string]interface{}", m["recent"])
+	}
+	if recent[locale] == nil {
+		return nil
+	}
+	books, ok := recent[locale].([]bookshelf.BookEntry)
+	if !ok {
+		t.Fatalf("recent[%q] type = %T, want []bookshelf.BookEntry", locale, recent[locale])
+	}
+	return books
+}
+
+func TestBookshelf_SiteData_NoBooks(t *testing.T) {
+	b := bookshelf.New()
+	site := &model.Site{
+		Config: model.Config{
+			Site: model.SiteConfig{Language: "en"},
+			I18n: model.I18nConfig{DefaultLocale: "en"},
+		},
+		Articles: []*model.ProcessedArticle{
+			{Article: model.Article{FrontMatter: model.FrontMatter{Title: "No books"}}},
+		},
+	}
+	data, err := b.SiteData(site, cfg(true, "test-22"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data != nil {
+		t.Errorf("SiteData = %v, want nil when no article declares books", data)
+	}
+}
+
+func TestBookshelf_SiteData_RecentSortedAndCapped(t *testing.T) {
+	b := bookshelf.New()
+	var articles []*model.ProcessedArticle
+	// 7 books, increasing dates so the newest has the highest index.
+	for i := 1; i <= 7; i++ {
+		articles = append(articles, &model.ProcessedArticle{
+			Article: model.Article{FrontMatter: model.FrontMatter{
+				Title: "Book",
+				Slug:  "book",
+				Date:  time.Date(2024, 1, i, 0, 0, 0, 0, time.UTC),
+				Extra: map[string]interface{}{
+					"books": []interface{}{
+						map[string]interface{}{"asin": string(rune('A' + i - 1))},
+					},
+				},
+			}},
+			Locale: "en",
+		})
+	}
+	site := &model.Site{
+		Config: model.Config{
+			Site: model.SiteConfig{Language: "en"},
+			I18n: model.I18nConfig{DefaultLocale: "en"},
+		},
+		Articles: articles,
+	}
+
+	// Default limit (5).
+	data, err := b.SiteData(site, cfg(true, "test-22"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	books := recentBooks(t, data, "en")
+	if len(books) != 5 {
+		t.Fatalf("expected default cap of 5, got %d", len(books))
+	}
+	// Newest first: G (i=7) then F, E, D, C.
+	if books[0].ASIN != "G" {
+		t.Errorf("books[0].ASIN = %q, want G (newest)", books[0].ASIN)
+	}
+	if books[4].ASIN != "C" {
+		t.Errorf("books[4].ASIN = %q, want C", books[4].ASIN)
+	}
+
+	// Custom limit honored.
+	cfgLimited := map[string]interface{}{"enabled": true, "tag": "test-22", "recent_limit": 2}
+	data2, err := b.SiteData(site, cfgLimited)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	books2 := recentBooks(t, data2, "en")
+	if len(books2) != 2 {
+		t.Fatalf("expected cap of 2, got %d", len(books2))
+	}
+	if books2[0].ASIN != "G" || books2[1].ASIN != "F" {
+		t.Errorf("recent_limit=2 returned %q,%q; want G,F", books2[0].ASIN, books2[1].ASIN)
+	}
+}
+
+func TestBookshelf_SiteData_PerLocale(t *testing.T) {
+	b := bookshelf.New()
+	date := time.Date(2024, 5, 4, 0, 0, 0, 0, time.UTC)
+	site := &model.Site{
+		Config: model.Config{
+			Site: model.SiteConfig{Language: "en"},
+			I18n: model.I18nConfig{DefaultLocale: "en", Locales: []string{"en", "ja"}},
+		},
+		Articles: []*model.ProcessedArticle{
+			{
+				Article: model.Article{FrontMatter: model.FrontMatter{
+					Title: "Book EN", Slug: "book-en", Date: date,
+					Extra: map[string]interface{}{
+						"books": []interface{}{map[string]interface{}{"asin": "AAA"}},
+					},
+				}},
+				Locale: "en", URL: "/posts/book-en/",
+			},
+			{
+				Article: model.Article{FrontMatter: model.FrontMatter{
+					Title: "本 JA", Slug: "book-ja", Date: date,
+					Extra: map[string]interface{}{
+						"books": []interface{}{map[string]interface{}{"asin": "BBB"}},
+					},
+				}},
+				Locale: "ja", URL: "/ja/posts/book-ja/",
+			},
+		},
+	}
+
+	data, err := b.SiteData(site, cfg(true, "test-22"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	en := recentBooks(t, data, "en")
+	ja := recentBooks(t, data, "ja")
+	if len(en) != 1 || en[0].ASIN != "AAA" {
+		t.Errorf("en recent = %+v, want single AAA", en)
+	}
+	if len(ja) != 1 || ja[0].ASIN != "BBB" {
+		t.Errorf("ja recent = %+v, want single BBB", ja)
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -56,3 +56,16 @@ type SitePlugin interface {
 	// to be rendered by the HTML generator.
 	VirtualPages(site *model.Site, cfg map[string]interface{}) ([]*model.VirtualPage, error)
 }
+
+// SiteDataProvider is an optional interface a SitePlugin may implement to
+// contribute global data that is propagated to every rendered page (not just
+// its own VirtualPages).
+//
+// The returned value is stored at Site.SiteData[<plugin name>] and is
+// accessible in any template via {{index .SiteData "<plugin name>"}}.
+// Return a nil value to contribute nothing.
+type SiteDataProvider interface {
+	// SiteData inspects the full site and returns global data to expose on
+	// every page. cfg is the map under plugins.<name> in config.yaml.
+	SiteData(site *model.Site, cfg map[string]interface{}) (interface{}, error)
+}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -67,6 +67,20 @@ func (r *Registry) EnrichVirtual(site *model.Site) error {
 			return fmt.Errorf("site plugin %s: %w", sp.Name(), err)
 		}
 		site.VirtualPages = append(site.VirtualPages, pages...)
+
+		// Optionally collect global, cross-page data from the plugin.
+		if sdp, ok := sp.(SiteDataProvider); ok {
+			data, err := sdp.SiteData(site, cfg)
+			if err != nil {
+				return fmt.Errorf("site plugin %s site data: %w", sp.Name(), err)
+			}
+			if data != nil {
+				if site.SiteData == nil {
+					site.SiteData = make(map[string]interface{})
+				}
+				site.SiteData[sp.Name()] = data
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds a global, cross-page data channel so `SitePlugin`s can surface aggregate information **outside their own VirtualPages**, and uses it in the `bookshelf` plugin to expose the most recently read books on every page.

Motivation: themes want a "recently read" widget (e.g. a homepage sidebar) that updates automatically as book-review posts are added — without sending readers to the dedicated `/bookshelf/` page. Until now the aggregated, date-sorted book list only existed on the bookshelf `VirtualPage` (`.VirtualPageData`), unreachable from other pages.

## Changes

- **`model.Site`**: new `SiteData map[string]interface{}` field, propagated to every rendered page (complements the existing per-virtual-page `VirtualPageData`).
- **`plugin.SiteDataProvider`**: new *optional* interface. A `SitePlugin` may implement `SiteData(site, cfg) (interface{}, error)` to contribute global data. The registry collects it during `EnrichVirtual` and stores it at `Site.SiteData[<plugin name>]`. Existing plugins are unaffected (type assertion).
- **`bookshelf`**: implements `SiteDataProvider`, exposing newest-first books per locale at `SiteData.bookshelf.recent.<locale>`, capped by a new `recent_limit` config key (default `5`). The book-aggregation logic is factored into a shared helper reused by `VirtualPages` (no behavior change to the bookshelf page).
- **generator**: `siteFor` / `localeTaxonomyBase` carry `SiteData` into per-page site copies.

## Template usage

```gotemplate
{{$bs := index .SiteData "bookshelf"}}
{{if $bs}}{{$recent := index (index $bs "recent") .CurrentLocale}}
  {{range $recent}}
    <a href="{{.LinkURL}}" rel="sponsored noopener noreferrer">
      <img src="{{.ImageURL}}" alt="{{.Title}}">
    </a>
  {{end}}
{{end}}
```

## Config

```yaml
plugins:
  bookshelf:
    enabled: true
    tag: "your-associate-tag-22"
    recent_limit: 6   # optional; default 5
```

## Tests

- New unit tests for `SiteData`: no-books returns nil; per-locale separation; newest-first sort + default and custom `recent_limit` capping.
- `make test`, `make coverage-check` (84.9%), `make lint`, `make tidy` all pass locally; `go test ./...` green.

## Compatibility

Backward compatible: additive `Site` field and an optional interface. Themes that don't reference `.SiteData` are unaffected.