### PR TITLE
ci: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+# Default token to no permissions; the auto-merge job below requests just
+# what it needs.
+permissions: {}
+
+jobs:
+  automerge:
+    name: Auto-merge safe Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

Dependabot の PR を CI 通過後に自動マージするワークフローを追加します。

- 対象: `dependabot[bot]` が作成した PR のみ
- patch / minor 更新のみ auto-merge（major はレビューのため除外）
- `gh pr merge --auto --squash` で CI 通過後に自動マージ

## 備考
auto-merge を機能させるにはリポジトリ設定で **Allow auto-merge** を有効化する必要があります（本対応で別途有効化済み）。